### PR TITLE
fix: Do not recache ProviderConfig on security change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Do not recache ProviderConfiguration on security values change
 
 ## [1.5.0] - 2022-06-09
 ### Added

--- a/src/client/provider.test.ts
+++ b/src/client/provider.test.ts
@@ -7,9 +7,7 @@ jest.mock('./client');
 describe('Provider Configuration', () => {
   it('should cache key correctly', async () => {
     const mockProviderConfiguration = new ProviderConfiguration('test', []);
-    expect(mockProviderConfiguration.cacheKey).toEqual(
-      JSON.stringify(mockProviderConfiguration)
-    );
+    expect(mockProviderConfiguration.cacheKey).toEqual('{"provider":"test"}');
   });
 });
 describe('Provider', () => {

--- a/src/client/provider.ts
+++ b/src/client/provider.ts
@@ -11,7 +11,7 @@ export class ProviderConfiguration {
 
   get cacheKey(): string {
     // TODO: Research a better way?
-    return JSON.stringify(this);
+    return JSON.stringify({ provider: this.name });
   }
 }
 


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
Changes ProviderConfiguration cache key so it doesn't get recached on security change

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With the addition of passing security values in runtime, we don't want to rebind on every change

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [x] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
