### PR TITLE
feat: Add toString() methods to errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- `ErrorBase` now contains `toString()` method and getter for `Symbol.toStringTag`
+- `CrossFetchError` is now union of `NetworkFetchError` and `RequestFetchError` classes
 - `SuperfaceClient::getProvider` throws if the provider is not found
 - `SuperfaceClient::getProviderForProfile` no longer takes an optional non-documented preference argument
 - `FailurePolicyRouter::constructor` now takes a function which is called to instantiate policy for specified provider

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superfaceai/one-sdk",
-  "version": "0.0.29-beta.4",
+  "version": "0.0.29-beta.5",
   "description": "Level 5 autonomous, self-driving API client, https://superface.ai",
   "main": "dist/index.js",
   "source": "src/index.ts",

--- a/src/client/failure/event-adapter.ts
+++ b/src/client/failure/event-adapter.ts
@@ -2,7 +2,7 @@ import createDebug from 'debug';
 
 import { clone, sleep } from '../../lib';
 import { Events } from '../../lib/events';
-import { CrossFetchError } from '../../lib/fetch';
+import { CrossFetchError } from '../../lib/fetch.errors';
 import { FailurePolicyRouter } from './policies';
 
 const debug = createDebug('superface:failover');
@@ -139,7 +139,7 @@ export function registerHooks(hookContext: HooksContext, events: Events): void {
     const resolution = performContext.router.afterFailure({
       time: context.time.getTime(),
       registryCacheAge: 0, // TODO,
-      ...error,
+      ...error.normalized,
     });
 
     switch (resolution.kind) {

--- a/src/internal/errors.test.ts
+++ b/src/internal/errors.test.ts
@@ -55,17 +55,8 @@ Hint: hint3
 `
       );
 
-      expect(error[Symbol.toStringTag]()).toBe(
-        `short
-
-long1
-long2
-long3
-
-Hint: hint1
-Hint: hint2
-Hint: hint3
-`
+      expect(Object.prototype.toString.call(error)).toBe(
+        '[object SdkExecutionError]'
       );
     });
 

--- a/src/internal/errors.test.ts
+++ b/src/internal/errors.test.ts
@@ -1,19 +1,34 @@
-import { SDKExecutionError } from './errors';
+import { SDKExecutionError, UnexpectedError } from './errors';
 
-describe('format', () => {
-  const error = new SDKExecutionError(
-    'short',
-    ['long1', 'long2', 'long3'],
-    ['hint1', 'hint2', 'hint3']
-  );
+describe('errors', () => {
+  describe('UnexpectedError', () => {
+    const error = new UnexpectedError('out of nowhere');
 
-  it('only returns the short message when short format is requested', () => {
-    expect(error.formatShort()).toBe('short');
+    it('throws in correct format', () => {
+      expect(() => {
+        throw error;
+      }).toThrow('out of nowhere');
+    });
+
+    it('returns correct format', () => {
+      expect(error.toString()).toEqual('UnexpectedError: out of nowhere');
+    });
   });
 
-  it('returns the short message, long message and hints when long format is requested', () => {
-    expect(error.formatLong()).toBe(
-      `short
+  describe('SDKExecutionError', () => {
+    const error = new SDKExecutionError(
+      'short',
+      ['long1', 'long2', 'long3'],
+      ['hint1', 'hint2', 'hint3']
+    );
+
+    it('only returns the short message when short format is requested', () => {
+      expect(error.formatShort()).toBe('short');
+    });
+
+    it('returns the short message, long message and hints when long format is requested', () => {
+      expect(error.formatLong()).toBe(
+        `short
 
 long1
 long2
@@ -23,25 +38,12 @@ Hint: hint1
 Hint: hint2
 Hint: hint3
 `
-    );
-  });
+      );
+    });
 
-  it('returns the long format on .toString', () => {
-    expect(error.toString()).toBe(
-      `short
-
-long1
-long2
-long3
-
-Hint: hint1
-Hint: hint2
-Hint: hint3
-`
-    );
-
-    expect(error[Symbol.toStringTag]()).toBe(
-      `short
+    it('returns the long format on .toString', () => {
+      expect(error.toString()).toBe(
+        `short
 
 long1
 long2
@@ -51,12 +53,10 @@ Hint: hint1
 Hint: hint2
 Hint: hint3
 `
-    );
-  });
+      );
 
-  it('returns the long format in .message', () => {
-    expect(error.message).toBe(
-      `short
+      expect(error[Symbol.toStringTag]()).toBe(
+        `short
 
 long1
 long2
@@ -66,14 +66,12 @@ Hint: hint1
 Hint: hint2
 Hint: hint3
 `
-    );
-  });
+      );
+    });
 
