### PR TITLE
fix: Pass errors through operation call levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `result` variable no longer has special meaning
 - `outcome.data` is no longer overwritten by `result`
 - `fail` correctly sets `outcome.error` in caller
+- errors are passed correctly through multiple levels of operation calls
+- inline calls throw error when they fail
 
 ### Added
 - MapInterpreter now supports integration parameters

--- a/src/internal/interpreter/map-interpreter.errors.test.ts
+++ b/src/internal/interpreter/map-interpreter.errors.test.ts
@@ -509,4 +509,110 @@ AST Path: definitions[0].statements[0].assignments[0].value`
       );
     });
   });
+
+  it('should not allow inline calls to fail', async () => {
+    const ast = parseMapFromSource(`
+      map Test {
+        call FirstOperation() {
+            return map error if (outcome.error) outcome.error
+            return map result { message = 'this is not to be seen' }
+          }
+      }
+
+      operation FirstOperation {
+        result = call foreach(_ of Array(1)) SecondOperation()
+
+        return result
+      }
+
+      operation SecondOperation {
+        fail 'this should not be allowed to fail'
+      }
+  `);
+
+    const interpreter = new MapInterpreter(
+      {
+        usecase: 'Test',
+        security: [],
+      },
+      { fetchInstance }
+    );
+
+    const result = await interpreter.perform(ast);
+
+    expect(result.isErr() && result.error.toString()).toMatch(
+      'Unexpected inline call failure'
+    );
+  });
+
+  it('should properly pass error from nested operation calls', async () => {
+    const ast = parseMapFromSource(`
+      map Test {
+        call FirstOperation() {
+            return map error if (outcome.error) outcome.error
+            return map result { message = 'this is not to be seen' }
+          }
+      }
+
+      operation FirstOperation {
+        call SecondOperation() {
+          fail if (outcome.error) outcome.error
+        }
+      }
+
+      operation SecondOperation {
+        fail 'the best error in the world'
+      }
+  `);
+
+    const interpreter = new MapInterpreter(
+      {
+        usecase: 'Test',
+        security: [],
+      },
+      { fetchInstance }
+    );
+
+    const result = await interpreter.perform(ast);
+
+    expect(result.isErr() && result.error.toString()).toMatch(
+      'the best error in the world'
+    );
+  });
+
+  it('should properly pass error from nested operation calls in loops', async () => {
+    const ast = parseMapFromSource(`
+      map Test {
+        call FirstOperation() {
+            return map error if (outcome.error) outcome.error
+            return map result { message = 'this is not to be seen' }
+          }
+      }
+
+      operation FirstOperation {
+        call foreach(_ of Array(1)) SecondOperation() {
+          fail if (outcome.error) outcome.error
+        }
+      }
+
+      operation SecondOperation {
+        fail 'the best error in the world'
+      }
+  `);
+
+    const interpreter = new MapInterpreter(
+      {
+        usecase: 'Test',
+        security: [],
+      },
+      { fetchInstance }
+    );
+
+    const result = await interpreter.perform(ast);
+    console.log(result);
+
+    expect(result.isErr() && result.error.toString()).toMatch(
+      'the best error in the world'
+    );
+  });
 });


### PR DESCRIPTION
- also throw on inline call failure

<!--- Tip: You don't have to remove these comments -->

## Description
- pass errors through operation call levels
- also throw on inline call failure
<!--- Describe your changes in detail -->

## Motivation and Context
Errors were not passed through multiple levels and inline call failures should not happen
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](SECURITY.md) is correct.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
