### PR TITLE
chore: Mark cacheBoundProfileProvider deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - replaced zod with ast validations
+- deprecated cacheBoundProfileProvider function on SuperfaceClient
 
 ## [0.0.40] - 2021-10-18
 ### Changed

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -63,6 +63,7 @@ export abstract class SuperfaceClientBase extends Events {
 
   /**
    * @deprecated
+   * This is not a part of the public API, DON'T USE THIS METHOD
    * Returns a BoundProfileProvider that is cached according to `profileConfig` and `providerConfig` cache keys.
    */
   async cacheBoundProfileProvider(

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -61,7 +61,10 @@ export abstract class SuperfaceClientBase extends Events {
     registerFailoverHooks(this.hookContext, this);
   }
 
-  /** Returns a BoundProfileProvider that is cached according to `profileConfig` and `providerConfig` cache keys. */
+  /**
+   * @deprecated
+   * Returns a BoundProfileProvider that is cached according to `profileConfig` and `providerConfig` cache keys.
+   */
   async cacheBoundProfileProvider(
     profileConfig: ProfileConfiguration,
     providerConfig: ProviderConfiguration


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
Marks cacheBoundProfileProvider as deprecated
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This function should not have been a part of Client's public interface as it's not intended for consumer use

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](SECURITY.md) is correct.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