-  it('formats correctly when thrown', () => {
-    expect(() => {
-      throw error;
-    }).toThrow(
-      `short
+    it('returns the long format in .message', () => {
+      expect(error.message).toBe(
+        `short
 
 long1
 long2
@@ -83,6 +81,24 @@ Hint: hint1
 Hint: hint2
 Hint: hint3
 `
-    );
+      );
+    });
+
+    it('formats correctly when thrown', () => {
+      expect(() => {
+        throw error;
+      }).toThrow(
+        `short
+
+long1
+long2
+long3
+
+Hint: hint1
+Hint: hint2
+Hint: hint3
+`
+      );
+    });
   });
 });

--- a/src/internal/errors.ts
+++ b/src/internal/errors.ts
@@ -1,8 +1,8 @@
 export class ErrorBase {
   constructor(public kind: string, public message: string) {}
 
-  [Symbol.toStringTag](): string {
-    return this.toString();
+  get [Symbol.toStringTag](): string {
+    return this.kind;
   }
 
   toString(): string {
@@ -69,11 +69,11 @@ export class SDKExecutionError extends Error {
     return result + '\n';
   }
 
-  [Symbol.toStringTag](): string {
-    return this.formatLong();
+  get [Symbol.toStringTag](): string {
+    return this.name;
   }
 
   override toString(): string {
-    return this[Symbol.toStringTag]();
+    return this.formatLong();
   }
 }

--- a/src/internal/errors.ts
+++ b/src/internal/errors.ts
@@ -1,5 +1,13 @@
 export class ErrorBase {
   constructor(public kind: string, public message: string) {}
+
+  [Symbol.toStringTag](): string {
+    return this.toString();
+  }
+
+  toString(): string {
+    return `${this.kind}: ${this.message}`;
+  }
 }
 
 export class UnexpectedError extends ErrorBase {

--- a/src/internal/interpreter/map-interpreter.errors.test.ts
+++ b/src/internal/interpreter/map-interpreter.errors.test.ts
@@ -57,7 +57,7 @@ describe('MapInterpreter errors', () => {
         ],
       };
 
-      const err = new MapASTError('Some error', { node, ast });
+      const err = new MapASTError('Some map ast error', { node, ast });
       expect(err.astPath).toStrictEqual([
         'definitions[0]',
         'statements[0]',
@@ -65,7 +65,10 @@ describe('MapInterpreter errors', () => {
         'value',
       ]);
 
-      expect(err.toString()).toEqual('')
+      expect(err.toString()).toEqual(
+        `MapASTError: Some map ast error
+AST Path: definitions[0].statements[0].assignments[0].value`
+      );
     });
   });
 
@@ -99,15 +102,28 @@ describe('MapInterpreter errors', () => {
         ],
       };
 
-      const err = new HTTPError('Some http error', { node, ast }, 500);
+      const err = new HTTPError('Some http error', { node, ast }, 500, {
+        url: 'https://my-site.com/',
+        headers: {
+          'content-type': 'json',
+          Authorization: 'bearer jasldfhasfklgj',
+        },
+      });
       expect(err.astPath).toStrictEqual([
         'definitions[0]',
         'statements[0]',
         'assignments[0]',
         'value',
       ]);
-      
-      expect(err.toString()).toEqual('')
+
+      expect(err.toString()).toEqual(
+        `HTTPError: Some http error
+AST Path: definitions[0].statements[0].assignments[0].value
+Request URL: https://my-site.com/
+Request headers:
+\tcontent-type: json
+\tAuthorization: bearer jasldfhasfklgj`
+      );
     });
   });
 
@@ -141,15 +157,23 @@ describe('MapInterpreter errors', () => {
         ],
       };
 
-      const err = new JessieError('Some jessie error', new Error('original error'), { node, ast });
+      const err = new JessieError(
+        'Some jessie error',
+        new Error('original error'),
+        { node, ast }
+      );
       expect(err.astPath).toStrictEqual([
         'definitions[0]',
         'statements[0]',
         'assignments[0]',
         'value',
       ]);
-      
-      expect(err.toString()).toEqual('')
+
+      expect(err.toString()).toEqual(
+        `JessieError: Some jessie error
+Error: original error
+AST Path: definitions[0].statements[0].assignments[0].value`
+      );
     });
   });
 

--- a/src/internal/interpreter/map-interpreter.errors.test.ts
+++ b/src/internal/interpreter/map-interpreter.errors.test.ts
@@ -5,6 +5,7 @@ import { CrossFetch } from '../../lib/fetch';
 import { UnexpectedError } from '../errors';
 import { MapInterpreter } from './map-interpreter';
 import {
+  HTTPError,
   JessieError,
   MapASTError,
   MappedHTTPError,
@@ -63,6 +64,92 @@ describe('MapInterpreter errors', () => {
         'assignments[0]',
         'value',
       ]);
+
+      expect(err.toString()).toEqual('')
+    });
+  });
+
+  describe('HTTPError', () => {
+    it('should correctly resolve AST path from node', () => {
+      const node: MapASTNode = {
+        kind: 'JessieExpression',
+        expression: '1 + 2',
+      };
+      const ast: MapDocumentNode = {
+        kind: 'MapDocument',
+        header,
+        definitions: [
+          {
+            kind: 'MapDefinition',
+            name: 'testMap',
+            usecaseName: 'testCase',
+            statements: [
+              {
+                kind: 'SetStatement',
+                assignments: [
+                  {
+                    kind: 'Assignment',
+                    key: ['result'],
+                    value: node,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const err = new HTTPError('Some http error', { node, ast }, 500);
+      expect(err.astPath).toStrictEqual([
+        'definitions[0]',
+        'statements[0]',
+        'assignments[0]',
+        'value',
+      ]);
+      
+      expect(err.toString()).toEqual('')
+    });
+  });
+
+  describe('JessieError', () => {
+    it('should correctly resolve AST path from node', () => {
+      const node: MapASTNode = {
+        kind: 'JessieExpression',
+        expression: '1 + 2',
+      };
+      const ast: MapDocumentNode = {
+        kind: 'MapDocument',
+        header,
+        definitions: [
+          {
+            kind: 'MapDefinition',
+            name: 'testMap',
+            usecaseName: 'testCase',
+            statements: [
+              {
+                kind: 'SetStatement',
+                assignments: [
+                  {
+                    kind: 'Assignment',
+                    key: ['result'],
+                    value: node,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const err = new JessieError('Some jessie error', new Error('original error'), { node, ast });
+      expect(err.astPath).toStrictEqual([
+        'definitions[0]',
+        'statements[0]',
+        'assignments[0]',
+        'value',
+      ]);
+      
+      expect(err.toString()).toEqual('')
     });
   });
 

--- a/src/internal/interpreter/map-interpreter.errors.test.ts
+++ b/src/internal/interpreter/map-interpreter.errors.test.ts
@@ -119,10 +119,7 @@ AST Path: definitions[0].statements[0].assignments[0].value`
       expect(err.toString()).toEqual(
         `HTTPError: Some http error
 AST Path: definitions[0].statements[0].assignments[0].value
-Request URL: https://my-site.com/
-Request headers:
-\tcontent-type: json
-\tAuthorization: bearer jasldfhasfklgj`
+Request URL: https://my-site.com/`
       );
     });
   });

