### PR TITLE
feat: remove onFail property

### DIFF
--- a/src/client/profile-provider.test.ts
+++ b/src/client/profile-provider.test.ts
@@ -256,7 +256,7 @@ describe('profile provider', () => {
               defaults: {
                 test: {
                   input: { t: 't' },
-                  retryPolicy: { onFail: OnFail.NONE },
+                  retryPolicy: { kind: OnFail.NONE },
                 },
               },
             },

--- a/src/internal/superjson/normalize.ts
+++ b/src/internal/superjson/normalize.ts
@@ -1,5 +1,6 @@
 import { resolveEnvRecord } from '../../lib/env';
 import { clone } from '../../lib/object';
+import { SDKExecutionError } from '../errors';
 import { castToNonPrimitive, mergeVariables } from '../interpreter/variables';
 import {
   BackOffKind,
@@ -111,8 +112,16 @@ export function normalizeRetryPolicy(
         factor: retryPolicy.backoff?.factor ?? baseOnFail?.backoff?.factor,
       };
     }
-    throw new Error(
-      'invalid backoff entry format: ' + retryPolicy.backoff.kind
+    throw new SDKExecutionError(
+      `Invalid backoff entry format: "${retryPolicy.backoff.kind}"`,
+      [
+        `Property "kind" in retryPolicy.backoof object has unexpected value "${retryPolicy.backoff.kind}"`,
+        `Property "kind" in super.json [profile].providers.[provider].defaults.[usecase].retryPolicy.backoff with value "${retryPolicy.backoff.kind}" is not valid`,
+      ],
+      [
+        `Check your super.json`,
+        `Check property "kind" in [profile].providers.[provider].defaults.[usecase].retryPolicy.backoff with value "${retryPolicy.backoff.kind}"`,
+      ]
     );
   };
 

--- a/src/internal/superjson/normalize.ts
+++ b/src/internal/superjson/normalize.ts
@@ -121,7 +121,7 @@ export function normalizeRetryPolicy(
       [
         `Check your super.json`,
         `Check property "kind" in [profile].providers.[provider].defaults.[usecase].retryPolicy.backoff with value "${retryPolicy.backoff.kind}"`,
-        `Change value of property "kind" in retryPolicy.backoff to one of possible values: ${Object.values(BackOffKind)}`,
+        `Change value of property "kind" in retryPolicy.backoff to one of possible values: ${Object.values(BackOffKind).join(', ')}`,
       ]
     );
   };

--- a/src/internal/superjson/normalize.ts
+++ b/src/internal/superjson/normalize.ts
@@ -115,12 +115,13 @@ export function normalizeRetryPolicy(
     throw new SDKExecutionError(
       `Invalid backoff entry format: "${retryPolicy.backoff.kind}"`,
       [
-        `Property "kind" in retryPolicy.backoof object has unexpected value "${retryPolicy.backoff.kind}"`,
+        `Property "kind" in retryPolicy.backoff object has unexpected value "${retryPolicy.backoff.kind}"`,
         `Property "kind" in super.json [profile].providers.[provider].defaults.[usecase].retryPolicy.backoff with value "${retryPolicy.backoff.kind}" is not valid`,
       ],
       [
         `Check your super.json`,
         `Check property "kind" in [profile].providers.[provider].defaults.[usecase].retryPolicy.backoff with value "${retryPolicy.backoff.kind}"`,
+        `Change value of property "kind" in retryPolicy.backoff to one of possible values: ${Object.values(BackOffKind)}`,
       ]
     );
   };

