### PR TITLE
feat: make sandbox timeout configurabe through an env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Make sandbox timeout configurable through environment variable `SUPERFACE_SANDBOX_TIMEOUT`
+
 ## [1.2.1] - 2022-01-19
 
 ## [1.1.0] - 2021-12-22

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@ const METRIC_DEBOUNCE_TIME = {
   max: 'SUPERFACE_METRIC_DEBOUNCE_TIME_MAX',
 };
 const DISABLE_REPORTING = 'SUPERFACE_DISABLE_METRIC_REPORTING';
+const SANDBOX_TIMEOUT_ENV_NAME = 'SUPERFACE_SANDBOX_TIMEOUT';
 
 // Defaults
 export const DEFAULT_API_URL = 'https://superface.ai';
@@ -29,6 +30,7 @@ export const DEFAULT_CACHE_PATH = joinPath(
   'superface',
   '.cache'
 );
+export const DEFAULT_SANDBOX_TIMEOUT = 100;
 
 // Extraction functions
 function getSuperfaceApiUrl(): string {
@@ -79,6 +81,28 @@ function getMetricDebounceTime(which: 'min' | 'max'): number {
   }
 }
 
+function getSandboxTimeout(): number {
+  const envValue = process.env[SANDBOX_TIMEOUT_ENV_NAME];
+  if (envValue === undefined) {
+    return DEFAULT_SANDBOX_TIMEOUT;
+  }
+
+  try {
+    const result = parseInt(envValue);
+    if (result <= 0) {
+      throw undefined;
+    }
+
+    return result;
+  } catch (e) {
+    configDebug(
+      `Invalid value: ${envValue} for ${SANDBOX_TIMEOUT_ENV_NAME}, expected positive number`
+    );
+
+    return DEFAULT_SANDBOX_TIMEOUT;
+  }
+}
+
 export class Config {
   private static _instance?: Config;
 
@@ -103,6 +127,7 @@ export class Config {
   public metricDebounceTimeMax: number;
   public disableReporting: boolean;
   public cachePath: string;
+  public sandboxTimeout: number;
 
   private static loadEnv() {
     return {
@@ -116,6 +141,7 @@ export class Config {
           ? true
           : !!process.env[DISABLE_REPORTING],
       cachePath: DEFAULT_CACHE_PATH,
+      sandboxTimeout: getSandboxTimeout(),
     };
   }
 
@@ -128,5 +154,6 @@ export class Config {
     this.metricDebounceTimeMax = env.metricDebounceTimeMax;
     this.disableReporting = env.disableReporting;
     this.cachePath = env.cachePath;
+    this.sandboxTimeout = env.sandboxTimeout;
   }
 }

--- a/src/internal/interpreter/sandbox.ts
+++ b/src/internal/interpreter/sandbox.ts
@@ -1,11 +1,10 @@
 import createDebug from 'debug';
 import { VM } from 'vm2';
 
+import { Config } from '../../config';
 import { NonPrimitive } from '../../internal/interpreter/variables';
 
 const debug = createDebug('superface:sandbox');
-
-export const SCRIPT_TIMEOUT = 100;
 
 export function evalScript(
   js: string,
@@ -18,7 +17,7 @@ export function evalScript(
     compiler: 'javascript',
     wasm: false,
     eval: false,
-    timeout: SCRIPT_TIMEOUT,
+    timeout: Config.instance().sandboxTimeout,
     fixAsync: true,
   });
 


### PR DESCRIPTION
## Description
Makes sandbox timeout configurable through an environment variable

## Motivation and Context
AWS lambda functions time out with the default timeout for some reason, this is a quick way to fix it in the meantime and also it's good to have it configurable anyway

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [ ] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
