### PR TITLE
fix: Forbid absolute URLs in map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- **BREAKING CHANGE**: absolute URLs are no longer allowed in maps
+- **BREAKING CHANGE**: interpolation no longer works in base URLs
 
 ## [0.0.36] - 2021-09-29
 ### Fixed

--- a/src/client/registry.test.ts
+++ b/src/client/registry.test.ts
@@ -3,11 +3,7 @@ import { MapDocumentNode } from '@superfaceai/ast';
 import { Config } from '../config';
 import { UnexpectedError } from '../internal/errors';
 import { ProviderJson } from '../internal/providerjson';
-import {
-  assertIsRegistryProviderInfo,
-  fetchBind,
-  fetchProviders,
-} from './registry';
+import { assertIsRegistryProviderInfo, fetchBind } from './registry';
 
 const request = jest.fn();
 jest.mock('../internal/interpreter/http', () => {
@@ -98,55 +94,6 @@ describe('registry', () => {
       expect(() => assertIsRegistryProviderInfo(record)).toThrowError(
         'Invalid response from registry'
       );
-    });
-  });
-
-  describe('when fetching providers', () => {
-    const mockRecord = {
-      url: 'test/url',
-      registryId: 'some-registiry-id',
-      serviceUrl: 'test/service/url',
-      mappingUrl: 'test/mapping/url',
-      semanticProfile: 'test/profile',
-      disco: [
-        {
-          url: 'disco/test/url',
-          registryId: 'disco/some-registiry-id',
-          serviceUrl: 'disco/test/service/url',
-          mappingUrl: 'disco/test/mapping/url',
-          semanticProfile: 'disco/test/profile',
-        },
-      ],
-    };
-
-    it('fetches map documentt', async () => {
-      const mockResponse = {
-        statusCode: 200,
-        body: mockRecord,
-        headers: { test: 'test' },
-        debug: {
-          request: {
-            headers: { test: 'test' },
-            url: 'test',
-            body: {},
-          },
-        },
-      };
-
-      request.mockResolvedValue(mockResponse);
-
-      await expect(fetchProviders('test-id', 'test-url')).resolves.toEqual(
-        mockRecord.disco
-      );
-
-      expect(request).toHaveBeenCalledTimes(1);
-      expect(request).toHaveBeenCalledWith('test-url', {
-        method: 'GET',
-        queryParameters: {
-          semanticProfile: 'test-id',
-        },
-        accept: 'application/json',
-      });
     });
   });
 

--- a/src/client/registry.ts
+++ b/src/client/registry.ts
@@ -55,26 +55,6 @@ export function assertIsRegistryProviderInfo(
   }
 }
 
