### PR TITLE
Feat/pass security values

### DIFF
--- a/src/client/usecase.ts
+++ b/src/client/usecase.ts
@@ -59,6 +59,18 @@ class UseCaseBase implements Interceptable {
         `${this.profile.configuration.id}/${this.name}`
       ].router;
 
+    //In this instance we can set metadata for events
+    this.boundProfileProvider =
+      await this.profile.client.cacheBoundProfileProvider(
+        this.profile.configuration,
+        await this.getProviderConfiguration(hookRouter, options)
+      );
+  }
+
+  private async getProviderConfiguration(
+    hookRouter: FailurePolicyRouter,
+    options?: PerformOptions
+  ): Promise<ProviderConfiguration> {
     let providerConfig: ProviderConfiguration;
 
     const chosenProvider = options?.provider ?? hookRouter.getCurrentProvider();
@@ -84,12 +96,8 @@ class UseCaseBase implements Interceptable {
         options.security
       );
     }
-    //In this instance we can set metadata for events
-    this.boundProfileProvider =
-      await this.profile.client.cacheBoundProfileProvider(
-        this.profile.configuration,
-        providerConfig
-      );
+
+    return providerConfig;
   }
 
   @eventInterceptor({ eventName: 'perform', placement: 'around' })

--- a/src/client/usecase.ts
+++ b/src/client/usecase.ts
@@ -1,4 +1,4 @@
-import { BackoffKind, OnFail } from '@superfaceai/ast';
+import { BackoffKind, OnFail, SecurityValues } from '@superfaceai/ast';
 import createDebug from 'debug';
 
 import { MapInterpreterError, ProfileParameterError } from '../internal';
@@ -27,6 +27,7 @@ const debug = createDebug('superface:usecase');
 export type PerformOptions = {
   provider?: Provider | string;
   parameters?: Record<string, string>;
+  security?: SecurityValues[];
 };
 
 // TODO
@@ -75,6 +76,12 @@ class UseCaseBase implements Interceptable {
     this.metadata.provider = providerConfig.name;
     hookRouter.setCurrentProvider(providerConfig.name);
 
+    if (options?.security) {
+      providerConfig = new ProviderConfiguration(
+        providerConfig.name,
+        options.security
+      );
+    }
     //In this instance we can set metadata for events
     this.boundProfileProvider =
       await this.profile.client.cacheBoundProfileProvider(

--- a/src/client/usecase.ts
+++ b/src/client/usecase.ts
@@ -76,6 +76,7 @@ class UseCaseBase implements Interceptable {
     this.metadata.provider = providerConfig.name;
     hookRouter.setCurrentProvider(providerConfig.name);
 
+    //If we have security values pass directly to perform we use them
     if (options?.security) {
       providerConfig = new ProviderConfiguration(
         providerConfig.name,
@@ -153,10 +154,8 @@ class UseCaseBase implements Interceptable {
       console.warn(
         `Super.json sets provider failover priority to: "${profileEntry.priority.join(
           ', '
-        )}" but provider failover is not allowed for usecase "${
-          this.name
-        }".\nTo allow provider failover please set property "providerFailover" in "${profileId}.defaults[${
-          this.name
+        )}" but provider failover is not allowed for usecase "${this.name
+        }".\nTo allow provider failover please set property "providerFailover" in "${profileId}.defaults[${this.name
         }]" to true`
       );
     }
@@ -274,7 +273,7 @@ export class UseCase extends UseCaseBase {
 export class TypedUseCase<
   TInput extends NonPrimitive | undefined,
   TOutput
-> extends UseCaseBase {
+  > extends UseCaseBase {
   async perform(
     input: TInput,
     options?: PerformOptions

--- a/src/client/usecase.ts
+++ b/src/client/usecase.ts
@@ -77,7 +77,7 @@ class UseCaseBase implements Interceptable {
     this.metadata.provider = providerConfig.name;
     hookRouter.setCurrentProvider(providerConfig.name);
 
-    //If we have security values pass directly to perform we use them
+    //If we have security values pass them directly to perform
     if (options?.security) {
       providerConfig = new ProviderConfiguration(
         providerConfig.name,


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->
This PR adds option to pass security values directly to perform call. Now it is more like POC of how it can be done, if we need to merge passed values with security values from super.json and how hard it will be to use this.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [x] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
