### PR TITLE
[WIP] feat: pass custom sdk auth token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - SuperfaceClient supports passing SuperJson as constructor parameter
 - Pass security values in `perform`
+- SuperfaceClient supports passing Superface token as constructor parameter
 
 ## [1.4.1] - 2022-05-17
 ### Fixed

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -110,7 +110,20 @@ describe('superface client', () => {
   afterEach(() => {
     jest.resetAllMocks();
     invalidateSuperfaceClientCache();
+    Config.reloadFromEnv();
   });
+  it('sets sdk token to custom value', () => {
+    Config.instance().disableReporting = false;
+    const superfaceToken =
+      'sfs_f68eb7a8f8f0399fdd69854b716ab2c176a87d1b3a8bdbb65b4155550c17518982783a98bd0e7225eb22065ebb30ae09d13c0c4e22b6368087681d6e588eea41_d1011fdc';
+
+    new SuperfaceClient({
+      superfaceToken,
+    });
+
+    expect(Config.instance().sdkAuthToken).toEqual(superfaceToken);
+  });
+
   it('does not cache super.json passed as parameter', () => {
     const statCalls = statSyncMock.mock.calls.length;
     const readFileCalls = readFileSyncMock.mock.calls.length;

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -43,14 +43,20 @@ export abstract class SuperfaceClientBase extends Events {
 
   public hookContext: HooksContext = {};
 
-  constructor(options?: { superJson?: SuperJson | SuperJsonDocument }) {
+  constructor(options?: {
+    superJson?: SuperJson | SuperJsonDocument;
+    superfaceToken?: string;
+  }) {
     super();
 
     this.superJson = resolveSuperJson(options?.superJson);
 
     if (!Config.instance().disableReporting) {
       this.hookMetrics();
-      this.metricReporter = new MetricReporter(this.superJson);
+      this.metricReporter = new MetricReporter(
+        this.superJson,
+        options?.superfaceToken
+      );
       this.metricReporter.reportEvent({
         eventType: 'SDKInit',
         occurredAt: new Date(),

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,6 +1,30 @@
 import { Config } from './config';
 
 describe('Config', () => {
+  describe('when setting sdk auth token', () => {
+    it('throws error - sdk token with invalid prefix', async () => {
+      const token =
+        'sfx_bb064dd57c302911602dd097bc29bedaea6a021c25a66992d475ed959aa526c7_37bce8b5';
+      expect(() => Config.setSdkAuthToken(token)).toThrowError(
+        new Error(`${token} is not valid Superface authentication token.`)
+      );
+    });
+
+    it('returns undefined - sdk token with invalid sufix', async () => {
+      const token =
+        'sfs_bb064dd57c302911602dd097bc29bedaea6a021c25a66992d475ed959aa526c7_37bXe8b5';
+      expect(() => Config.setSdkAuthToken(token)).toThrowError(
+        new Error(`${token} is not valid Superface authentication token.`)
+      );
+    });
+
+    it('sets token - sdk token with space at the end', async () => {
+      const token =
+        'sfs_bb064dd57c302911602dd097bc29bedaea6a021c25a66992d475ed959aa526c7_37bce8b5';
+      Config.setSdkAuthToken(token + '  ');
+      expect(Config.instance().sdkAuthToken).toEqual(token);
+    });
+  });
   describe('when loading sdk auth token', () => {
     let originalToken: string | undefined;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -131,6 +131,18 @@ function getSandboxTimeout(): number {
 export class Config {
   private static _instance?: Config;
 
+  public static setSdkAuthToken(passedToken: string): void {
+    const token = passedToken.trim();
+    const tokenRegexp = /^(sfs)_([^_]+)_([0-9A-F]{8})$/i;
+    if (!tokenRegexp.test(token)) {
+      throw new Error(
+        `${passedToken} is not valid Superface authentication token.`
+      );
+    }
+
+    Config.instance().sdkAuthToken = token;
+  }
+
   static instance(): Config {
     if (Config._instance === undefined) {
       Config._instance = new Config();

--- a/src/lib/reporter.ts
+++ b/src/lib/reporter.ts
@@ -143,8 +143,12 @@ export class MetricReporter {
   private configHash: string;
   private anonymizedSuperJson: AnonymizedSuperJsonDocument;
 
-  constructor(superJson: SuperJson) {
+  constructor(superJson: SuperJson, superfaceToken?: string) {
     this.fetchInstance = new CrossFetch();
+
+    if (superfaceToken !== undefined) {
+      Config.setSdkAuthToken(superfaceToken);
+    }
     this.sdkToken = Config.instance().sdkAuthToken;
     this.configHash = superJson.configHash;
     this.anonymizedSuperJson = superJson.anonymized;


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->
This PR adds option to pass Superface authentication token directly to `SuperfaceClient` constructor.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [x] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
