### PR TITLE
fix(http): Don't set content-type w/ form-data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Send multipart boundary in content-type header for `multipart/form-data`
 
 ## [1.4.0] - 2022-05-17
 ### Added

--- a/src/internal/interpreter/http/filters.test.ts
+++ b/src/internal/interpreter/http/filters.test.ts
@@ -335,5 +335,28 @@ describe('HTTP Filters', () => {
         'content-type': JSON_CONTENT,
       });
     });
+
+    it("doesn't set content-type for multipart/form-data", async () => {
+      const result = await headersFilter({
+        parameters: {
+          url: '/test',
+          method: '',
+          baseUrl: 'https://example.com',
+          headers: {
+            test: 'test',
+          },
+          contentType: FORMDATA_CONTENT,
+        },
+      });
+
+      expect(result.request?.headers).toMatchObject({
+        test: 'test',
+      });
+      expect(result.request?.headers).toEqual(
+        expect.not.objectContaining({
+          'content-type': expect.anything(),
+        })
+      );
+    });
   });
 });

--- a/src/internal/interpreter/http/filters.ts
+++ b/src/internal/interpreter/http/filters.ts
@@ -265,7 +265,7 @@ export const headersFilter: Filter = ({
   } else if (parameters.contentType === URLENCODED_CONTENT) {
     headers['content-type'] ??= URLENCODED_CONTENT;
   } else if (parameters.contentType === FORMDATA_CONTENT) {
-    headers['content-type'] ??= FORMDATA_CONTENT;
+    // NOTE: Do not set content-type explicitly, it will be read from FormData along with boundary
   } else if (
     parameters.contentType !== undefined &&
     BINARY_CONTENT_REGEXP.test(parameters.contentType)

--- a/src/internal/interpreter/http/http.test.ts
+++ b/src/internal/interpreter/http/http.test.ts
@@ -150,4 +150,32 @@ describe('HttpClient', () => {
       });
     }
   });
+
+  describe('multipart/form-data', () => {
+    it('encodes multipart boundary correctly', async () => {
+      await mockServer.post('/data').thenCallback(async req => {
+        return {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            contentType: req.headers['content-type'],
+            body: await req.body.getText(),
+          }),
+        };
+      });
+
+      const response = await http.request('/data', {
+        method: 'post',
+        contentType: 'multipart/form-data',
+        body: {
+          foo: 1,
+          bar: 'baz',
+        },
+        baseUrl,
+      });
+      expect(response.statusCode).toBe(200);
+      const body = response.body as any;
+      expect(body.contentType).toMatch(/^multipart\/form-data;boundary=/);
+    });
+  });
 });


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description

Related to #230 (but not root cause).

When I want to send body with `multipart/form-data` encoding to Mailgun, I am getting back server error "Missing content boundary". Upon closer inspection, the [boundary directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type#directives) is missing in the `Content-Type` header. It is normally automatically read from `FormData`, but since `content-type` is set explicitly, it's not overwritten.

Thanks to @lukas-valenta for helping me to solve this issue.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [x] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