--- a/src/internal/interpreter/map-interpreter.errors.test.ts
+++ b/src/internal/interpreter/map-interpreter.errors.test.ts
@@ -466,7 +466,7 @@ AST Path: definitions[0].statements[0].assignments[0].value`
           },
         ],
       });
-      expect(result.isErr()).toEqual(true); 
+      expect(result.isErr()).toEqual(true);
       expect(() => {
         result.unwrap();
       }).toThrow('Security values for security scheme not found: nonexistent');

--- a/src/internal/interpreter/map-interpreter.errors.test.ts
+++ b/src/internal/interpreter/map-interpreter.errors.test.ts
@@ -118,8 +118,7 @@ AST Path: definitions[0].statements[0].assignments[0].value`
 
       expect(err.toString()).toEqual(
         `HTTPError: Some http error
-AST Path: definitions[0].statements[0].assignments[0].value
-Request URL: https://my-site.com/`
+AST Path: definitions[0].statements[0].assignments[0].value`
       );
     });
   });

--- a/src/internal/interpreter/map-interpreter.errors.test.ts
+++ b/src/internal/interpreter/map-interpreter.errors.test.ts
@@ -253,10 +253,9 @@ AST Path: definitions[0].statements[0].assignments[0].value`
         ],
       });
       expect(result.isErr()).toEqual(true);
