### PR TITLE
[WIP] feat/early profile resolution

### DIFF
--- a/src/client/profile.ts
+++ b/src/client/profile.ts
@@ -1,3 +1,5 @@
+import { ProfileDocumentNode } from '@superfaceai/ast';
+
 import { UnexpectedError } from '../internal/errors';
 import { usecaseNotFoundError } from '../internal/errors.helpers';
 import { NonPrimitive } from '../internal/interpreter/variables';
@@ -29,7 +31,8 @@ export type KnownUsecase<TUsecase extends UsecaseType> = {
 export class ProfileBase {
   constructor(
     public readonly client: SuperfaceClientBase,
-    public readonly configuration: ProfileConfiguration
+    public readonly configuration: ProfileConfiguration,
+    public readonly ast: ProfileDocumentNode
   ) {}
 
   getConfiguredProviders(): string[] {
@@ -55,9 +58,10 @@ export class TypedProfile<
   constructor(
     public override readonly client: SuperfaceClientBase,
     public override readonly configuration: ProfileConfiguration,
+    public override readonly ast: ProfileDocumentNode,
     usecases: (keyof TUsecaseTypes)[]
   ) {
-    super(client, configuration);
+    super(client, configuration, ast);
     this.knownUsecases = usecases.reduce(
       (acc, usecase) => ({
         ...acc,

--- a/src/client/registry.ts
+++ b/src/client/registry.ts
@@ -229,6 +229,25 @@ export async function fetchBind(request: {
   return parseBindResponse(request, fetchResponse);
 }
 
+//TODO: fetch source or AST? Send AST/parser version to brain and let it deal with version matching?
+export async function fetchProfileSource(profileId: string): Promise<string> {
+  const fetchInstance = new CrossFetch();
+  const http = new HttpClient(fetchInstance);
+  const sdkToken = Config.instance().sdkAuthToken;
+  registryDebug(`Getting source of profile: "${profileId}"`);
+
+  const { body } = await http.request(`/${profileId}`, {
+    method: 'GET',
+    headers: sdkToken
+      ? [`Authorization: SUPERFACE-SDK-TOKEN ${sdkToken}`]
+      : undefined,
+    baseUrl: Config.instance().superfaceApiUrl,
+    accept: 'application/vnd.superface.profile',
+  });
+
+  return body as string;
+}
+
 export async function fetchMapSource(mapId: string): Promise<string> {
   const fetchInstance = new CrossFetch();
   const http = new HttpClient(fetchInstance);

--- a/src/client/usecase.ts
+++ b/src/client/usecase.ts
@@ -79,7 +79,7 @@ class UseCaseBase implements Interceptable {
     //In this instance we can set metadata for events
     this.boundProfileProvider =
       await this.profile.client.cacheBoundProfileProvider(
-        this.profile.configuration,
+        this.profile,
         providerConfig
       );
   }


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

**POC PR for now**
This PR moves resolving of the profile AST to `getProfile` function. It also adds ability to use profile without need to specify it in super.json (local or in code). Profile id and version is specified in `getProfile`

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [x] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
