### PR TITLE
Lock ast to 0.0.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Log warning when user does not handle rejections properly
+- Lcked AST version with matching schemas from parser
 
 ## [0.0.37] - 2021-10-14
 ### Changed

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@superfaceai/ast": ">=0.0.32",
+    "@superfaceai/ast": "0.0.32",
     "@superfaceai/parser": ">=0.0.22",
     "abort-controller": "^3.0.0",
     "cross-fetch": "^3.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -660,7 +660,7 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@superfaceai/ast@>=0.0.32":
+"@superfaceai/ast@0.0.32":
   version "0.0.32"
   resolved "https://registry.yarnpkg.com/@superfaceai/ast/-/ast-0.0.32.tgz#9230c970e6c3319e89eea312925b9d63d3c2c47b"
   integrity sha512-ZAsLWlr7b/orV3zRpXySeihhYLQE1t9J+ZHYnsnb4UKahXPqIPr7F3bnRCusS6scXOvCA2oCu1cOsotHqcg5cA==


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->

OneSDK fails tu run with cached asts, because it uses newer version of AST with breaking change, than teh AST is generated with.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Make it work again.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](SECURITY.md) is correct.
- [ ] I have read the **CONTRIBUTION_GUIDE** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
