### PR TITLE
feat: get configured providers

### DIFF
--- a/src/client/profile.test.ts
+++ b/src/client/profile.test.ts
@@ -21,9 +21,21 @@ describe('Profile', () => {
     profiles: {
       test: {
         version: '1.0.0',
+        providers: {
+          first: {
+            file: '../some.suma',
+          },
+          second: {
+            file: '../some.suma',
+          },
+        },
       },
     },
-    providers: {},
+    providers: {
+      first: {
+        file: '../provider.json',
+      },
+    },
   });
   afterEach(() => {
     jest.resetAllMocks();
@@ -40,6 +52,17 @@ describe('Profile', () => {
     expect(profile.getUseCase('sayHello')).toEqual(
       new UseCase(profile, 'sayHello')
     );
+  });
+
+  it('should call getConfiguredProviders correctly', async () => {
+    mockLoadSync.mockReturnValue(ok(mockSuperJson));
+    SuperJson.loadSync = mockLoadSync;
+    const mockClient = new SuperfaceClient();
+    const mockProfileConfiguration = new ProfileConfiguration('test', '1.0.0');
+
+    const profile = new Profile(mockClient, mockProfileConfiguration);
+
+    expect(profile.getConfiguredProviders()).toEqual(['first', 'second']);
   });
 });
 

--- a/src/client/profile.ts
+++ b/src/client/profile.ts
@@ -31,6 +31,13 @@ export class ProfileBase {
     public readonly client: SuperfaceClientBase,
     public readonly configuration: ProfileConfiguration
   ) {}
+
+  getConfiguredProviders(): string[] {
+    return Object.keys(
+      this.client.superJson.normalized.profiles[this.configuration.id]
+        ?.providers ?? {}
+    );
+  }
 }
 
 export class Profile extends ProfileBase {


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
This PR adds getConfiguredProviders function for getting providers(maps) configured for current profile.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/superfaceai/one-sdk-js/issues/211

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [x] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