--- a/src/internal/superjson/schema.ts
+++ b/src/internal/superjson/schema.ts
@@ -41,9 +41,6 @@ export const composeFileURI = (path: string): string => {
 //Retry policy
 export enum OnFail {
   NONE = 'none',
-}
-
-export enum OnFailKind {
   CIRCUIT_BREAKER = 'circuit-breaker',
 }
 
@@ -54,54 +51,60 @@ export enum BackOffKind {
  * RetryPolicy per usecase values.
  * ```
  * {
- *   "$retryPolicy": {
- *     "onFail": "none" | {
+ *   "$retryPolicy":  "none" | "circuit-breaker" |
+ *      {
+ *        "kind": "none"
+ *      } | {
  *       "kind": "circuit-breaker",
  *       "maxContiguousRetries": number, // opt
  *       "requestTimeout": number, // opt
- *       "backoff": {
+ *       "backoff": "exponential" | {
  *          "kind": "exponential",
  *          "start": number,
  *          "factor": number,
  *        }
- *     }
  *   } // opt
  * }
  * ```
  */
-const retryPolicy = zod.object({
-  onFail: zod.union([
-    zod.literal(OnFail.NONE),
-    zod.object({
-      kind: zod.literal(OnFailKind.CIRCUIT_BREAKER),
-      maxContiguousRetries: zod.number().int().positive().optional(),
-      requestTimeout: zod.number().int().positive().optional(),
-      backoff: zod
-        .object({
+const retryPolicy = zod.union([
+  zod.literal(OnFail.NONE),
+  zod.literal(OnFail.CIRCUIT_BREAKER),
+  zod.object({
+    kind: zod.literal(OnFail.NONE),
+  }),
+  zod.object({
+    kind: zod.literal(OnFail.CIRCUIT_BREAKER),
+    maxContiguousRetries: zod.number().int().positive().optional(),
+    requestTimeout: zod.number().int().positive().optional(),
+    backoff: zod
+      .union([
+        zod.literal(BackOffKind.EXPONENTIAL),
+        zod.object({
           kind: zod.literal(BackOffKind.EXPONENTIAL),
           start: zod.number().int().positive().optional(),
           factor: zod.number().int().positive().optional(),
-        })
-        .optional(),
-    }),
-  ]),
-});
+        }),
+      ])
+      .optional(),
+  }),
+]);
 
-const normalizedRetryPolicy = zod.object({
-  onFail: zod.union([
-    zod.literal(OnFail.NONE),
-    zod.object({
-      kind: zod.literal(OnFailKind.CIRCUIT_BREAKER),
-      maxContiguousRetries: zod.number().int().positive().optional(),
-      requestTimeout: zod.number().int().positive().optional(),
-      backoff: zod.object({
-        kind: zod.literal(BackOffKind.EXPONENTIAL),
-        start: zod.number().int().positive().optional(),
-        factor: zod.number().int().positive().optional(),
-      }),
+const normalizedRetryPolicy = zod.union([
+  zod.object({
+    kind: zod.literal(OnFail.NONE),
+  }),
+  zod.object({
+    kind: zod.literal(OnFail.CIRCUIT_BREAKER),
+    maxContiguousRetries: zod.number().int().positive().optional(),
+    requestTimeout: zod.number().int().positive().optional(),
+    backoff: zod.object({
+      kind: zod.literal(BackOffKind.EXPONENTIAL),
+      start: zod.number().int().positive().optional(),
+      factor: zod.number().int().positive().optional(),
     }),
-  ]),
-});
+  }),
+]);
 
 const providerFailover = zod.boolean().optional();
 const normalizedProviderFailover = zod.boolean();

--- a/src/internal/superjson/schema.ts
+++ b/src/internal/superjson/schema.ts
@@ -62,8 +62,8 @@ export enum BackOffKind {
  *          "kind": "exponential",
  *          "start": number,
  *          "factor": number,
- *        }
- *   } // opt
+ *        } // opt
+ *   }
  * }
  * ```
  */
@@ -98,11 +98,13 @@ const normalizedRetryPolicy = zod.union([
     kind: zod.literal(OnFail.CIRCUIT_BREAKER),
     maxContiguousRetries: zod.number().int().positive().optional(),
     requestTimeout: zod.number().int().positive().optional(),
-    backoff: zod.object({
-      kind: zod.literal(BackOffKind.EXPONENTIAL),
-      start: zod.number().int().positive().optional(),
-      factor: zod.number().int().positive().optional(),
-    }),
+    backoff: zod
+      .object({
+        kind: zod.literal(BackOffKind.EXPONENTIAL),
+        start: zod.number().int().positive().optional(),
+        factor: zod.number().int().positive().optional(),
+      })
+      .optional(),
   }),
 ]);
 

--- a/src/internal/superjson/superjson.test.ts
+++ b/src/internal/superjson/superjson.test.ts
@@ -21,7 +21,6 @@ import {
   isVersionString,
   NormalizedUsecaseDefaults,
   OnFail,
-  OnFailKind,
   ProfileEntry,
   ProfileProviderEntry,
   ProviderEntry,
@@ -852,9 +851,7 @@ describe('SuperJson', () => {
                 "defaults": {
                   "Usecase": {
                     "input": {},
-                    "retryPolicy": {
-                      "onFail": "none"
-                    }            
+                    "retryPolicy": "none"
                   }
                 }
               },
@@ -862,10 +859,9 @@ describe('SuperJson', () => {
                 "defaults": {
                   "Usecase": {
                     "retryPolicy": {
-                      "onFail": {
-                        "kind": "circuit-breaker",
-                        "maxContiguousRetries": 5
-                      }
+                      "kind": "circuit-breaker",
+                      "maxContiguousRetries": 5,
+                      "backoff": "exponential"
                     },
                     "input": {
                       "a": 12,
@@ -900,13 +896,17 @@ describe('SuperJson', () => {
               "foo": {
                 "defaults": {
                   "Usecase": {
-                    "input": {}               
+                    "input": {},
+                    "retryPolicy": "circuit-breaker"
                   }
                 }
               },
               "bar": {
                 "defaults": {
                   "Usecase": {
+                    "retryPolicy": {
+                      "kind": "none"
+                    },
                     "input": {
                       "a": 12,
                       "b": {
@@ -1016,7 +1016,7 @@ describe('SuperJson', () => {
                       },
                     },
                     retryPolicy: {
-                      onFail: OnFail.NONE,
+                      kind: OnFail.NONE,
                     },
                   },
                 },
@@ -1037,12 +1037,10 @@ describe('SuperJson', () => {
                       },
                     },
                     retryPolicy: {
-                      onFail: {
-                        kind: OnFailKind.CIRCUIT_BREAKER,
-                        maxContiguousRetries: 5,
-                        backoff: {
-                          kind: BackOffKind.EXPONENTIAL,
-                        },
+                      kind: OnFail.CIRCUIT_BREAKER,
+                      maxContiguousRetries: 5,
+                      backoff: {
+                        kind: BackOffKind.EXPONENTIAL,
                       },
                     },
                   },
@@ -1079,7 +1077,10 @@ describe('SuperJson', () => {
                       },
                     },
                     retryPolicy: {
-                      onFail: 'none',
+                      kind: 'circuit-breaker',
+                      backoff: {
+                        kind: 'exponential',
+                      },
                     },
                   },
                 },
@@ -1100,7 +1101,7 @@ describe('SuperJson', () => {
                       },
                     },
                     retryPolicy: {
-                      onFail: 'none',
+                      kind: 'none',
                     },
                   },
                 },
@@ -1336,7 +1337,7 @@ describe('SuperJson', () => {
             defaults: {
               input: {
                 input: { test: 'test' },
-                retryPolicy: { onFail: OnFail.NONE },
+                retryPolicy: { kind: OnFail.NONE },
               },
             },
             mapRevision: undefined,
@@ -1558,7 +1559,7 @@ describe('SuperJson', () => {
             defaults: {
               input: {
                 input: { test: 'test' },
-                retryPolicy: { onFail: OnFail.NONE },
+                retryPolicy: { kind: OnFail.NONE },
               },
             },
             file: 'some/path',
@@ -1606,7 +1607,7 @@ describe('SuperJson', () => {
             defaults: {
               input: {
                 input: { test: 'test' },
-                retryPolicy: { onFail: OnFail.NONE },
+                retryPolicy: { kind: OnFail.NONE },
               },
             },
             file: 'provider/path',
@@ -1655,7 +1656,7 @@ describe('SuperJson', () => {
             defaults: {
               input: {
                 input: { test: 'test' },
-                retryPolicy: { onFail: OnFail.NONE },
+                retryPolicy: { kind: OnFail.NONE },
               },
             },
             mapVariant: 'test',
@@ -1702,7 +1703,7 @@ describe('SuperJson', () => {
             defaults: {
               input: {
                 input: { test: 'test' },
-                retryPolicy: { onFail: OnFail.NONE },
+                retryPolicy: { kind: OnFail.NONE },
               },
             },
             mapVariant: 'test',
@@ -1730,7 +1731,7 @@ describe('SuperJson', () => {
                 defaults: {
                   input: {
                     input: { test: 'test' },
-                    retryPolicy: { onFail: OnFail.NONE },
+                    retryPolicy: { kind: OnFail.NONE },
                   },
                 },
               },
@@ -1755,7 +1756,7 @@ describe('SuperJson', () => {
             defaults: {
               input: {
                 input: { test: 'test' },
-                retryPolicy: { onFail: OnFail.NONE },
+                retryPolicy: { kind: OnFail.NONE },
               },
             },
             file: 'provider/path',

--- a/src/internal/superjson/superjson.test.ts
+++ b/src/internal/superjson/superjson.test.ts
@@ -918,6 +918,26 @@ describe('SuperJson', () => {
                     }
                   }
                 }
+              },
+              "zoo": {
+                "defaults": {
+                  "Usecase": {
+                    "retryPolicy": {
+                      "kind": "circuit-breaker",
+                      "maxContiguousRetries": 5,
+                      "backoff": {
+                        "kind": "exponential",
+                        "start": 5
+                      }
+                    },
+                    "input": {
+                      "a": 12,
+                      "b": {
+                        "x": {}
+                      }
+                    }
+                  }
+                }
               }
             }
           }
@@ -1102,6 +1122,29 @@ describe('SuperJson', () => {
                     },
                     retryPolicy: {
                       kind: 'none',
+                    },
+                  },
+                },
+                mapVariant: undefined,
+                mapRevision: undefined,
+              },
+              zoo: {
+                defaults: {
+                  Usecase: {
+                    input: {
+                      a: 12,
+                      b: {
+                        x: {},
+                        y: true,
+                      },
+                    },
+                    retryPolicy: {
+                      kind: 'circuit-breaker',
+                      maxContiguousRetries: 5,
+                      backoff: {
+                        kind: 'exponential',
+                        start: 5,
+                      },
                     },
                   },
                 },

--- a/src/internal/superjson/superjson.test.ts
+++ b/src/internal/superjson/superjson.test.ts
@@ -1098,9 +1098,6 @@ describe('SuperJson', () => {
                     },
                     retryPolicy: {
                       kind: 'circuit-breaker',
-                      backoff: {
-                        kind: 'exponential',
-                      },
                     },
                   },
                 },


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
This PR removes `onFail` property from `retryPolicy`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](SECURITY.md) is correct.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