-      // expect(result.isErr() && result.error).toEqual({
-      //   error: 'Operation not found: my beloved operation',
-      // });
-      // ).rejects.toThrow('Operation not found: my beloved operation');
+      expect(() => {
+        result.unwrap();
+      }).toThrow('Operation not found: my beloved operation');
     });
 
     it('should fail when calling an API with relative URL but not providing baseUrl', async () => {
@@ -327,7 +326,9 @@ AST Path: definitions[0].statements[0].assignments[0].value`
         ],
       });
       expect(result.isErr()).toEqual(true);
-      // ).rejects.toThrow('Relative URL specified, but base URL not provided!');
+      expect(() => {
+        result.unwrap();
+      }).toThrow('Relative URL specified, but base URL not provided!');
     });
 
     it('should fail when calling an API with path parameters and some are missing', async () => {
@@ -411,9 +412,11 @@ AST Path: definitions[0].statements[0].assignments[0].value`
         ],
       });
       expect(result.isErr()).toEqual(true);
-      // ).rejects.toThrow(
-      //   'Values for URL replacement keys not found: missing, alsoMissing'
-      // );
+      expect(() => {
+        result.unwrap();
+      }).toThrow(
+        'Missing values for URL path replacement: missing, alsoMissing'
+      );
     });
 
     it('should fail when calling an API with Basic auth, but with no credentials', async () => {
@@ -463,7 +466,10 @@ AST Path: definitions[0].statements[0].assignments[0].value`
           },
         ],
       });
-      expect(result.isErr()).toEqual(true); // ('Missing credentials for Basic auth!');
+      expect(result.isErr()).toEqual(true); 
+      expect(() => {
+        result.unwrap();
+      }).toThrow('Security values for security scheme not found: nonexistent');
     });
 
     it('should fail when calling an API with Bearer auth, but with no credentials', async () => {
@@ -514,7 +520,9 @@ AST Path: definitions[0].statements[0].assignments[0].value`
         ],
       });
       expect(result.isErr()).toEqual(true);
