### PR TITLE
fix: http::replaceParameters now trims whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed iterated variable in `foreach` being merged instead of overwritten, breaking iteration of objects
 - Fixed Buffer (`Buffer.isBuffer(x) == true`) being considered a composite structure and being merged as an object
 - Fixed authentication clearing query parameters
+- Fixed url path parameter replacement not working with whitespace around replacement keys
 
 ## [1.3.0] - 2022-02-15
 ### Added

--- a/src/internal/interpreter/http/http.test.ts
+++ b/src/internal/interpreter/http/http.test.ts
@@ -55,6 +55,18 @@ describe('HttpClient', () => {
     expect(url).toEqual('https://example.com/test/hello');
   });
 
+  it('should correctly interpolate parameters with whitespaces in interpolation key', () => {
+    const baseUrl = 'https://example.com/';
+    const inputUrl = '/test/{ parameter.value   }';
+
+    const url = createUrl(inputUrl, {
+      baseUrl,
+      pathParameters: { parameter: { value: 'hello' } },
+    });
+
+    expect(url).toEqual('https://example.com/test/hello');
+  });
+
   it('should correctly interpolate multiple parameters', () => {
     const inputUrl = '/test/{parameter.value}/another/{parameter.another}';
 

--- a/src/internal/interpreter/http/http.ts
+++ b/src/internal/interpreter/http/http.ts
@@ -79,7 +79,7 @@ function replaceParameters(url: string, parameters: NonPrimitive) {
     const start = match.index;
     // Why can this be undefined?
     if (start === undefined) {
-      throw new Error('Unexpected regex match state - missing start index');
+      throw new UnexpectedError('Invalid regex match state - missing start index');
     }
 
     const end = start + match[0].length;

--- a/src/internal/interpreter/http/http.ts
+++ b/src/internal/interpreter/http/http.ts
@@ -18,6 +18,7 @@ import {
   NonPrimitive,
   Variables,
   variablesToStrings,
+  variableToString,
 } from '../variables';
 import {
   authenticateFilter,
@@ -67,38 +68,43 @@ export enum NetworkErrors {
 }
 
 function replaceParameters(url: string, parameters: NonPrimitive) {
-  const replacements: string[] = [];
+  let result = '';
+
+  let lastIndex = 0;
+  const allKeys: string[] = [];
+  const missingKeys: string[] = [];
 
   const regex = RegExp('{([^}]*)}', 'g');
-  let replacement: RegExpExecArray | null;
-  while ((replacement = regex.exec(url)) !== null) {
-    replacements.push(replacement[1]);
-  }
+  for (const match of url.matchAll(regex)) {
+    const start = match.index;
+    // Why can this be undefined?
+    if (start === undefined) {
+      throw new Error('Unexpected regex match state - missing start index');
+    }
 
-  const entries = replacements.map<[string, Variables | undefined]>(key => [
-    key,
-    getValue(parameters, key.split('.')),
-  ]);
-  const values = Object.fromEntries(entries);
-  const missingKeys = replacements.filter(key => values[key] === undefined);
+    const end = start + match[0].length;
+    const key = match[1].trim();
+    const value = getValue(parameters, key.split('.'));
+
+    allKeys.push(key);
+    if (value === undefined) {
+      missingKeys.push(key);
+      continue;
+    }
+
+    result += url.slice(lastIndex, start);
+    result += variableToString(value);
+    lastIndex = end;
+  }
+  result += url.slice(lastIndex);
 
   if (missingKeys.length > 0) {
-    const missing = missingKeys;
-    const all = replacements;
     const available = recursiveKeyList(parameters ?? {});
 
-    throw missingPathReplacementError(missing, url, all, available);
+    throw missingPathReplacementError(missingKeys, url, allKeys, available);
   }
 
-  const stringifiedValues = variablesToStrings(values);
-
-  for (const param of Object.keys(values)) {
-    const replacement = stringifiedValues[param];
-
-    url = url.replace(`{${param}}`, replacement);
-  }
-
-  return url;
+  return result;
 }
 
 export const createUrl = (

--- a/src/internal/interpreter/map-interpreter.test.ts
+++ b/src/internal/interpreter/map-interpreter.test.ts
@@ -228,6 +228,40 @@ describe('MapInterpreter', () => {
     expect(result.isOk() && result.value).toEqual(144);
   });
 
+  it('should correctly trim and parse path parameters in http call', async () => {
+    const url = '/thirteen';
+    await mockServer.get(url + '/2/get/now').thenJson(200, { data: 169 });
+
+    const interpreter = new MapInterpreter(
+      {
+        usecase: 'Test',
+        input: { page: '2', cmd: 'get', when: 'now' },
+        security: [],
+        services: mockServicesSelector,
+      },
+      { fetchInstance }
+    );
+    const ast = parseMapFromSource(`
+      map Test {
+        page = input.page
+        http GET "${url}/{ page     	  }/{input.cmd }/{ input.when}" {
+          request {
+            headers {
+              "content-type" = "application/json"
+            }
+          }
+
+          response 200 "application/json" "en-US" {
+            map result body.data
+          }
+        }
+      }`);
+    const result = await interpreter.perform(ast);
+
+    result.unwrap();
+    expect(result.isOk() && result.value).toEqual(169);
+  });
+
   it('should call an API with parameters', async () => {
     const url = '/twelve';
     await mockServer

--- a/src/internal/interpreter/variables.ts
+++ b/src/internal/interpreter/variables.ts
@@ -110,7 +110,7 @@ export const getValue = (
 };
 
 /**
- * Stringifies a primitive variable.
+ * Turns a variable (both primitive and non-primitive) into a string.
 */
 export const variableToString = (
 	variable: Variables

--- a/src/internal/interpreter/variables.ts
+++ b/src/internal/interpreter/variables.ts
@@ -110,6 +110,19 @@ export const getValue = (
 };
 
 /**
+ * Stringifies a primitive variable.
+*/
+export const variableToString = (
+	variable: Variables
+): string => {
+	if (typeof variable === 'string') {
+		return variable;
+	}
+
+	return JSON.stringify(variable);
+}
+
+/**
  * Stringifies a Record of variables. `undefined` values are removed.
  */
 export const variablesToStrings = (
@@ -120,7 +133,7 @@ export const variablesToStrings = (
   if (variables) {
     for (const [key, value] of Object.entries(variables)) {
       if (value !== undefined) {
-        result[key] = typeof value === 'string' ? value : JSON.stringify(value);
+        result[key] = variableToString(value);
       }
     }
   }


### PR DESCRIPTION
## Description
Rewritten `replaceParameters` using the newer `String.matchAll` api while taking care of whitespace. I believe this makes the method more readable as well.

## Motivation and Context
Fixes #228 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
