### PR TITLE
feat: throw error on local provider and remote map

### DIFF
--- a/src/client/profile-provider.test.ts
+++ b/src/client/profile-provider.test.ts
@@ -2,6 +2,7 @@ import { MapDocumentNode, ProfileDocumentNode } from '@superfaceai/ast';
 import { promises as fsp } from 'fs';
 import { mocked } from 'ts-jest/utils';
 
+import { localProviderAndRemoteMapError } from '../internal/errors.helpers';
 import { MapInterpreter } from '../internal/interpreter/map-interpreter';
 import { MapASTError } from '../internal/interpreter/map-interpreter.errors';
 import { ProfileParameterValidator } from '../internal/interpreter/profile-parameter-validator';
@@ -498,7 +499,9 @@ describe('profile provider', () => {
                 version: '1.0.0',
                 defaults: {},
                 providers: {
-                  test: {},
+                  test: {
+                    file: 'file://some/file',
+                  },
                 },
               },
             },
@@ -557,7 +560,7 @@ describe('profile provider', () => {
         const mockProfileProvider = new ProfileProvider(
           mockSuperJson,
           'test-profile',
-          mockProviderConfiguration,
+          'test',
           mockSuperfacClient
         );
         await expect(mockProfileProvider.bind()).rejects.toThrow(
@@ -605,6 +608,51 @@ describe('profile provider', () => {
         expect(result).toMatchObject(expectedBoundProfileProvider);
       });
 
+      it('throws error when provider is provided locally but map is not', async () => {
+        //normalized is getter on SuperJson - unable to mock or spy on
+        Object.assign(mockSuperJson, {
+          normalized: {
+            profiles: {
+              ['test-profile']: {
+                version: '1.0.0',
+                defaults: {},
+                providers: {
+                  test: {},
+                },
+              },
+            },
+            providers: {
+              test: {
+                file: 'file://some/file',
+              },
+            },
+          },
+        });
+
+        mocked(mockResolvePath).mockReturnValue('file://some/path/to');
+
+        jest
+          .spyOn(fsp, 'readFile')
+          .mockResolvedValueOnce(JSON.stringify(mockProfileDocument))
+          .mockResolvedValueOnce(JSON.stringify(mockProviderJson));
+
+        mocked(fetchProviderInfo).mockResolvedValue(mockProviderJson);
+
+        const mockProfileProvider = new ProfileProvider(
+          mockSuperJson,
+          'test-profile',
+          mockProviderConfiguration,
+          mockSuperfacClient
+        );
+
+        await expect(() => mockProfileProvider.bind()).rejects.toThrow(
+          localProviderAndRemoteMapError(
+            mockProviderJson.name,
+            mockProfileDocument.header.name
+          )
+        );
+      });
+
       it('throws error without profile provider settings', async () => {
         mocked(fetchBind).mockResolvedValue(mockFetchResponse);
         //normalized is getter on SuperJson - unable to mock or spy on
@@ -620,7 +668,6 @@ describe('profile provider', () => {
             },
             providers: {
               test: {
-                file: 'file://some/file',
                 security: [],
               },
             },
@@ -707,7 +754,9 @@ describe('profile provider', () => {
               ['test-profile']: {
                 version: '1.0.0',
                 defaults: {},
-                providers: {},
+                providers: {
+                  test: {},
+                },
               },
             },
             providers: {
@@ -729,7 +778,7 @@ describe('profile provider', () => {
         const mockProfileProvider = new ProfileProvider(
           mockSuperJson,
           mockProfileDocument,
-          mockProviderJson,
+          'test',
           mockSuperfacClient
         );
 
@@ -747,7 +796,9 @@ but a secret value was provided for security scheme: made-up-id`
               ['test-profile']: {
                 version: '1.0.0',
                 defaults: {},
-                providers: {},
+                providers: {
+                  test: {},
+                },
               },
             },
             providers: {
@@ -768,7 +819,7 @@ but a secret value was provided for security scheme: made-up-id`
         const mockProfileProvider = new ProfileProvider(
           mockSuperJson,
           mockProfileDocument,
-          mockProviderJson,
+          'test',
           mockSuperfacClient
         );
 
@@ -786,7 +837,9 @@ but apiKey scheme requires: apikey`
               ['test-profile']: {
                 version: '1.0.0',
                 defaults: {},
-                providers: {},
+                providers: {
+                  test: {},
+                },
               },
             },
             providers: {
@@ -807,7 +860,7 @@ but apiKey scheme requires: apikey`
         const mockProfileProvider = new ProfileProvider(
           mockSuperJson,
           mockProfileDocument,
-          mockProviderJson,
+          'test',
           mockSuperfacClient
         );
 
@@ -825,7 +878,9 @@ but http scheme requires: username, password`
               ['test-profile']: {
                 version: '1.0.0',
                 defaults: {},
-                providers: {},
+                providers: {
+                  test: {},
+                },
               },
             },
             providers: {
@@ -846,7 +901,7 @@ but http scheme requires: username, password`
         const mockProfileProvider = new ProfileProvider(
           mockSuperJson,
           mockProfileDocument,
-          mockProviderJson,
+          'test',
           mockSuperfacClient
         );
 
@@ -864,7 +919,9 @@ but http scheme requires: token`
               ['test-profile']: {
                 version: '1.0.0',
                 defaults: {},
-                providers: {},
+                providers: {
+                  test: {},
+                },
               },
             },
             providers: {
@@ -885,7 +942,7 @@ but http scheme requires: token`
         const mockProfileProvider = new ProfileProvider(
           mockSuperJson,
           mockProfileDocument,
-          mockProviderJson,
+          'test',
           mockSuperfacClient
         );
 

--- a/src/client/profile-provider.ts
+++ b/src/client/profile-provider.ts
@@ -19,6 +19,7 @@ import {
 import {
   invalidProfileError,
   invalidSecurityValuesError,
+  localProviderAndRemoteMapError,
   referencedFileNotFoundError,
   securityNotFoundError,
   serviceNotFoundError,
@@ -255,6 +256,11 @@ export class ProfileProvider {
 
     // resolve map ast using bind and fill in provider info if not specified
     if (mapAst === undefined) {
+      profileProviderDebug('Fetching map from store');
+      //throw error when we have remote map and local provider
+      if (providerInfo) {
+        throw localProviderAndRemoteMapError(providerName, this.profileId);
+      }
       const fetchResponse = await fetchBind({
         profileId:
           profileId +

--- a/src/internal/errors.helpers.ts
+++ b/src/internal/errors.helpers.ts
@@ -318,6 +318,24 @@ export function invalidProfileProviderError(
   );
 }
 
+export function localProviderAndRemoteMapError(
+  providerName: string,
+  profileId: string
+): SDKExecutionError {
+  return new SDKExecutionError(
+    `Unable to use local provider ${providerName} and remote profile provider (map)`,
+    [
+      `Super.json settings: ${profileId}.providers.${providerName}`,
+      `Super.json settings providers.${providerName}`,
+    ],
+    [
+      `Use local provider and profile provider (map)`,
+      `Use remote provider and profile provider (map)`,
+      `Use remote provider and local profile provider (map)`,
+    ]
+  );
+}
+
 export function referencedFileNotFoundError(
   fileName: string,
   extensions: string[]


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

This PR adds throwing error in cases when user has local provider and remote map.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](SECURITY.md) is correct.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