-      // ).rejects.toThrow('Missing credentials for Bearer auth!');
+      expect(() => {
+        result.unwrap();
+      }).toThrow('Security values for security scheme not found: nonexistent');
     });
 
     it('should fail when calling an API with Apikey auth, but with no credentials', async () => {
@@ -565,7 +573,9 @@ AST Path: definitions[0].statements[0].assignments[0].value`
         ],
       });
       expect(result.isErr()).toEqual(true);
-      // ).rejects.toThrow('Missing credentials for Apikey auth!');
+      expect(() => {
+        result.unwrap();
+      }).toThrow('Security values for security scheme not found: nonexistent');
     });
 
     it('should map an error from API', async () => {

--- a/src/internal/interpreter/map-interpreter.errors.ts
+++ b/src/internal/interpreter/map-interpreter.errors.ts
@@ -108,11 +108,6 @@ export class HTTPError extends MapInterpreterErrorBase {
         ? `Original Map Location: Line ${this.metadata.node.location.line}, column ${this.metadata.node.location.column}`
         : undefined,
       this.request?.url ? `Request URL: ${this.request.url}` : undefined,
-      this.response?.headers
-        ? `Response headers:\n${Object.entries(this.response.headers)
-            .map(([key, value]) => `\t${key}: ${value}`)
-            .join('\n')}`
-        : undefined,
     ]
       .filter(line => !!line)
       .join('\n');

--- a/src/internal/interpreter/map-interpreter.errors.ts
+++ b/src/internal/interpreter/map-interpreter.errors.ts
@@ -59,6 +59,22 @@ export class MapInterpreterErrorBase extends ErrorBase {
 
     return this.path;
   }
+
+  override toString(): string {
+    return [
+      `${this.constructor.name}: ${this.message}`,
+      this.astPath ? `AST Path: ${this.astPath.join('.')}` : undefined,
+      this.metadata?.node?.location
+        ? `Original Map Location: Line ${this.metadata.node.location.line}, column ${this.metadata.node.location.column}`
+        : undefined,
+    ]
+      .filter(line => !!line)
+      .join('\n');
+  }
+
+  [Symbol.toStringTag](): string {
+    return this.toString()
+  }
 }
 
 export class MapASTError extends MapInterpreterErrorBase {
@@ -67,18 +83,6 @@ export class MapASTError extends MapInterpreterErrorBase {
     public override metadata?: ErrorMetadata
   ) {
     super('MapASTError', message, metadata);
-  }
-
-  public override toString(): string {
-    return [
-      `MapASTError: ${this.message}`,
-      this.astPath ? `AST Path: ${this.astPath.join('.')}` : undefined,
-      this.metadata?.node?.location
-        ? `Original Map Location: Line ${this.metadata.node.location.line}, column ${this.metadata.node.location.column}`
-        : undefined,
-    ]
-      .filter(line => !!line)
-      .join('\n');
   }
 }
 

--- a/src/internal/interpreter/map-interpreter.errors.ts
+++ b/src/internal/interpreter/map-interpreter.errors.ts
@@ -99,19 +99,6 @@ export class HTTPError extends MapInterpreterErrorBase {
   ) {
     super('HTTPError', message, metadata);
   }
-
-  override toString(): string {
-    return [
-      `${this.kind}: ${this.message}`,
-      this.astPath ? `AST Path: ${this.astPath.join('.')}` : undefined,
-      this.metadata?.node?.location
-        ? `Original Map Location: Line ${this.metadata.node.location.line}, column ${this.metadata.node.location.column}`
-        : undefined,
-      this.request?.url ? `Request URL: ${this.request.url}` : undefined,
-    ]
-      .filter(line => !!line)
-      .join('\n');
-  }
 }
 
 export class MappedHTTPError<T> extends HTTPError {

--- a/src/internal/interpreter/map-interpreter.errors.ts
+++ b/src/internal/interpreter/map-interpreter.errors.ts
@@ -108,11 +108,6 @@ export class HTTPError extends MapInterpreterErrorBase {
         ? `Original Map Location: Line ${this.metadata.node.location.line}, column ${this.metadata.node.location.column}`
         : undefined,
       this.request?.url ? `Request URL: ${this.request.url}` : undefined,
-      this.request?.headers
-        ? `Request headers:\n${Object.entries(this.request.headers)
-            .map(([key, value]) => `\t${key}: ${value}`)
-            .join('\n')}`
-        : undefined,
       this.response?.headers
         ? `Response headers:\n${Object.entries(this.response.headers)
             .map(([key, value]) => `\t${key}: ${value}`)

--- a/src/internal/interpreter/map-interpreter.errors.ts
+++ b/src/internal/interpreter/map-interpreter.errors.ts
@@ -62,7 +62,7 @@ export class MapInterpreterErrorBase extends ErrorBase {
 
   override toString(): string {
     return [
-      `${this.constructor.name}: ${this.message}`,
+      `${this.kind}: ${this.message}`,
       this.astPath ? `AST Path: ${this.astPath.join('.')}` : undefined,
       this.metadata?.node?.location
         ? `Original Map Location: Line ${this.metadata.node.location.line}, column ${this.metadata.node.location.column}`
@@ -70,10 +70,6 @@ export class MapInterpreterErrorBase extends ErrorBase {
     ]
       .filter(line => !!line)
       .join('\n');
-  }
-
-  [Symbol.toStringTag](): string {
-    return this.toString()
   }
 }
 
@@ -103,6 +99,29 @@ export class HTTPError extends MapInterpreterErrorBase {
   ) {
     super('HTTPError', message, metadata);
   }
+
+  override toString(): string {
+    return [
+      `${this.kind}: ${this.message}`,
+      this.astPath ? `AST Path: ${this.astPath.join('.')}` : undefined,
+      this.metadata?.node?.location
+        ? `Original Map Location: Line ${this.metadata.node.location.line}, column ${this.metadata.node.location.column}`
+        : undefined,
+      this.request?.url ? `Request URL: ${this.request.url}` : undefined,
+      this.request?.headers
+        ? `Request headers:\n${Object.entries(this.request.headers)
+            .map(([key, value]) => `\t${key}: ${value}`)
+            .join('\n')}`
+        : undefined,
+      this.response?.headers
+        ? `Response headers:\n${Object.entries(this.response.headers)
+            .map(([key, value]) => `\t${key}: ${value}`)
+            .join('\n')}`
+        : undefined,
+    ]
+      .filter(line => !!line)
+      .join('\n');
+  }
 }
 
 export class MappedHTTPError<T> extends HTTPError {
@@ -127,7 +146,7 @@ export class JessieError extends MapInterpreterErrorBase {
 
   public override toString(): string {
     return [
-      this.message,
+      `${this.kind}: ${this.message}`,
       this.originalError.toString(),
       this.astPath ? `AST Path: ${this.astPath.join('.')}` : undefined,
       this.metadata?.node?.location

--- a/src/lib/fetch.errors.ts
+++ b/src/lib/fetch.errors.ts
@@ -10,12 +10,11 @@ interface RequestError {
   issue: 'abort' | 'timeout';
 }
 
+export type FetchErrorIssue = NetworkError['issue'] | RequestError['issue'];
+
 export class FetchError extends ErrorBase {
-  constructor(
-    public override kind: string,
-    public issue: NetworkError['issue'] | RequestError['issue']
-  ) {
-    super(kind, `Fetch failed because of ${issue} issue`);
+  constructor(public override kind: string, public issue: FetchErrorIssue) {
+    super(kind, `Fetch failed: ${issue} issue`);
   }
 }
 

--- a/src/lib/fetch.errors.ts
+++ b/src/lib/fetch.errors.ts
@@ -1,0 +1,25 @@
+import { ErrorBase } from '../internal/errors';
+
+export interface NetworkError {
+  kind: 'network';
+  issue: 'unsigned-ssl' | 'dns' | 'timeout' | 'reject';
+}
+
+export interface RequestError {
+  kind: 'request';
+  issue: 'abort' | 'timeout';
+}
+
+export class NetworkFetchError extends ErrorBase {
+  constructor(public issue: NetworkError['issue']) {
+    super('NetworkError', `Fetch failed because of ${issue} issue`);
+  }
+}
+
+export class RequestFetchError extends ErrorBase {
+  constructor(public issue: RequestError['issue']) {
+    super('RequestError', `Fetch failed because of ${issue} issue`);
+  }
+}
+
+export type CrossFetchError = NetworkFetchError | RequestFetchError;

--- a/src/lib/fetch.errors.ts
+++ b/src/lib/fetch.errors.ts
@@ -1,24 +1,41 @@
 import { ErrorBase } from '../internal/errors';
 
-export interface NetworkError {
+interface NetworkError {
   kind: 'network';
   issue: 'unsigned-ssl' | 'dns' | 'timeout' | 'reject';
 }
 
-export interface RequestError {
+interface RequestError {
   kind: 'request';
   issue: 'abort' | 'timeout';
 }
 
-export class NetworkFetchError extends ErrorBase {
-  constructor(public issue: NetworkError['issue']) {
-    super('NetworkError', `Fetch failed because of ${issue} issue`);
+export class FetchError extends ErrorBase {
+  constructor(
+    public override kind: string,
+    public issue: NetworkError['issue'] | RequestError['issue']
+  ) {
+    super(kind, `Fetch failed because of ${issue} issue`);
   }
 }
 
-export class RequestFetchError extends ErrorBase {
-  constructor(public issue: RequestError['issue']) {
-    super('RequestError', `Fetch failed because of ${issue} issue`);
+export class NetworkFetchError extends FetchError {
+  constructor(public override issue: NetworkError['issue']) {
+    super('NetworkError', issue);
+  }
+
+  get normalized(): NetworkError {
+    return { kind: 'network', issue: this.issue };
+  }
+}
+
+export class RequestFetchError extends FetchError {
+  constructor(public override issue: RequestError['issue']) {
+    super('RequestError', issue);
+  }
+
+  get normalized(): RequestError {
+    return { kind: 'request', issue: this.issue };
   }
 }
 

--- a/src/lib/fetch.test.ts
+++ b/src/lib/fetch.test.ts
@@ -1,5 +1,6 @@
 import { getLocal } from 'mockttp';
 import { mocked } from 'ts-jest/utils';
+import { NetworkFetchError, RequestFetchError } from './fetch.errors';
 
 const mockServer = getLocal();
 
@@ -23,7 +24,7 @@ describe('fetch', () => {
 
       await expect(
         fetch.fetch(`${mockServer.url}/test`, { method: 'GET', timeout: 2000 })
-      ).rejects.toEqual({ kind: 'network', issue: 'timeout' });
+      ).rejects.toEqual(new NetworkFetchError('timeout'));
     }, 10000);
 
     it('rejects on rejected connection', async () => {
@@ -34,7 +35,7 @@ describe('fetch', () => {
 
       await expect(
         fetch.fetch(`${mockServer.url}/test`, { method: 'GET', timeout: 2000 })
-      ).rejects.toEqual({ kind: 'network', issue: 'reject' });
+      ).rejects.toEqual(new NetworkFetchError('reject'));
     }, 10000);
 
     it('rethrows error if it is string', async () => {
@@ -88,7 +89,7 @@ describe('fetch', () => {
           method: 'GET',
           timeout: 2000,
         })
-      ).rejects.toEqual({ kind: 'request', issue: 'abort' });
+      ).rejects.toEqual(new RequestFetchError('abort'));
     }, 10000);
 
     it('throws on dns ENOTFOUND', async () => {
@@ -110,7 +111,7 @@ describe('fetch', () => {
           method: 'GET',
           timeout: 2000,
         })
-      ).rejects.toEqual({ kind: 'network', issue: 'dns' });
+      ).rejects.toEqual(new NetworkFetchError('dns'));
     }, 10000);
 
     it('throws on dns EAI_AGAIN', async () => {
@@ -132,7 +133,7 @@ describe('fetch', () => {
           method: 'GET',
           timeout: 2000,
         })
-      ).rejects.toEqual({ kind: 'network', issue: 'dns' });
+      ).rejects.toEqual(new NetworkFetchError('dns'));
     }, 10000);
   });
 });

--- a/src/lib/fetch.test.ts
+++ b/src/lib/fetch.test.ts
@@ -1,5 +1,6 @@
 import { getLocal } from 'mockttp';
 import { mocked } from 'ts-jest/utils';
+
 import { NetworkFetchError, RequestFetchError } from './fetch.errors';
 
 const mockServer = getLocal();

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -19,7 +19,11 @@ import {
   Interceptable,
   InterceptableMetadata,
 } from './events';
-import { CrossFetchError, NetworkFetchError, RequestFetchError } from './fetch.errors';
+import {
+  CrossFetchError,
+  NetworkFetchError,
+  RequestFetchError,
+} from './fetch.errors';
 
 export class CrossFetch implements FetchInstance, Interceptable {
   public metadata: InterceptableMetadata | undefined;
@@ -111,7 +115,7 @@ export class CrossFetch implements FetchInstance, Interceptable {
 
     const error: { type: string } = err as { type: string };
     if (error.type === 'aborted') {
-      return new NetworkFetchError('timeout')
+      return new NetworkFetchError('timeout');
     }
 
     if (error.type === 'system') {
@@ -127,11 +131,11 @@ export class CrossFetch implements FetchInstance, Interceptable {
 
       // TODO: unsigned ssl?
 
-      return new NetworkFetchError('reject')
+      return new NetworkFetchError('reject');
     }
 
     // TODO: Match other errors here
-    return new RequestFetchError('abort')
+    return new RequestFetchError('abort');
   }
 
   private queryParameters(parameters?: Record<string, string>): string {


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
Add `toString()` methods to error classes that don't contain this method.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Error formatting.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](SECURITY.md) is correct.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
