### PR TITLE
fix(ProfileParameterValidator): Resolve NamedModels first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- ProfileParameterValidator now resolves named models before field references
 
 ## [1.0.0] - 2021-11-04
 ### Added

--- a/src/internal/interpreter/map-interpreter.errors.test.ts
+++ b/src/internal/interpreter/map-interpreter.errors.test.ts
@@ -632,8 +632,6 @@ AST Path: definitions[0].statements[0].assignments[0].value`
     );
 
     const result = await interpreter.perform(ast);
-    console.log(result);
-
     expect(result.isErr() && result.error.toString()).toMatch(
       'the best error in the world'
     );

--- a/src/internal/interpreter/profile-parameter-validator.test.ts
+++ b/src/internal/interpreter/profile-parameter-validator.test.ts
@@ -45,7 +45,11 @@ describe('ProfileParameterValidator', () => {
         usecase Test safe {
           input {}
         }`);
-      const parameterValidator = new ProfileParameterValidator(ast);
+      let parameterValidator: ProfileParameterValidator;
+
+      beforeEach(() => {
+        parameterValidator = new ProfileParameterValidator(ast);
+      });
 
       it('should pass with empty input', () => {
         expect(parameterValidator.validate({}, 'input', 'Test').isOk()).toEqual(
@@ -70,7 +74,11 @@ describe('ProfileParameterValidator', () => {
           }
         }
       `);
-      const parameterValidator = new ProfileParameterValidator(ast);
+      let parameterValidator: ProfileParameterValidator;
+
+      beforeEach(() => {
+        parameterValidator = new ProfileParameterValidator(ast);
+      });
 
       it('should pass with or without optional prop', () => {
         expect(
@@ -110,7 +118,11 @@ describe('ProfileParameterValidator', () => {
           }
         }
       `);
-      const parameterValidator = new ProfileParameterValidator(ast);
+      let parameterValidator: ProfileParameterValidator;
+
+      beforeEach(() => {
+        parameterValidator = new ProfileParameterValidator(ast);
+      });
 
       it('should pass with missing optional input', () => {
         expect(parameterValidator.validate({}, 'input', 'Test').isOk()).toEqual(
@@ -144,7 +156,11 @@ describe('ProfileParameterValidator', () => {
           }
         }
       `);
-      const parameterValidator = new ProfileParameterValidator(ast);
+      let parameterValidator: ProfileParameterValidator;
+
+      beforeEach(() => {
+        parameterValidator = new ProfileParameterValidator(ast);
+      });
 
       it('should pass with correct type', () => {
         expect(
@@ -190,7 +206,11 @@ describe('ProfileParameterValidator', () => {
           }
         }
       `);
-      const parameterValidator = new ProfileParameterValidator(ast);
+      let parameterValidator: ProfileParameterValidator;
+
+      beforeEach(() => {
+        parameterValidator = new ProfileParameterValidator(ast);
+      });
 
       it('should pass with valid input', () => {
         expect(
@@ -265,7 +285,11 @@ describe('ProfileParameterValidator', () => {
 
         field test string
       `);
-      const parameterValidator = new ProfileParameterValidator(ast);
+      let parameterValidator: ProfileParameterValidator;
+
+      beforeEach(() => {
+        parameterValidator = new ProfileParameterValidator(ast);
+      });
 
       it('should pass with valid input', () => {
         expect(parameterValidator.validate({}, 'input', 'Test').isOk()).toEqual(
@@ -295,7 +319,11 @@ describe('ProfileParameterValidator', () => {
           }
         }
       `);
-      const parameterValidator = new ProfileParameterValidator(ast);
+      let parameterValidator: ProfileParameterValidator;
+
+      beforeEach(() => {
+        parameterValidator = new ProfileParameterValidator(ast);
+      });
 
       it('should pass with valid input', () => {
         expect(
@@ -335,7 +363,11 @@ describe('ProfileParameterValidator', () => {
 
         field test enum { hello, goodbye }
       `);
-      const parameterValidator = new ProfileParameterValidator(ast);
+      let parameterValidator: ProfileParameterValidator;
+
+      beforeEach(() => {
+        parameterValidator = new ProfileParameterValidator(ast);
+      });
 
       it('should pass with valid input', () => {
         expect(
@@ -372,7 +404,11 @@ describe('ProfileParameterValidator', () => {
         model TestEnum enum { A, B, C = 'CC', D }
         field test TestEnum
       `);
-      const parameterValidator = new ProfileParameterValidator(ast);
+      let parameterValidator: ProfileParameterValidator;
+
+      beforeEach(() => {
+        parameterValidator = new ProfileParameterValidator(ast);
+      });
 
       it.each(['A', 'B', 'CC', 'D'])(
         'should pass with valid input: %s',
@@ -404,7 +440,11 @@ describe('ProfileParameterValidator', () => {
           }
         }
       `);
-      const parameterValidator = new ProfileParameterValidator(ast);
+      let parameterValidator: ProfileParameterValidator;
+
+      beforeEach(() => {
+        parameterValidator = new ProfileParameterValidator(ast);
+      });
 
       it('should pass with valid input', () => {
         expect(
@@ -451,7 +491,11 @@ describe('ProfileParameterValidator', () => {
           }
         }
       `);
-      const parameterValidator = new ProfileParameterValidator(ast);
+      let parameterValidator: ProfileParameterValidator;
+
+      beforeEach(() => {
+        parameterValidator = new ProfileParameterValidator(ast);
+      });
 
       it('should pass with valid input', () => {
         expect(parameterValidator.validate({}, 'input', 'Test').isOk()).toEqual(
@@ -521,7 +565,11 @@ describe('ProfileParameterValidator', () => {
           hello! string!
         }
       `);
-      const parameterValidator = new ProfileParameterValidator(ast);
+      let parameterValidator: ProfileParameterValidator;
+
+      beforeEach(() => {
+        parameterValidator = new ProfileParameterValidator(ast);
+      });
 
       it('should pass with valid input', () => {
         expect(
@@ -564,7 +612,11 @@ describe('ProfileParameterValidator', () => {
           }
         }
       `);
-      const parameterValidator = new ProfileParameterValidator(ast);
+      let parameterValidator: ProfileParameterValidator;
+
+      beforeEach(() => {
+        parameterValidator = new ProfileParameterValidator(ast);
+      });
 
       it('should pass with valid input', () => {
         expect(parameterValidator.validate({}, 'input', 'Test').isOk()).toEqual(
@@ -599,7 +651,11 @@ describe('ProfileParameterValidator', () => {
 
         model TestUnion string | number
       `);
-      const parameterValidator = new ProfileParameterValidator(ast);
+      let parameterValidator: ProfileParameterValidator;
+
+      beforeEach(() => {
+        parameterValidator = new ProfileParameterValidator(ast);
+      });
 
       it('should pass with valid input', () => {
         expect(
@@ -632,7 +688,11 @@ describe('ProfileParameterValidator', () => {
           }
         }
       `);
-      const parameterValidator = new ProfileParameterValidator(ast);
+      let parameterValidator: ProfileParameterValidator;
+
+      beforeEach(() => {
+        parameterValidator = new ProfileParameterValidator(ast);
+      });
 
       it('should pass with valid input', () => {
         expect(parameterValidator.validate({}, 'input', 'Test').isOk()).toEqual(
@@ -679,7 +739,11 @@ describe('ProfileParameterValidator', () => {
           }
         }
       `);
-      const parameterValidator = new ProfileParameterValidator(ast);
+      let parameterValidator: ProfileParameterValidator;
+
+      beforeEach(() => {
+        parameterValidator = new ProfileParameterValidator(ast);
+      });
 
       it('should pass with valid input', () => {
         expect(
@@ -717,6 +781,54 @@ describe('ProfileParameterValidator', () => {
         expect(checkErrorPath(result3)).toEqual([['input', 'test']]);
       });
     });
+
+    describe('AST with multiple levels of field references', () => {
+      const ast = parseProfileFromSource(`
+        usecase Test safe {
+          input {
+            test
+          }
+        }
+
+        model TestModel {
+          another
+        }
+
+        model AnotherModel {
+          value
+        }
+
+        field test TestModel
+        field another AnotherModel
+        field value boolean
+      `);
+      let parameterValidator: ProfileParameterValidator;
+
+      beforeEach(() => {
+        parameterValidator = new ProfileParameterValidator(ast);
+      });
+
+      it.each([true, false])('should pass with valid input: %s', value => {
+        const result = parameterValidator.validate(
+          { test: { another: { value } } },
+          'input',
+          'Test'
+        );
+        expect(result.isOk()).toEqual(true);
+      });
+
+      it.each(['banana'])('should fail with invalid value: %p', value => {
+        const result = parameterValidator.validate(
+          { test: { another: { value } } },
+          'input',
+          'Test'
+        );
+        expect(checkErrorKind(result)).toEqual(['wrongType']);
+        expect(checkErrorPath(result)).toEqual([
+          ['input', 'test', 'another', 'value'],
+        ]);
+      });
+    });
   });
 
   describe('Result', () => {
@@ -732,7 +844,11 @@ describe('ProfileParameterValidator', () => {
           }
         }
       `);
-      const parameterValidator = new ProfileParameterValidator(ast);
+      let parameterValidator: ProfileParameterValidator;
+
+      beforeEach(() => {
+        parameterValidator = new ProfileParameterValidator(ast);
+      });
 
       it('should pass with valid input', () => {
         expect(
@@ -799,7 +915,11 @@ describe('ProfileParameterValidator', () => {
           c
         }
       `);
-      const parameterValidator = new ProfileParameterValidator(ast);
+      let parameterValidator: ProfileParameterValidator;
+
+      beforeEach(() => {
+        parameterValidator = new ProfileParameterValidator(ast);
+      });
 
       it('should pass with valid input', () => {
         expect(
@@ -838,49 +958,6 @@ describe('ProfileParameterValidator', () => {
         );
         expect(checkErrorKind(result3)).toEqual(['enumValue']);
         expect(checkErrorPath(result3)).toEqual([['result', 'test']]);
-      });
-    });
-
-    describe('AST with multiple levels of field references', () => {
-      const ast = parseProfileFromSource(`
-        usecase Test safe {
-          input {
-            test
-          }
-        }
-
-        model TestModel {
-          another
-        }
-
-        model AnotherModel {
-          value boolean
-        }
-
-        field test TestModel
-        field another AnotherModel
-      `);
-      const parameterValidator = new ProfileParameterValidator(ast);
-
-      it.each([true, false])('should pass with valid input: %s', value => {
-        const result = parameterValidator.validate(
-          { test: { another: { value } } },
-          'input',
-          'Test'
-        );
-        expect(result.isOk()).toEqual(true);
-      });
-
-      it.each(['banana'])('should fail with invalid value: %p', value => {
-        const result = parameterValidator.validate(
-          { test: { another: { value } } },
-          'input',
-          'Test'
-        );
-        expect(checkErrorKind(result)).toEqual(['wrongType']);
-        expect(checkErrorPath(result)).toEqual([
-          ['input', 'test', 'another', 'value'],
-        ]);
       });
     });
   });

--- a/src/internal/interpreter/profile-parameter-validator.ts
+++ b/src/internal/interpreter/profile-parameter-validator.ts
@@ -483,12 +483,12 @@ export class ProfileParameterValidator implements ProfileVisitor {
     if (!this.namedDefinitionsInitialized) {
       node.definitions
         .filter(
-          (definition): definition is NamedFieldDefinitionNode =>
-            definition.kind === 'NamedFieldDefinition'
+          (definition): definition is NamedModelDefinitionNode =>
+            definition.kind === 'NamedModelDefinition'
         )
         .forEach(
           definition =>
-            (this.namedFieldDefinitions[definition.fieldName] = this.visit(
+            (this.namedModelDefinitions[definition.modelName] = this.visit(
               definition,
               kind,
               usecase
@@ -497,12 +497,12 @@ export class ProfileParameterValidator implements ProfileVisitor {
 
       node.definitions
         .filter(
-          (definition): definition is NamedModelDefinitionNode =>
-            definition.kind === 'NamedModelDefinition'
+          (definition): definition is NamedFieldDefinitionNode =>
+            definition.kind === 'NamedFieldDefinition'
         )
         .forEach(
           definition =>
-            (this.namedModelDefinitions[definition.modelName] = this.visit(
+            (this.namedFieldDefinitions[definition.fieldName] = this.visit(
               definition,
               kind,
               usecase

--- a/src/internal/interpreter/profile-parameter-validator.ts
+++ b/src/internal/interpreter/profile-parameter-validator.ts
@@ -5,6 +5,8 @@ import {
   EnumDefinitionNode,
   EnumValueNode,
   FieldDefinitionNode,
+  isNamedFieldDefinitionNode,
+  isNamedModelDefinitionNode,
   ListDefinitionNode,
   ModelTypeNameNode,
   NamedFieldDefinitionNode,
@@ -482,32 +484,24 @@ export class ProfileParameterValidator implements ProfileVisitor {
 
     if (!this.namedDefinitionsInitialized) {
       node.definitions
-        .filter(
-          (definition): definition is NamedModelDefinitionNode =>
-            definition.kind === 'NamedModelDefinition'
-        )
-        .forEach(
-          definition =>
-            (this.namedModelDefinitions[definition.modelName] = this.visit(
-              definition,
-              kind,
-              usecase
-            ))
-        );
+        .filter(isNamedModelDefinitionNode)
+        .forEach(definition => {
+          this.namedModelDefinitions[definition.modelName] = this.visit(
+            definition,
+            kind,
+            usecase
+          );
+        });
 
       node.definitions
-        .filter(
-          (definition): definition is NamedFieldDefinitionNode =>
-            definition.kind === 'NamedFieldDefinition'
-        )
-        .forEach(
-          definition =>
-            (this.namedFieldDefinitions[definition.fieldName] = this.visit(
-              definition,
-              kind,
-              usecase
-            ))
-        );
+        .filter(isNamedFieldDefinitionNode)
+        .forEach(definition => {
+          this.namedFieldDefinitions[definition.fieldName] = this.visit(
+            definition,
+            kind,
+            usecase
+          );
+        });
 
       this.namedDefinitionsInitialized = true;
     }


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
Changes ProfileParameterValidator behavior to resolve NamedModels before field references.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When the field references were resolved before named models, the model definitions were not found, thus crashing the validator.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](SECURITY.md) is correct.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
