### PR TITLE
fix: move Config.instance() call out of global scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Do not recache ProviderConfiguration on security values change
+- Do not call `Config.instance()` in the global scope to defer reading of env variables
 
 ## [1.5.0] - 2022-06-09
 ### Added

--- a/src/client/profile-provider.ts
+++ b/src/client/profile-provider.ts
@@ -65,7 +65,6 @@ function profileAstId(ast: ProfileDocumentNode): string {
 const boundProfileProviderDebug = createDebug(
   'superface:bound-profile-provider'
 );
-const cachePath = joinPath(Config.instance().cachePath, 'providers');
 
 export class BoundProfileProvider {
   private profileValidator: ProfileParameterValidator;
@@ -214,6 +213,7 @@ export class ProfileProvider {
   private scope: string | undefined;
   private profileName: string;
   private providerJson?: ProviderJson;
+  private readonly cachePath: string;
 
   constructor(
     /** Preloaded superJson instance */
@@ -241,6 +241,8 @@ export class ProfileProvider {
       this.scope = scopeOrProfileName;
       this.profileName = profileName;
     }
+
+    this.cachePath = joinPath(Config.instance().cachePath, 'providers');
   }
 
   /**
@@ -420,7 +422,7 @@ export class ProfileProvider {
   private async cacheProviderInfo(providerName: string): Promise<ProviderJson> {
     const errors: Error[] = [];
     if (this.providerJson === undefined) {
-      const providerCachePath = joinPath(cachePath, providerName);
+      const providerCachePath = joinPath(this.cachePath, providerName);
       // If we don't have provider info, we first try to fetch it from the registry
       try {
         this.providerJson = await fetchProviderInfo(providerName);
@@ -462,9 +464,9 @@ export class ProfileProvider {
   }
 
   private async writeProviderCache(providerJson: ProviderJson): Promise<void> {
-    const providerCachePath = joinPath(cachePath, `${providerJson.name}.json`);
+    const providerCachePath = joinPath(this.cachePath, `${providerJson.name}.json`);
     try {
-      await fsp.mkdir(cachePath, { recursive: true });
+      await fsp.mkdir(this.cachePath, { recursive: true });
       await fsp.writeFile(
         providerCachePath,
         JSON.stringify(providerJson, undefined, 2)


### PR DESCRIPTION
## Description
Moves `Config.instance()` out of global scope - this was instantiating the global singleton during importing of the module, which prevented `process.env` modification in the importing module from having the intended effect.

This will be fixed again by #236 

## Motivation and Context
Bug #235 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
