### PR TITLE
feat: map info as perform parameter

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -103,6 +103,8 @@ export abstract class SuperfaceClientBase extends Events {
 
     const boundProfileProvider = await profileProvider.bind({
       security: providerConfig.security,
+      mapRevision: providerConfig.mapRevision,
+      mapVarinat: providerConfig.mapVariant,
     });
     this.boundCache[cacheKey] = {
       profileProvider: boundProfileProvider,

--- a/src/client/profile-provider.ts
+++ b/src/client/profile-provider.ts
@@ -54,7 +54,7 @@ import { ProviderConfiguration } from './provider';
 import { fetchBind, fetchMapSource, fetchProviderInfo } from './registry';
 import { resolveSecurityConfiguration } from './security';
 
-function forceCast<T>(_: unknown): asserts _ is T { }
+function forceCast<T>(_: unknown): asserts _ is T {}
 
 function profileAstId(ast: ProfileDocumentNode): string {
   return ast.header.scope !== undefined
@@ -353,7 +353,7 @@ export class ProfileProvider {
         ),
         profileProviderSettings:
           this.superJson.normalized.profiles[profileId]?.providers[
-          providerInfo.name
+            providerInfo.name
           ],
         security: securityConfiguration,
         parameters: this.resolveIntegrationParameters(

--- a/src/client/profile-provider.ts
+++ b/src/client/profile-provider.ts
@@ -54,7 +54,7 @@ import { ProviderConfiguration } from './provider';
 import { fetchBind, fetchMapSource, fetchProviderInfo } from './registry';
 import { resolveSecurityConfiguration } from './security';
 
-function forceCast<T>(_: unknown): asserts _ is T {}
+function forceCast<T>(_: unknown): asserts _ is T { }
 
 function profileAstId(ast: ProfileDocumentNode): string {
   return ast.header.scope !== undefined
@@ -205,6 +205,8 @@ export class BoundProfileProvider {
 
 export type BindConfiguration = {
   security?: SecurityValues[];
+  mapRevision?: string;
+  mapVarinat?: string;
 };
 
 const profileProviderDebug = createDebug('superface:profile-provider');
@@ -283,8 +285,9 @@ export class ProfileProvider {
       `${profileId}.${providerName}`
     );
     let mapAst = resolvedMapAst.mapAst;
-    const mapVariant = resolvedMapAst.mapVariant;
-    const mapRevision = resolvedMapAst.mapRevision;
+    const mapVariant = configuration?.mapVarinat ?? resolvedMapAst.mapVariant;
+    const mapRevision =
+      configuration?.mapRevision ?? resolvedMapAst.mapRevision;
 
     // resolve map ast using bind and fill in provider info if not specified
     if (mapAst === undefined) {
@@ -350,7 +353,7 @@ export class ProfileProvider {
         ),
         profileProviderSettings:
           this.superJson.normalized.profiles[profileId]?.providers[
-            providerInfo.name
+          providerInfo.name
           ],
         security: securityConfiguration,
         parameters: this.resolveIntegrationParameters(

--- a/src/client/provider.ts
+++ b/src/client/provider.ts
@@ -6,7 +6,9 @@ import { SuperfaceClientBase } from './client';
 export class ProviderConfiguration {
   constructor(
     public readonly name: string,
-    public readonly security: SecurityValues[]
+    public readonly security: SecurityValues[],
+    public readonly mapRevision?: string,
+    public readonly mapVariant?: string
   ) {}
 
   get cacheKey(): string {
@@ -26,7 +28,9 @@ export class Provider {
   }): Promise<Provider> {
     const newConfiguration = new ProviderConfiguration(
       this.configuration.name,
-      mergeSecurity(this.configuration.security, configuration.security ?? [])
+      mergeSecurity(this.configuration.security, configuration.security ?? []),
+      this.configuration.mapRevision,
+      this.configuration.mapVariant
     );
 
     return new Provider(this.client, newConfiguration);

--- a/src/client/provider.ts
+++ b/src/client/provider.ts
@@ -15,6 +15,27 @@ export class ProviderConfiguration {
     // TODO: Research a better way?
     return JSON.stringify(this);
   }
+
+  public static mergeWithOptions({
+    configuration,
+    name,
+    security,
+    mapRevision,
+    mapVariant,
+  }: {
+    configuration: ProviderConfiguration;
+    name?: string;
+    security?: SecurityValues[];
+    mapRevision?: string;
+    mapVariant?: string;
+  }): ProviderConfiguration {
+    return new ProviderConfiguration(
+      name ?? configuration.name,
+      security ?? configuration.security,
+      mapRevision ?? configuration.mapRevision,
+      mapVariant ?? configuration.mapVariant
+    );
+  }
 }
 
 export class Provider {

--- a/src/client/usecase.ts
+++ b/src/client/usecase.ts
@@ -84,17 +84,13 @@ class UseCaseBase implements Interceptable {
     const providerConfig = await this.getProviderConfiguration(
       options?.provider ?? currentProvider
     );
-    //If we have security values pass them directly to perform
-    if (options?.security) {
-      return new ProviderConfiguration(providerConfig.name, options.security);
-    }
 
-    //TODO: make this nice 
-    if (options?.mapRevision !== undefined || options?.mapVariant !== undefined) {
-      return new ProviderConfiguration(providerConfig.name, providerConfig.security, options.mapRevision, options.mapVariant);
-    }
-
-    return providerConfig;
+    return ProviderConfiguration.mergeWithOptions({
+      configuration: providerConfig,
+      security: options?.security,
+      mapRevision: options?.mapRevision,
+      mapVariant: options?.mapVariant,
+    });
   }
 
   private async getProviderConfiguration(
@@ -179,8 +175,10 @@ class UseCaseBase implements Interceptable {
       console.warn(
         `Super.json sets provider failover priority to: "${profileEntry.priority.join(
           ', '
-        )}" but provider failover is not allowed for usecase "${this.name
-        }".\nTo allow provider failover please set property "providerFailover" in "${profileId}.defaults[${this.name
+        )}" but provider failover is not allowed for usecase "${
+          this.name
+        }".\nTo allow provider failover please set property "providerFailover" in "${profileId}.defaults[${
+          this.name
         }]" to true`
       );
     }
@@ -257,7 +255,7 @@ class UseCaseBase implements Interceptable {
         usecaseInfo,
         //TODO are these defauts ok?
         retryPolicyConfig.maxContiguousRetries ??
-        RetryPolicy.DEFAULT_MAX_CONTIGUOUS_RETRIES,
+          RetryPolicy.DEFAULT_MAX_CONTIGUOUS_RETRIES,
         retryPolicyConfig.openTime ?? CircuitBreakerPolicy.DEFAULT_OPEN_TIME,
         retryPolicyConfig.requestTimeout ?? RetryPolicy.DEFAULT_REQUEST_TIMEOUT,
         backoff
@@ -266,7 +264,7 @@ class UseCaseBase implements Interceptable {
       policy = new RetryPolicy(
         usecaseInfo,
         retryPolicyConfig.maxContiguousRetries ??
-        RetryPolicy.DEFAULT_MAX_CONTIGUOUS_RETRIES,
+          RetryPolicy.DEFAULT_MAX_CONTIGUOUS_RETRIES,
         retryPolicyConfig.requestTimeout ?? RetryPolicy.DEFAULT_REQUEST_TIMEOUT,
         new ConstantBackoff(0)
       );
@@ -310,7 +308,7 @@ export class UseCase extends UseCaseBase {
 export class TypedUseCase<
   TInput extends NonPrimitive | undefined,
   TOutput
-  > extends UseCaseBase {
+> extends UseCaseBase {
   async perform(
     input: TInput,
     options?: PerformOptions

--- a/src/client/usecase.ts
+++ b/src/client/usecase.ts
@@ -29,6 +29,8 @@ export type PerformOptions = {
   provider?: Provider | string;
   parameters?: Record<string, string>;
   security?: SecurityValues[];
+  mapVariant?: string;
+  mapRevision?: string;
 };
 
 // TODO
@@ -85,6 +87,11 @@ class UseCaseBase implements Interceptable {
     //If we have security values pass them directly to perform
     if (options?.security) {
       return new ProviderConfiguration(providerConfig.name, options.security);
+    }
+
+    //TODO: make this nice 
+    if (options?.mapRevision !== undefined || options?.mapVariant !== undefined) {
+      return new ProviderConfiguration(providerConfig.name, providerConfig.security, options.mapRevision, options.mapVariant);
     }
 
     return providerConfig;
@@ -172,10 +179,8 @@ class UseCaseBase implements Interceptable {
       console.warn(
         `Super.json sets provider failover priority to: "${profileEntry.priority.join(
           ', '
-        )}" but provider failover is not allowed for usecase "${
-          this.name
-        }".\nTo allow provider failover please set property "providerFailover" in "${profileId}.defaults[${
-          this.name
+        )}" but provider failover is not allowed for usecase "${this.name
+        }".\nTo allow provider failover please set property "providerFailover" in "${profileId}.defaults[${this.name
         }]" to true`
       );
     }
@@ -252,7 +257,7 @@ class UseCaseBase implements Interceptable {
         usecaseInfo,
         //TODO are these defauts ok?
         retryPolicyConfig.maxContiguousRetries ??
-          RetryPolicy.DEFAULT_MAX_CONTIGUOUS_RETRIES,
+        RetryPolicy.DEFAULT_MAX_CONTIGUOUS_RETRIES,
         retryPolicyConfig.openTime ?? CircuitBreakerPolicy.DEFAULT_OPEN_TIME,
         retryPolicyConfig.requestTimeout ?? RetryPolicy.DEFAULT_REQUEST_TIMEOUT,
         backoff
@@ -261,7 +266,7 @@ class UseCaseBase implements Interceptable {
       policy = new RetryPolicy(
         usecaseInfo,
         retryPolicyConfig.maxContiguousRetries ??
-          RetryPolicy.DEFAULT_MAX_CONTIGUOUS_RETRIES,
+        RetryPolicy.DEFAULT_MAX_CONTIGUOUS_RETRIES,
         retryPolicyConfig.requestTimeout ?? RetryPolicy.DEFAULT_REQUEST_TIMEOUT,
         new ConstantBackoff(0)
       );
@@ -305,7 +310,7 @@ export class UseCase extends UseCaseBase {
 export class TypedUseCase<
   TInput extends NonPrimitive | undefined,
   TOutput
-> extends UseCaseBase {
+  > extends UseCaseBase {
   async perform(
     input: TInput,
     options?: PerformOptions


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->
This PR adds option to pass map variant and map revision to `perform` call. It uses `ProviderConfiguration` to store passed information. 

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [ ] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
