### PR TITLE
fix: Preserve query in auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed iterated variable in `foreach` being merged instead of overwritten, breaking iteration of objects
 - Fixed Buffer (`Buffer.isBuffer(x) == true`) being considered a composite structure and being merged as an object
+- Fixed authentication clearing query parameters
 
 ## [1.3.0] - 2022-02-15
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superfaceai/one-sdk",
-  "version": "1.3.1-rc.0",
+  "version": "1.3.1-beta.0",
   "description": "Level 5 autonomous, self-driving API client, https://superface.ai",
   "main": "dist/index.js",
   "source": "src/index.ts",

--- a/src/internal/interpreter/http/http.ts
+++ b/src/internal/interpreter/http/http.ts
@@ -191,7 +191,7 @@ export class HttpClient {
     parameters: {
       method: string;
       headers?: Variables;
-      queryParameters?: Variables;
+      queryParameters?: NonPrimitive;
       body?: Variables;
       contentType?: string;
       accept?: string;

--- a/src/internal/interpreter/http/security/apiKey/api-key.test.ts
+++ b/src/internal/interpreter/http/security/apiKey/api-key.test.ts
@@ -197,6 +197,19 @@ describe('ApiKeyHandler', () => {
       );
     });
 
+    it('keep content of existing query parameters', async () => {
+      parameters.queryParameters = { d: 'existing' };
+      configuration.in = ApiKeyPlacement.QUERY;
+      configuration.name = 'test';
+
+      expect(
+        (await apiKeyHandler.authenticate(parameters)).queryParameters
+      ).toMatchObject({
+        d: 'existing',
+        test: 'secret',
+      });
+    });
+
     it('throws exception if request body is array', async () => {
       parameters.body = [];
       parameters.contentType = JSON_CONTENT;

--- a/src/internal/interpreter/http/security/apiKey/api-key.ts
+++ b/src/internal/interpreter/http/security/apiKey/api-key.ts
@@ -28,7 +28,7 @@ export class ApiKeyHandler implements ISecurityHandler {
     let body: Variables | undefined = parameters.body;
     const headers: Record<string, string> = parameters.headers ?? {};
     const pathParameters = parameters.pathParameters ?? {};
-    const queryParameters: Record<string, string> = {};
+    const queryParameters = parameters.queryParameters ?? {};
 
     const name = this.configuration.name || DEFAULT_AUTHORIZATION_HEADER_NAME;
 

--- a/src/internal/interpreter/http/security/interfaces.ts
+++ b/src/internal/interpreter/http/security/interfaces.ts
@@ -60,7 +60,7 @@ export type RequestParameters = {
   url: string;
   method: string;
   headers?: Record<string, string>;
-  queryParameters?: Variables;
+  queryParameters?: NonPrimitive;
   body?: Variables;
   contentType?: string;
   accept?: string;

--- a/src/internal/interpreter/map-interpreter.ts
+++ b/src/internal/interpreter/map-interpreter.ts
@@ -100,7 +100,7 @@ interface HttpRequest {
   contentType?: string;
   contentLanguage?: string;
   headers?: Variables;
-  queryParameters?: Variables;
+  queryParameters?: NonPrimitive;
   body?: Variables;
   security: HttpSecurityRequirement[];
 }
@@ -173,6 +173,7 @@ export class MapInterpreter<TInput extends NonPrimitive | undefined>
   }
 
   visit(node: PrimitiveLiteralNode): Primitive;
+  async visit(node: ObjectLiteralNode): Promise<NonPrimitive>;
   async visit(node: SetStatementNode): Promise<void>;
   async visit(
     node: OutcomeStatementNode
@@ -608,7 +609,7 @@ export class MapInterpreter<TInput extends NonPrimitive | undefined>
     throw new UnexpectedError('Method not implemented.');
   }
 
-  async visitObjectLiteralNode(node: ObjectLiteralNode): Promise<Variables> {
+  async visitObjectLiteralNode(node: ObjectLiteralNode): Promise<NonPrimitive> {
     let result: NonPrimitive = {};
 
     for (const field of node.fields) {


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
Fixes an issue where authentication deleted existing query parameters

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Query parameters were deleted, which was sad, because I needed them for my usecase

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [x] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
