### PR TITLE
feat: add initial unstable stdlib to sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Sandbox stdlib - `std.unstable.time.{isoDateToUnixTimestamp, unixTimestampToIsoDate}, std.unstable.debug.log`
+
 ## [1.3.0] - 2022-02-15
 ### Added
 - Added support for service selection in http calls

--- a/src/internal/interpreter/sandbox/index.ts
+++ b/src/internal/interpreter/sandbox/index.ts
@@ -1,0 +1,1 @@
+export { evalScript } from './sandbox';

--- a/src/internal/interpreter/sandbox/sandbox.test.ts
+++ b/src/internal/interpreter/sandbox/sandbox.test.ts
@@ -114,4 +114,20 @@ describe('sandbox', () => {
     expect(v).toStrictEqual([1, 2, 3]);
     expect(Array.isArray(v)).toBe(true);
   });
+
+  describe('stdlib', () => {
+    it('provides unstable stdlib', () => {
+      expect(
+        evalScript(
+          'std.unstable.time.isoDateToUnixTimestamp("2022-01-01T00:11:00.123Z")'
+        )
+      ).toStrictEqual(1640995860123);
+
+      expect(
+        evalScript(
+          '(std.unstable.debug.log(1123), std.unstable.time.unixTimestampToIsoDate(1640995860123))'
+        )
+      ).toStrictEqual('2022-01-01T00:11:00.123Z');
+    });
+  });
 });

--- a/src/internal/interpreter/sandbox/sandbox.ts
+++ b/src/internal/interpreter/sandbox/sandbox.ts
@@ -1,8 +1,9 @@
 import createDebug from 'debug';
 import { VM } from 'vm2';
 
-import { Config } from '../../config';
-import { NonPrimitive } from '../../internal/interpreter/variables';
+import { Config } from '../../../config';
+import { NonPrimitive } from '../../../internal/interpreter/variables';
+import { getStdlib } from './stdlib';
 
 const debug = createDebug('superface:sandbox');
 
@@ -12,6 +13,7 @@ export function evalScript(
 ): unknown {
   const vm = new VM({
     sandbox: {
+      std: getStdlib(),
       ...variableDefinitions,
     },
     compiler: 'javascript',

--- a/src/internal/interpreter/sandbox/stdlib.ts
+++ b/src/internal/interpreter/sandbox/stdlib.ts
@@ -1,0 +1,30 @@
+import createDebug from 'debug';
+
+import { deepFreeze } from '../../../lib/object';
+
+const debugLog = createDebug('superface:debug-log');
+
+const STDLIB_UNSTABLE = {
+  time: {
+    isoDateToUnixTimestamp(iso: string): number {
+      return new Date(iso).getTime();
+    },
+    unixTimestampToIsoDate(unix: number): string {
+      return new Date(unix).toISOString();
+    },
+  },
+  debug: {
+    log(formatter: unknown, ...args: unknown[]): void {
+      return debugLog(formatter, ...args);
+    },
+  },
+};
+
+const STDLIB = deepFreeze({
+  unstable: STDLIB_UNSTABLE,
+});
+
+export function getStdlib(): typeof STDLIB {
+  // TODO: This should later decide whether to return debug functions or just their stubs
+  return STDLIB;
+}

--- a/src/lib/object.ts
+++ b/src/lib/object.ts
@@ -105,3 +105,18 @@ export function indexRecord<T extends unknown | Record<string, T>>(
 
   return indexRecord(next as Record<string, T>, key);
 }
+
+// from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze
+export type RecursiveReadonly<T> = {
+  readonly [P in keyof T]: RecursiveReadonly<T[P]>;
+};
+export function deepFreeze<T>(o: T): RecursiveReadonly<T> {
+  for (const name of Object.getOwnPropertyNames(o)) {
+    const value = (o as Record<string, unknown>)[name];
+    if (value && typeof value === 'object') {
+      deepFreeze(value);
+    }
+  }
+
+  return Object.freeze(o);
+}


### PR DESCRIPTION
## Description
Adds an inital stdlib available to script sandbox. Currently only `unstable` symbols.

## Motivation and Context
Need to have at least some support for ISO date <-> unix timestamp conversion

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [ ] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
