### PR TITLE
Fix Buffer and Date cloning

### DIFF
--- a/src/lib/object.test.ts
+++ b/src/lib/object.test.ts
@@ -66,6 +66,12 @@ describe('clone', () => {
     expect(cloned).toStrictEqual(null);
   });
 
+  it('should clone empty object', () => {
+    const object = {};
+    const cloned = clone(object);
+    expect(cloned).toStrictEqual({});
+  });
+
   describe('when cloning buffer', () => {
     let object: { buffer: Buffer };
 

--- a/src/lib/object.test.ts
+++ b/src/lib/object.test.ts
@@ -53,4 +53,79 @@ describe('clone', () => {
     const cloned = clone(object);
     expect(cloned).toStrictEqual(cloned);
   });
+
+  it('should clone undefined', () => {
+    const object = undefined;
+    const cloned = clone(object);
+    expect(cloned).toStrictEqual(undefined);
+  });
+
+  it('should clone null', () => {
+    const object = null;
+    const cloned = clone(object);
+    expect(cloned).toStrictEqual(null);
+  });
+
+  describe('when cloning buffer', () => {
+    let object: { buffer: Buffer };
+
+    beforeEach(() => {
+      object = {
+        buffer: Buffer.from('data'),
+      };
+    });
+
+    it('should clone buffer', () => {
+      const cloned = clone(object);
+      expect(Buffer.isBuffer(cloned.buffer)).toBe(true);
+      expect(cloned.buffer.toString()).toEqual(object.buffer.toString());
+    });
+
+    it('should create new instance of buffer', () => {
+      const cloned = clone(object);
+      expect(cloned.buffer !== object.buffer).toBe(true);
+    });
+  });
+
+  describe('when cloning array', () => {
+    let object: { array: Array<any> };
+
+    beforeEach(() => {
+      object = {
+        array: [1, { a: 1, b: 2, c: 'string' }],
+      };
+    });
+
+    it('should clone array', () => {
+      const cloned = clone(object);
+      expect(Array.isArray(cloned.array)).toBe(true);
+      expect(cloned).toStrictEqual(object);
+    });
+
+    it('should create new instance of array', () => {
+      const cloned = clone(object);
+      expect(cloned.array !== object.array).toBe(true);
+    });
+  });
+
+  describe('when cloning date', () => {
+    let object: { date: Date };
+
+    beforeEach(() => {
+      object = {
+        date: new Date(),
+      };
+    });
+
+    it('should clone date', () => {
+      const cloned = clone(object);
+      expect(cloned.date).toBeInstanceOf(Date);
+      expect(cloned.date).toStrictEqual(object.date);
+    });
+
+    it('should create new instance of date', () => {
+      const cloned = clone(object);
+      expect(cloned.date !== object.date).toBe(true);
+    });
+  });
 });

--- a/src/lib/object.ts
+++ b/src/lib/object.ts
@@ -14,13 +14,11 @@ export function clone<T>(value: T): T {
 
   if (Array.isArray(value)) {
     const arrayCopy = [] as unknown[];
-    value.forEach(item => {
-      arrayCopy.push(item);
-    });
+   for (const item of value) {
+     arrayCopy.push(clone<unknown>(item))
+   }
 
-    return arrayCopy.map((item: unknown) =>
-      clone<unknown>(item)
-    ) as unknown as T;
+   return arrayCopy as unknown as T;
   }
 
   if (Buffer.isBuffer(value)) {

--- a/src/lib/object.ts
+++ b/src/lib/object.ts
@@ -26,16 +26,12 @@ export function clone<T>(value: T): T {
   }
 
   if (typeof value === 'object') {
-    const objectCopy = {
-      ...(value as unknown as { [key: string]: unknown }),
-    } as {
-      [key: string]: unknown;
-    };
-    Object.keys(objectCopy).forEach(key => {
-      objectCopy[key] = clone<unknown>(objectCopy[key]);
-    });
+    const objectCopy = Object.entries(value).map(([key, value]) => [
+      key,
+      clone(value) as unknown,
+    ]);
 
-    return objectCopy as unknown as T;
+    return Object.fromEntries(objectCopy) as unknown as T;
   }
 
   return value;

--- a/src/lib/object.ts
+++ b/src/lib/object.ts
@@ -12,7 +12,7 @@ export function clone<T>(value: T): T {
     return new Date(value.getTime()) as unknown as T;
   }
 
-  if (value instanceof Array) {
+  if (Array.isArray(value)) {
     const arrayCopy = [] as unknown[];
     value.forEach(item => {
       arrayCopy.push(item);

--- a/src/lib/object.ts
+++ b/src/lib/object.ts
@@ -14,11 +14,11 @@ export function clone<T>(value: T): T {
 
   if (Array.isArray(value)) {
     const arrayCopy = [] as unknown[];
-   for (const item of value) {
-     arrayCopy.push(clone<unknown>(item))
-   }
+    for (const item of value) {
+      arrayCopy.push(clone<unknown>(item));
+    }
 
-   return arrayCopy as unknown as T;
+    return arrayCopy as unknown as T;
   }
 
   if (Buffer.isBuffer(value)) {

--- a/src/lib/object.ts
+++ b/src/lib/object.ts
@@ -27,7 +27,7 @@ export function clone<T>(value: T): T {
     return Buffer.from(value) as unknown as T;
   }
 
-  if (typeof value === 'object' && value !== {}) {
+  if (typeof value === 'object') {
     const objectCopy = {
       ...(value as unknown as { [key: string]: unknown }),
     } as {


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
This PR fixes `Buffer` and `Date` cloning

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

ONESDK clones fetch params. If there is `Buffer` instance in body fetch parameter it is cloned as `Object` without prototype. Fetch then serialises the object as `[object Object]`.

This PR uses recursion to traverse over object properties and depending on the property type creates deep copy of it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](SECURITY.md) is correct.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