-export async function fetchProviders(
-  profileId: string,
-  registryUrl: string
-): Promise<RegistryProviderInfo[]> {
-  const fetchInstance = new CrossFetch();
-  const http = new HttpClient(fetchInstance);
-  registryDebug('Fetching providers from registry');
-  const { body } = await http.request(registryUrl, {
-    method: 'GET',
-    queryParameters: {
-      semanticProfile: profileId,
-    },
-    accept: 'application/json',
-  });
-
-  assertIsRegistryProviderInfo(body);
-
-  return body.disco;
-}
-
 export async function fetchProviderInfo(
   providerName: string
 ): Promise<ProviderJson> {

--- a/src/internal/interpreter/http/http.ts
+++ b/src/internal/interpreter/http/http.ts
@@ -62,26 +62,21 @@ export enum NetworkErrors {
 
 export const createUrl = (
   inputUrl: string,
-  parameters?: {
-    baseUrl?: string;
+  parameters: {
+    baseUrl: string;
     pathParameters?: NonPrimitive;
   }
 ): string => {
-  const isRelative = /^\/[^/]/.test(inputUrl);
-
-  let url: string;
-
-  if (isRelative) {
-    if (parameters?.baseUrl === undefined) {
-      throw new UnexpectedError(
-        'Relative URL specified, but base URL not provided!'
-      );
-    } else {
-      url = parameters.baseUrl.replace(/\/+$/, '') + inputUrl;
-    }
-  } else {
-    url = inputUrl;
+  if (inputUrl === '') {
+    return parameters.baseUrl;
   }
+  const isRelative = /^\/[^/]/.test(inputUrl);
+  if (!isRelative) {
+    console.log(inputUrl);
+    throw new UnexpectedError('Expected relative url, but received absolute!');
+  }
+
+  let url = inputUrl;
 
   if (parameters?.pathParameters !== undefined) {
     const replacements: string[] = [];
@@ -116,6 +111,8 @@ export const createUrl = (
     }
   }
 
+  url = parameters.baseUrl.replace(/\/+$/, '') + url;
+
   return `${url}`;
 };
 
@@ -133,7 +130,7 @@ export class HttpClient {
       accept?: string;
       securityRequirements?: HttpSecurityRequirement[];
       securityConfiguration?: SecurityConfiguration[];
-      baseUrl?: string;
+      baseUrl: string;
       pathParameters?: NonPrimitive;
     }
   ): Promise<HttpResponse> {

--- a/src/internal/interpreter/http/http.ts
+++ b/src/internal/interpreter/http/http.ts
@@ -72,7 +72,6 @@ export const createUrl = (
   }
   const isRelative = /^\/[^/]/.test(inputUrl);
   if (!isRelative) {
-    console.log(inputUrl);
     throw new UnexpectedError('Expected relative url, but received absolute!');
   }
 

--- a/src/internal/interpreter/map-interpreter.test.ts
+++ b/src/internal/interpreter/map-interpreter.test.ts
@@ -21,8 +21,11 @@ const header: MapHeaderNode = {
 };
 
 describe('MapInterpreter', () => {
+  let serviceBaseUrl: string;
+
   beforeEach(async () => {
     await mockServer.start();
+    serviceBaseUrl = mockServer.url;
   });
 
   afterEach(async () => {
@@ -366,7 +369,8 @@ describe('MapInterpreter', () => {
   });
 
   it('should call an API', async () => {
-    await mockServer.get('/twelve').thenJson(
+    const url = '/twelve';
+    await mockServer.get(url).thenJson(
       200,
       { data: 12 },
       {
@@ -374,11 +378,11 @@ describe('MapInterpreter', () => {
         'Content-Language': 'en-US, en-CA',
       }
     );
-    const url = mockServer.urlFor('/twelve');
     const interpreter = new MapInterpreter(
       {
         usecase: 'Test',
         security: [],
+        serviceBaseUrl,
       },
       { fetchInstance }
     );
@@ -518,13 +522,14 @@ describe('MapInterpreter', () => {
   });
 
   it('should call an API with path parameters', async () => {
-    await mockServer.get('/twelve/2').thenJson(200, { data: 144 });
-    const url = mockServer.urlFor('/twelve');
+    const url = '/twelve';
+    await mockServer.get(url + '/2').thenJson(200, { data: 144 });
     const interpreter = new MapInterpreter(
       {
         usecase: 'Test',
         input: { page: '2' },
         security: [],
+        serviceBaseUrl,
       },
       { fetchInstance }
     );
@@ -604,16 +609,17 @@ describe('MapInterpreter', () => {
   });
 
   it('should call an API with parameters', async () => {
+    const url = '/twelve';
     await mockServer
-      .get('/twelve')
+      .get(url)
       .withQuery({ page: 2 })
       .thenJson(200, { data: 144 });
-    const url = mockServer.urlFor('/twelve');
     const interpreter = new MapInterpreter(
       {
         usecase: 'Test',
         input: { page: 2 },
         security: [],
+        serviceBaseUrl,
       },
       { fetchInstance }
     );
@@ -693,16 +699,17 @@ describe('MapInterpreter', () => {
   });
 
   it('should call an API with parameters and POST request', async () => {
+    const url = '/checkBody';
     await mockServer
-      .post('/checkBody')
+      .post(url)
       .withJsonBody({ anArray: [1, 2, 3] })
       .withHeaders({ someheader: 'hello' })
       .thenJson(201, { bodyOk: true, headerOk: true });
-    const url = mockServer.urlFor('/checkBody');
     const interpreter = new MapInterpreter(
       {
         usecase: 'Test',
         security: [],
+        serviceBaseUrl,
       },
       { fetchInstance }
     );
@@ -783,16 +790,15 @@ describe('MapInterpreter', () => {
   });
 
   it('should run multi step operation', async () => {
-    await mockServer
-      .get('/first')
-      .thenJson(200, { firstStep: { someVar: 12 } });
-    await mockServer.get('/second').thenJson(200, { secondStep: 5 });
-    const url1 = mockServer.urlFor('/first');
-    const url2 = mockServer.urlFor('/second');
+    const url1 = '/first';
+    const url2 = '/second';
+    await mockServer.get(url1).thenJson(200, { firstStep: { someVar: 12 } });
+    await mockServer.get(url2).thenJson(200, { secondStep: 5 });
     const interpreter = new MapInterpreter(
       {
         usecase: 'Test',
         security: [],
+        serviceBaseUrl,
       },
       { fetchInstance }
     );
@@ -882,11 +888,11 @@ describe('MapInterpreter', () => {
   });
 
   it('should call an API with Basic auth', async () => {
+    const url = '/basic';
     await mockServer
-      .get('/basic')
+      .get(url)
       .withHeaders({ Authorization: 'Basic bmFtZTpwYXNzd29yZA==' })
       .thenJson(200, { data: 12 });
-    const url = mockServer.urlFor('/basic');
     const interpreter = new MapInterpreter(
       {
         usecase: 'testCase',
@@ -899,6 +905,7 @@ describe('MapInterpreter', () => {
             password: 'password',
           },
         ],
+        serviceBaseUrl,
       },
       { fetchInstance }
     );
@@ -946,11 +953,11 @@ describe('MapInterpreter', () => {
   });
 
   it('should call an API with Bearer auth', async () => {
+    const url = '/bearer';
     await mockServer
-      .get('/bearer')
+      .get(url)
       .withHeaders({ Authorization: 'Bearer SuperSecret' })
       .thenJson(200, { data: 12 });
-    const url = mockServer.urlFor('/bearer');
     const interpreter = new MapInterpreter(
       {
         usecase: 'testCase',
@@ -962,6 +969,7 @@ describe('MapInterpreter', () => {
             token: 'SuperSecret',
           },
         ],
+        serviceBaseUrl,
       },
       { fetchInstance }
     );
@@ -1009,11 +1017,11 @@ describe('MapInterpreter', () => {
   });
 
   it('should call an API with Apikey auth in header', async () => {
+    const url = '/apikey';
     await mockServer
-      .get('/apikey')
+      .get(url)
       .withHeaders({ Key: 'SuperSecret' })
       .thenJson(200, { data: 12 });
-    const url = mockServer.urlFor('/apikey');
     const interpreter = new MapInterpreter(
       {
         usecase: 'testCase',
@@ -1026,6 +1034,7 @@ describe('MapInterpreter', () => {
             apikey: 'SuperSecret',
           },
         ],
+        serviceBaseUrl,
       },
       { fetchInstance }
     );
@@ -1074,11 +1083,11 @@ describe('MapInterpreter', () => {
   });
 
   it('should call an API with Apikey auth in query', async () => {
+    const url = '/apikey';
     await mockServer
-      .get('/apikey')
+      .get(url)
       .withQuery({ key: 'SuperSecret' })
       .thenJson(200, { data: 12 });
-    const url = mockServer.urlFor('/apikey');
     const interpreter = new MapInterpreter(
       {
         usecase: 'testCase',
@@ -1091,6 +1100,7 @@ describe('MapInterpreter', () => {
             apikey: 'SuperSecret',
           },
         ],
+        serviceBaseUrl,
       },
       { fetchInstance }
     );
@@ -1138,13 +1148,15 @@ describe('MapInterpreter', () => {
   });
 
   it('should call an API with multipart/form-data body', async () => {
-    await mockServer.post('/formdata').thenCallback(request => {
+    const url = '/formdata';
+    await mockServer.post(url).thenCallback(async request => {
+      const text = await request.body.getText();
       if (
-        request.body.text &&
-        request.body.text.includes('formData') &&
-        request.body.text.includes('myFormData') &&
-        request.body.text.includes('is') &&
-        request.body.text.includes('present')
+        text &&
+        text.includes('formData') &&
+        text.includes('myFormData') &&
+        text.includes('is') &&
+        text.includes('present')
       ) {
         return {
           json: { data: 12 },
@@ -1154,11 +1166,11 @@ describe('MapInterpreter', () => {
 
       return { json: { failed: true }, statusCode: 400 };
     });
-    const url = mockServer.urlFor('/formdata');
     const interpreter = new MapInterpreter(
       {
         usecase: 'testCase',
         security: [],
+        serviceBaseUrl,
       },
       { fetchInstance }
     );
@@ -1229,15 +1241,16 @@ describe('MapInterpreter', () => {
   });
 
   it('should call an API with application/x-www-form-urlencoded', async () => {
+    const url = '/urlencoded';
     await mockServer
-      .post('/urlencoded')
+      .post(url)
       .withForm({ form: 'is', o: 'k' })
       .thenJson(201, { data: 12 });
-    const url = mockServer.urlFor('/urlencoded');
     const interpreter = new MapInterpreter(
       {
         usecase: 'testCase',
         security: [],
+        serviceBaseUrl,
       },
       { fetchInstance }
     );
@@ -1475,12 +1488,13 @@ describe('MapInterpreter', () => {
   });
 
   it('should correctly return from operation', async () => {
-    await mockServer.get('/test').thenJson(200, {});
-    const url = mockServer.urlFor('/test');
+    const url = '/test';
+    await mockServer.get(url).thenJson(200, {});
     const interpreter = new MapInterpreter(
       {
         usecase: 'Test',
         security: [],
+        serviceBaseUrl,
       },
       { fetchInstance }
     );
@@ -1734,8 +1748,8 @@ describe('MapInterpreter', () => {
   });
 
   it('should perform operations with correct scoping', async () => {
-    await mockServer.get('/test').thenJson(200, {});
-    const url = mockServer.urlFor('/test');
+    const url = '/test';
+    await mockServer.get(url).thenJson(200, {});
     const ast: MapDocumentNode = {
       kind: 'MapDocument',
       header,
@@ -1883,6 +1897,7 @@ describe('MapInterpreter', () => {
       {
         usecase: 'Test',
         security: [],
+        serviceBaseUrl,
       },
       { fetchInstance }
     );
@@ -2544,8 +2559,8 @@ describe('MapInterpreter', () => {
   });
 
   it('should be able to use input in path parameters', async () => {
-    await mockServer.get('/twelve').thenJson(200, { data: 12 });
-    const baseUrl = mockServer.urlFor('/twelve').replace('/twelve', '');
+    const url = '/twelve';
+    await mockServer.get(url).thenJson(200, { data: 12 });
     const ast: MapDocumentNode = {
       kind: 'MapDocument',
       header,
@@ -2558,7 +2573,7 @@ describe('MapInterpreter', () => {
             {
               kind: 'HttpCallStatement',
               method: 'GET',
-              url: `${baseUrl}/{input.test}`,
+              url: `/{input.test}`,
               responseHandlers: [
                 {
                   kind: 'HttpResponseHandler',
@@ -2596,6 +2611,7 @@ describe('MapInterpreter', () => {
         usecase: 'Test',
         input: { test: 'twelve' },
         security: [],
+        serviceBaseUrl,
       },
       { fetchInstance }
     );
@@ -2680,7 +2696,8 @@ describe('MapInterpreter', () => {
   });
 
   it('should make response headers accessible', async () => {
-    await mockServer.get('/twelve').thenJson(
+    const url = '/twelve';
+    await mockServer.get(url).thenJson(
       200,
       {},
       {
@@ -2689,11 +2706,11 @@ describe('MapInterpreter', () => {
         Data: '12',
       }
     );
-    const url = mockServer.urlFor('/twelve');
     const interpreter = new MapInterpreter(
       {
         usecase: 'Test',
         security: [],
+        serviceBaseUrl,
       },
       { fetchInstance }
     );

--- a/src/internal/interpreter/map-interpreter.ts
+++ b/src/internal/interpreter/map-interpreter.ts
@@ -269,6 +269,12 @@ export class MapInterpreter<TInput extends NonPrimitive | undefined>
   }
 
   async visitHttpCallStatementNode(node: HttpCallStatementNode): Promise<void> {
+    if (this.parameters.serviceBaseUrl === undefined) {
+      throw new UnexpectedError(
+        'Base url for a service not provided for HTTP call.'
+      );
+    }
+
     const request = node.request && (await this.visit(node.request));
     const responseHandlers = node.responseHandlers.map(responseHandler =>
       this.visit(responseHandler)

--- a/src/lib/reporter.test.ts
+++ b/src/lib/reporter.test.ts
@@ -175,7 +175,7 @@ const mockMapDocumentFailure: (provider?: string) => MapDocumentNode = (
         {
           kind: 'HttpCallStatement',
           method: 'GET',
-          url: 'https://unavail.able',
+          url: '/unavailable',
           request: {
             kind: 'HttpRequest',
             security: [],
@@ -303,7 +303,7 @@ describe('MetricReporter', () => {
       mockProfileDocument,
       mockMapDocumentFailure(),
       'testprovider',
-      { baseUrl: mockServer.url, security: [] },
+      { baseUrl: 'https://unavai.lable', security: [] },
       client
     );
     jest
@@ -583,14 +583,14 @@ describe('MetricReporter', () => {
       mockProfileDocument,
       mockMapDocumentSuccess,
       'testprovider',
-      { baseUrl: mockServer.url, security: [] },
+      { baseUrl: 'https://unavail.able', security: [] },
       client
     );
     const mockBoundProfileProvider2 = new BoundProfileProvider(
       mockProfileDocument,
       mockMapDocumentFailure('testprovider2'),
       'testprovider2',
-      { baseUrl: mockServer.url, security: [] },
+      { baseUrl: 'https://unavail.able', security: [] },
       client
     );
     jest


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
This PR fixes two issues:
- it requires baseUrl to be specified for HTTP calls in map, as absolute URLs are no longer supported
- path parameter interpolation does not work on base URLs, only the relative path in map
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For security reasons, we need to only use base URL from provider.json and not allow interpolating it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](SECURITY.md) is correct.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
