### PR TITLE
fix: add profile defaults resolution

### DIFF
--- a/src/internal/superjson/mutate.ts
+++ b/src/internal/superjson/mutate.ts
@@ -1,6 +1,7 @@
 import { err, ok, Result } from '../../lib';
 import { isEmptyRecord } from '../interpreter/variables';
 import {
+  normalizeProfileProviderDefaults,
   normalizeProfileSettings,
   normalizeUsecaseDefaults,
 } from './normalize';
@@ -91,13 +92,19 @@ export function addProfile(
 
   // Priority #2: keep previous structure and merge
   let defaults: UsecaseDefaults | undefined;
+  let priority: string[] | undefined;
   if (typeof targetedProfile === 'string') {
     defaults = payload.defaults;
-  } else if (targetedProfile.defaults) {
-    defaults = normalizeUsecaseDefaults(
-      payload.defaults,
-      normalizeUsecaseDefaults(targetedProfile.defaults)
-    );
+  } else {
+    if (targetedProfile.defaults) {
+      defaults = normalizeUsecaseDefaults(
+        payload.defaults,
+        normalizeUsecaseDefaults(targetedProfile.defaults)
+      );
+    }
+    if (targetedProfile.priority) {
+      priority = targetedProfile.priority;
+    }
   }
 
   let providers: Record<string, ProfileProviderEntry> | undefined;
@@ -112,6 +119,7 @@ export function addProfile(
 
   document.profiles[profileName] = {
     ...payload,
+    priority,
     defaults,
     providers,
   };
@@ -190,9 +198,9 @@ export function addProfileProvider(
   if (typeof profileProvider === 'string') {
     defaults = payload.defaults;
   } else if (profileProvider.defaults) {
-    defaults = normalizeUsecaseDefaults(
+    defaults = normalizeProfileProviderDefaults(
       payload.defaults,
-      normalizeUsecaseDefaults(profileProvider.defaults)
+      normalizeUsecaseDefaults(targetedProfile.defaults)
     );
   }
 

--- a/src/internal/superjson/superjson.test.ts
+++ b/src/internal/superjson/superjson.test.ts
@@ -1416,6 +1416,195 @@ describe('SuperJson', () => {
         },
       });
     });
+
+    it('adds profile to super.json with priority and disabled providerFailover', () => {
+      const mockProfileName = 'profile';
+      const mockUseCaseName = 'usecase';
+
+      const mockProfileEntry: ProfileEntry = {
+        defaults: {
+          [mockUseCaseName]: {
+            providerFailover: false,
+          },
+        },
+        priority: ['test'],
+        file: 'some/path',
+        providers: { test: {} },
+      };
+
+      superjson = new SuperJson({
+        profiles: {
+          [mockProfileName]: '0.0.0',
+        },
+      });
+      expect(superjson.addProfile(mockProfileName, mockProfileEntry)).toEqual(
+        true
+      );
+      expect(superjson.normalized.profiles[mockProfileName]).toEqual({
+        defaults: {
+          [mockUseCaseName]: {
+            input: {},
+            providerFailover: false,
+          },
+        },
+        file: 'some/path',
+        priority: ['test'],
+        providers: {
+          test: {
+            defaults: {
+              [mockUseCaseName]: {
+                input: {},
+                retryPolicy: {
+                  kind: 'none',
+                },
+              },
+            },
+            mapRevision: undefined,
+            mapVariant: undefined,
+          },
+        },
+      });
+    });
+
+    it('adds profile to super.json with priority and enabled providerFailover', () => {
+      const mockProfileName = 'profile';
+      const mockUseCaseName = 'usecase';
+
+      const mockProfileEntry: ProfileEntry = {
+        defaults: {
+          [mockUseCaseName]: {
+            providerFailover: true,
+          },
+        },
+        priority: ['test'],
+        file: 'some/path',
+        providers: { test: {} },
+      };
+
+      superjson = new SuperJson({
+        profiles: {
+          [mockProfileName]: '0.0.0',
+        },
+      });
+      expect(superjson.addProfile(mockProfileName, mockProfileEntry)).toEqual(
+        true
+      );
+      expect(superjson.normalized.profiles[mockProfileName]).toEqual({
+        defaults: {
+          [mockUseCaseName]: {
+            input: {},
+            providerFailover: true,
+          },
+        },
+        file: 'some/path',
+        priority: ['test'],
+        providers: {
+          test: {
+            defaults: {
+              [mockUseCaseName]: {
+                input: {},
+                retryPolicy: {
+                  kind: 'none',
+                },
+              },
+            },
+            mapRevision: undefined,
+            mapVariant: undefined,
+          },
+        },
+      });
+    });
+
+    it('adds profile to super.json with existing priority, enabled providerFailover and retry policy', () => {
+      const mockProfileName = 'profile';
+      const mockUseCaseName = 'usecase';
+
+      const mockProfileEntry: ProfileEntry = {
+        defaults: {
+          [mockUseCaseName]: {
+            providerFailover: true,
+          },
+        },
+        priority: ['test'],
+        file: 'some/path',
+        providers: {
+          test: {
+            defaults: {
+              [mockUseCaseName]: {
+                input: {},
+                retryPolicy: {
+                  kind: OnFail.CIRCUIT_BREAKER,
+                  //Different numbers
+                  maxContiguousRetries: 10,
+                  requestTimeout: 60_000,
+                },
+              },
+            },
+            mapRevision: undefined,
+            mapVariant: undefined,
+          },
+        },
+      };
+
+      superjson = new SuperJson({
+        profiles: {
+          [mockProfileName]: {
+            defaults: {
+              [mockUseCaseName]: {
+                providerFailover: true,
+              },
+            },
+            priority: ['test'],
+            file: 'some/path',
+            providers: {
+              test: {
+                defaults: {
+                  [mockUseCaseName]: {
+                    input: {},
+                    retryPolicy: {
+                      kind: OnFail.CIRCUIT_BREAKER,
+                      maxContiguousRetries: 1,
+                      requestTimeout: 1500,
+                    },
+                  },
+                },
+                mapRevision: undefined,
+                mapVariant: undefined,
+              },
+            },
+          },
+        },
+      });
+      expect(superjson.addProfile(mockProfileName, mockProfileEntry)).toEqual(
+        true
+      );
+      expect(superjson.normalized.profiles[mockProfileName]).toEqual({
+        defaults: {
+          [mockUseCaseName]: {
+            input: {},
+            providerFailover: true,
+          },
+        },
+        file: 'some/path',
+        priority: ['test'],
+        providers: {
+          test: {
+            defaults: {
+              [mockUseCaseName]: {
+                input: {},
+                retryPolicy: {
+                  kind: OnFail.CIRCUIT_BREAKER,
+                  maxContiguousRetries: 10,
+                  requestTimeout: 60_000,
+                },
+              },
+            },
+            mapRevision: undefined,
+            mapVariant: undefined,
+          },
+        },
+      });
+    });
   });
 
   describe('when adding profile provider', () => {


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
This PR fixes problem with wrong profile provider defaults normalization and missing priority resolution

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](SECURITY.md) is correct.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
