### PR TITLE
Allow to use / in name to specify apikey location in body

### DIFF
--- a/src/internal/errors.helpers.ts
+++ b/src/internal/errors.helpers.ts
@@ -268,10 +268,13 @@ export function missingSecurityValuesError(id: string): SDKExecutionError {
   );
 }
 
-export function apiKeyInBodyError(bodyType: string): SDKExecutionError {
+export function apiKeyInBodyError(
+  valueLocation: string,
+  bodyType: string
+): SDKExecutionError {
   return new SDKExecutionError(
-    'ApiKey in body can be used only when body is an object.',
-    [`Actual body type is ${bodyType}`],
+    'ApiKey in body can be used only on object.',
+    [`Actual ${valueLocation} is ${bodyType}`],
     []
   );
 }

--- a/src/internal/interpreter/http/security.test.ts
+++ b/src/internal/interpreter/http/security.test.ts
@@ -1,0 +1,103 @@
+import { ApiKeyPlacement, SecurityType } from '@superfaceai/ast';
+
+import { SDKExecutionError } from '../../errors';
+import {
+  applyApiKeyAuth,
+  RequestContext,
+  SecurityConfiguration,
+} from './security';
+
+describe('http · security', () => {
+  describe('#applyApiKeyAuth', () => {
+    describe('in body', () => {
+      let context: RequestContext;
+      let configuration: SecurityConfiguration & { type: SecurityType.APIKEY };
+
+      beforeEach(() => {
+        context = {
+          headers: {},
+          pathParameters: {},
+          queryAuth: {},
+          requestBody: undefined,
+        };
+        configuration = {
+          id: 'test',
+          type: SecurityType.APIKEY,
+          in: ApiKeyPlacement.BODY,
+          name: undefined,
+          apikey: 'secret',
+        };
+      });
+
+      it('sets name with Primitive type', () => {
+        configuration.name = 'token';
+        applyApiKeyAuth(context, configuration);
+
+        expect(context.requestBody).toEqual({ token: 'secret' });
+      });
+
+      it('creates new nested sctructure', () => {
+        configuration.name = '/a/b/c';
+        applyApiKeyAuth(context, configuration);
+
+        expect(context.requestBody).toEqual({
+          a: {
+            b: {
+              c: 'secret',
+            },
+          },
+        });
+      });
+
+      it('keep content of existing objects', () => {
+        context.requestBody = { d: 'existing' };
+        configuration.name = '/a/b/c';
+        applyApiKeyAuth(context, configuration);
+
+        expect(context.requestBody).toEqual({
+          a: {
+            b: {
+              c: 'secret',
+            },
+          },
+          d: 'existing',
+        });
+      });
+
+      it('throws exception if request body is array', () => {
+        context.requestBody = [];
+        expect(() => applyApiKeyAuth(context, configuration)).toThrowError(
+          new SDKExecutionError(
+            'ApiKey in body can be used only on object.',
+            ['Actual body is Array'],
+            []
+          )
+        );
+      });
+
+      it('throws exception if in body path is array', () => {
+        context.requestBody = { a: { b: [] } };
+        configuration.name = '/a/b/c';
+        expect(() => applyApiKeyAuth(context, configuration)).toThrowError(
+          new SDKExecutionError(
+            'ApiKey in body can be used only on object.',
+            ['Actual value at /a/b is Array'],
+            []
+          )
+        );
+      });
+
+      it('throws exception if Primitive value is in body path', () => {
+        context.requestBody = { a: { b: { c: 'xxx' } } };
+        configuration.name = '/a/b/c';
+        expect(() => applyApiKeyAuth(context, configuration)).toThrowError(
+          new SDKExecutionError(
+            'ApiKey in body can be used only on object.',
+            ['Actual value at /a/b/c is string'],
+            []
+          )
+        );
+      });
+    });
+  });
+});

--- a/src/internal/interpreter/http/security.ts
+++ b/src/internal/interpreter/http/security.ts
@@ -33,6 +33,35 @@ export type RequestContext = {
   requestBody: Variables | undefined;
 };
 
+export function applyApiKeyAuthInBody(
+  requestBody: Variables,
+  referenceTokens: string[],
+  apikey: string,
+  visitedReferenceTokens: string[] = []
+): Variables {
+  if (typeof requestBody !== 'object' || Array.isArray(requestBody)) {
+    const valueLocation = visitedReferenceTokens.length
+      ? `value at /${visitedReferenceTokens.join('/')}`
+      : 'body';
+    const bodyType = Array.isArray(requestBody) ? 'Array' : typeof requestBody;
+
+    throw apiKeyInBodyError(valueLocation, bodyType);
+  }
+
+  const token = referenceTokens.shift();
+  if (token === undefined) {
+    return apikey;
+  }
+
+  const segVal = requestBody[token] ?? {};
+  requestBody[token] = applyApiKeyAuthInBody(segVal, referenceTokens, apikey, [
+    ...visitedReferenceTokens,
+    token,
+  ]);
+
+  return requestBody;
+}
+
 export function applyApiKeyAuth(
   context: RequestContext,
   configuration: SecurityConfiguration & { type: SecurityType.APIKEY }
@@ -45,17 +74,11 @@ export function applyApiKeyAuth(
       break;
 
     case ApiKeyPlacement.BODY:
-      if (
-        typeof context.requestBody !== 'object' ||
-        Array.isArray(context.requestBody)
-      ) {
-        throw apiKeyInBodyError(
-          Array.isArray(context.requestBody)
-            ? 'Array'
-            : typeof context.requestBody
-        );
-      }
-      context.requestBody[name] = configuration.apikey;
+      context.requestBody = applyApiKeyAuthInBody(
+        context.requestBody ?? {},
+        name.startsWith('/') ? name.slice(1).split('/') : [name],
+        configuration.apikey
+      );
       break;
 
     case ApiKeyPlacement.PATH:


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->

This PR allows to use `/` to specify nested location of apikey in JSON body.

It uses same syntax as JSON Poniter, but it doesn't allow to work with arrays.

Implements https://github.com/superfaceai/one-sdk-js/issues/176

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Some APIs have api tokens deeper in body payload. eg https://github.com/superfaceai/station/pull/158

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](SECURITY.md) is correct.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
