### PR TITLE
chore: refactor security passing through perform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Do not recache ProviderConfiguration on security values change
+- Refactor security values passing in `perform`
 
 ## [1.5.0] - 2022-06-09
 ### Added

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -234,7 +234,7 @@ but this path does not exist or is not accessible`
 
       const profileConfigA = new ProfileConfiguration('foo', '1.0.0');
       const profileConfigB = new ProfileConfiguration('foo', '2.0.0');
-      const providerConfig = new ProviderConfiguration('fooder', []);
+      const providerConfig = new ProviderConfiguration('fooder');
 
       const profileProviderBindMock = jest.fn(() => 'mocked bind result');
       const ProfileProviderMock = jest
@@ -267,7 +267,7 @@ but this path does not exist or is not accessible`
       const client = new SuperfaceClient();
 
       const profileConfig = new ProfileConfiguration('foo', '1.0.0');
-      const providerConfig = new ProviderConfiguration('fooder', []);
+      const providerConfig = new ProviderConfiguration('fooder');
 
       const profileProviderBindMock = jest
         .fn()

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -101,9 +101,7 @@ export abstract class SuperfaceClientBase extends Events {
       this
     );
 
-    const boundProfileProvider = await profileProvider.bind({
-      security: providerConfig.security,
-    });
+    const boundProfileProvider = await profileProvider.bind();
     this.boundCache[cacheKey] = {
       profileProvider: boundProfileProvider,
       expiresAt: now + Config.instance().superfaceCacheTimeout,
@@ -118,10 +116,7 @@ export abstract class SuperfaceClientBase extends Events {
       throw unconfiguredProviderError(providerName);
     }
 
-    return new Provider(
-      this,
-      new ProviderConfiguration(providerName, providerSettings.security)
-    );
+    return new Provider(this, new ProviderConfiguration(providerName));
   }
 
   /** Returns a provider configuration for when no provider is passed to untyped `.perform`. */

--- a/src/client/failure/event-adapter.test.ts
+++ b/src/client/failure/event-adapter.test.ts
@@ -436,21 +436,50 @@ function spyOnCacheBoundProfileProvider(client: SuperfaceClientBase) {
   const firstMockBoundProfileProvider = new BoundProfileProvider(
     firstMockProfileDocument,
     firstMockMapDocument,
-    'provider',
+    {
+      name: 'provider',
+      services: [
+        {
+          id: 'default',
+          baseUrl: 'service/base/url',
+        },
+      ],
+      defaultService: 'default',
+    },
     { services: ServiceSelector.withDefaultUrl(mockServer.url), security: [] },
     client
   );
   const secondMockBoundProfileProvider = new BoundProfileProvider(
     firstMockProfileDocument,
     secondMockMapDocument,
-    'second',
+    {
+      name: 'second',
+      services: [
+        {
+          id: 'default',
+          baseUrl: 'service/base/url',
+        },
+      ],
+      defaultService: 'default',
+    },
+
     { services: ServiceSelector.withDefaultUrl(mockServer.url), security: [] },
     client
   );
   const thirdMockBoundProfileProvider = new BoundProfileProvider(
     secondMockProfiledDocument,
     thirdMockMapDocument,
-    'third',
+    {
+      name: 'third',
+      services: [
+        {
+          id: 'default',
+          baseUrl: 'service/base/url',
+        },
+      ],
+      defaultService: 'default',
+    },
+
     { services: ServiceSelector.withDefaultUrl(mockServer.url), security: [] },
     client
   );

--- a/src/client/profile-provider.test.ts
+++ b/src/client/profile-provider.test.ts
@@ -1348,9 +1348,7 @@ but http scheme requires: digest`
           .mockResolvedValueOnce(JSON.stringify(mockProviderJson))
           .mockResolvedValueOnce(JSON.stringify(mockMapDocument));
 
-        const providerConfiguration = new ProviderConfiguration(
-          'test-boop'
-        );
+        const providerConfiguration = new ProviderConfiguration('test-boop');
 
         const mockProfileProvider = new ProfileProvider(
           mockSuperJson,

--- a/src/client/profile-provider.ts
+++ b/src/client/profile-provider.ts
@@ -74,7 +74,7 @@ export class BoundProfileProvider {
   constructor(
     private readonly profileAst: ProfileDocumentNode,
     private readonly mapAst: MapDocumentNode,
-    private readonly providerName: string,
+    private readonly provider: ProviderJson,
     readonly configuration: {
       services: IServiceSelector;
       profileProviderSettings?: NormalizedProfileProviderSettings;
@@ -88,7 +88,7 @@ export class BoundProfileProvider {
     this.fetchInstance = new CrossFetch();
     this.fetchInstance.metadata = {
       profile: profileAstId(profileAst),
-      provider: providerName,
+      provider: provider.name,
     };
     this.fetchInstance.events = events;
   }
@@ -123,12 +123,13 @@ export class BoundProfileProvider {
   >(
     usecase: string,
     input?: TInput,
-    parameters?: Record<string, string>
+    parameters?: Record<string, string>,
+    securityValues?: SecurityValues[]
   ): Promise<Result<TResult, ProfileParameterError | MapInterpreterError>> {
     this.fetchInstance.metadata = {
       profile: profileAstId(this.profileAst),
       usecase,
-      provider: this.providerName,
+      provider: this.provider.name,
     };
     // compose and validate the input
     const composedInput = this.composeInput(usecase, input);
@@ -143,13 +144,21 @@ export class BoundProfileProvider {
     }
     forceCast<TInput>(composedInput);
 
+    const security = securityValues
+      ? resolveSecurityConfiguration(
+          this.provider.securitySchemes ?? [],
+          securityValues,
+          this.provider.name
+        )
+      : this.configuration.security;
+
     // create and perform interpreter instance
     const interpreter = new MapInterpreter<TInput>(
       {
         input: composedInput,
         usecase,
         services: this.configuration.services,
-        security: this.configuration.security,
+        security,
         parameters: this.mergeParameters(
           parameters,
           this.configuration.parameters
@@ -342,7 +351,7 @@ export class ProfileProvider {
     return new BoundProfileProvider(
       profileAst,
       mapAst,
-      providerInfo.name,
+      providerInfo,
       {
         services: new ServiceSelector(
           providerInfo.services,
@@ -670,24 +679,19 @@ export class ProfileProvider {
   /**
    * Resolves auth variables by applying the provided overlay over the base variables.
    *
-   * The base variables either come from super.json or from `this.provider` if it is an instance of `ProviderConfiguration`
+   * The base variables either come from super.json
    */
   private resolveSecurityValues(
     providerName: string,
     overlay?: SecurityValues[]
   ): SecurityValues[] {
-    let base: SecurityValues[];
-    if (this.provider instanceof ProviderConfiguration) {
-      base = this.provider.security;
-    } else {
-      base = this.superJson.normalized.providers[providerName]?.security;
-    }
+    const base: SecurityValues[] =
+      this.superJson.normalized.providers[providerName]?.security;
 
-    let resolved = base;
     if (overlay !== undefined) {
-      resolved = mergeSecurity(base, overlay);
+      return mergeSecurity(base, overlay);
     }
 
-    return resolved;
+    return base;
   }
 }

--- a/src/client/profile-provider.ts
+++ b/src/client/profile-provider.ts
@@ -679,14 +679,14 @@ export class ProfileProvider {
   /**
    * Resolves auth variables by applying the provided overlay over the base variables.
    *
-   * The base variables either come from super.json
+   * The base variables come from super.json
    */
   private resolveSecurityValues(
     providerName: string,
     overlay?: SecurityValues[]
   ): SecurityValues[] {
     const base: SecurityValues[] =
-      this.superJson.normalized.providers[providerName]?.security;
+      this.superJson.normalized.providers[providerName]?.security ?? [];
 
     if (overlay !== undefined) {
       return mergeSecurity(base, overlay);

--- a/src/client/provider.test.ts
+++ b/src/client/provider.test.ts
@@ -20,79 +20,8 @@ describe('Provider', () => {
     const mockProviderConfiguration = new ProviderConfiguration('test');
     const mockProvider = new Provider(mockClient, mockProviderConfiguration);
 
-    await expect(
-      mockProvider
-        .configure
-        //   {
-        //   security: [
-        //     {
-        //       username: 'second',
-        //       password: 'seconds',
-        //       id: 'second-id',
-        //     },
-        //   ],
-        // }
-        ()
-    ).resolves.toEqual(
-      new Provider(
-        mockClient,
-        new ProviderConfiguration(
-          'test'
-          //  [
-          //   {
-          //     username: 'second',
-          //     password: 'seconds',
-          //     id: 'second-id',
-          //   },
-          // ]
-        )
-      )
-    );
-  });
-
-  it('configures provider correctly and merges configuration', async () => {
-    // const mockSecurity = [
-    //   { id: 'first-id', username: 'digest-user', password: 'digest-password' },
-    // ];
-    const mockClient = new SuperfaceClient();
-    const mockProviderConfiguration = new ProviderConfiguration(
-      'test'
-      // mockSecurity
-    );
-    const mockProvider = new Provider(mockClient, mockProviderConfiguration);
-
-    await expect(
-      mockProvider
-        .configure
-        //   {
-        //   security: [
-        //     {
-        //       username: 'second',
-        //       password: 'seconds',
-        //       id: 'second-id',
-        //     },
-        //   ],
-        // }
-        ()
-    ).resolves.toEqual(
-      new Provider(
-        mockClient,
-        new ProviderConfiguration(
-          'test'
-          // [
-          //   {
-          //     id: 'first-id',
-          //     username: 'digest-user',
-          //     password: 'digest-password',
-          //   },
-          //   {
-          //     username: 'second',
-          //     password: 'seconds',
-          //     id: 'second-id',
-          //   },
-          // ]
-        )
-      )
+    await expect(mockProvider.configure()).resolves.toEqual(
+      new Provider(mockClient, new ProviderConfiguration('test'))
     );
   });
 });

--- a/src/client/provider.test.ts
+++ b/src/client/provider.test.ts
@@ -6,7 +6,7 @@ jest.mock('./client');
 
 describe('Provider Configuration', () => {
   it('should cache key correctly', async () => {
-    const mockProviderConfiguration = new ProviderConfiguration('test', []);
+    const mockProviderConfiguration = new ProviderConfiguration('test');
     expect(mockProviderConfiguration.cacheKey).toEqual('{"provider":"test"}');
   });
 });
@@ -17,69 +17,81 @@ describe('Provider', () => {
 
   it('configures provider correctly', async () => {
     const mockClient = new SuperfaceClient();
-    const mockProviderConfiguration = new ProviderConfiguration('test', []);
+    const mockProviderConfiguration = new ProviderConfiguration('test');
     const mockProvider = new Provider(mockClient, mockProviderConfiguration);
 
     await expect(
-      mockProvider.configure({
-        security: [
-          {
-            username: 'second',
-            password: 'seconds',
-            id: 'second-id',
-          },
-        ],
-      })
+      mockProvider
+        .configure
+        //   {
+        //   security: [
+        //     {
+        //       username: 'second',
+        //       password: 'seconds',
+        //       id: 'second-id',
+        //     },
+        //   ],
+        // }
+        ()
     ).resolves.toEqual(
       new Provider(
         mockClient,
-        new ProviderConfiguration('test', [
-          {
-            username: 'second',
-            password: 'seconds',
-            id: 'second-id',
-          },
-        ])
+        new ProviderConfiguration(
+          'test'
+          //  [
+          //   {
+          //     username: 'second',
+          //     password: 'seconds',
+          //     id: 'second-id',
+          //   },
+          // ]
+        )
       )
     );
   });
 
   it('configures provider correctly and merges configuration', async () => {
-    const mockSecurity = [
-      { id: 'first-id', username: 'digest-user', password: 'digest-password' },
-    ];
+    // const mockSecurity = [
+    //   { id: 'first-id', username: 'digest-user', password: 'digest-password' },
+    // ];
     const mockClient = new SuperfaceClient();
     const mockProviderConfiguration = new ProviderConfiguration(
-      'test',
-      mockSecurity
+      'test'
+      // mockSecurity
     );
     const mockProvider = new Provider(mockClient, mockProviderConfiguration);
 
     await expect(
-      mockProvider.configure({
-        security: [
-          {
-            username: 'second',
-            password: 'seconds',
-            id: 'second-id',
-          },
-        ],
-      })
+      mockProvider
+        .configure
+        //   {
+        //   security: [
+        //     {
+        //       username: 'second',
+        //       password: 'seconds',
+        //       id: 'second-id',
+        //     },
+        //   ],
+        // }
+        ()
     ).resolves.toEqual(
       new Provider(
         mockClient,
-        new ProviderConfiguration('test', [
-          {
-            id: 'first-id',
-            username: 'digest-user',
-            password: 'digest-password',
-          },
-          {
-            username: 'second',
-            password: 'seconds',
-            id: 'second-id',
-          },
-        ])
+        new ProviderConfiguration(
+          'test'
+          // [
+          //   {
+          //     id: 'first-id',
+          //     username: 'digest-user',
+          //     password: 'digest-password',
+          //   },
+          //   {
+          //     username: 'second',
+          //     password: 'seconds',
+          //     id: 'second-id',
+          //   },
+          // ]
+        )
       )
     );
   });

--- a/src/client/provider.ts
+++ b/src/client/provider.ts
@@ -1,13 +1,7 @@
-import { SecurityValues } from '@superfaceai/ast';
-
-import { mergeSecurity } from '../internal/superjson/mutate';
 import { SuperfaceClientBase } from './client';
 
 export class ProviderConfiguration {
-  constructor(
-    public readonly name: string,
-    public readonly security: SecurityValues[]
-  ) {}
+  constructor(public readonly name: string) {}
 
   get cacheKey(): string {
     // TODO: Research a better way?
@@ -21,13 +15,8 @@ export class Provider {
     public readonly configuration: ProviderConfiguration
   ) {}
 
-  async configure(configuration: {
-    security?: SecurityValues[];
-  }): Promise<Provider> {
-    const newConfiguration = new ProviderConfiguration(
-      this.configuration.name,
-      mergeSecurity(this.configuration.security, configuration.security ?? [])
-    );
+  async configure(): Promise<Provider> {
+    const newConfiguration = new ProviderConfiguration(this.configuration.name);
 
     return new Provider(this.client, newConfiguration);
   }

--- a/src/client/usecase.test.ts
+++ b/src/client/usecase.test.ts
@@ -140,7 +140,6 @@ describe('UseCase', () => {
 
       const mockProviderConfiguration = new ProviderConfiguration(
         'test-provider'
-        // []
       );
       const mockProvider = new Provider(mockClient, mockProviderConfiguration);
 

--- a/src/client/usecase.test.ts
+++ b/src/client/usecase.test.ts
@@ -1,8 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import {
+  ApiKeyPlacement,
   AstMetadata,
+  HttpScheme,
   MapDocumentNode,
   ProfileDocumentNode,
+  ProviderJson,
+  SecurityType,
 } from '@superfaceai/ast';
 
 import { SuperJson } from '../internal';
@@ -79,6 +83,36 @@ describe('UseCase', () => {
     definitions: [],
   };
 
+  const mockProviderJson: ProviderJson = {
+    name: 'test',
+    services: [{ id: 'test-service', baseUrl: 'service/base/url' }],
+    securitySchemes: [
+      {
+        type: SecurityType.HTTP,
+        id: 'basic',
+        scheme: HttpScheme.BASIC,
+      },
+      {
+        id: 'api',
+        type: SecurityType.APIKEY,
+        in: ApiKeyPlacement.HEADER,
+        name: 'Authorization',
+      },
+      {
+        id: 'bearer',
+        type: SecurityType.HTTP,
+        scheme: HttpScheme.BEARER,
+        bearerFormat: 'some',
+      },
+      {
+        id: 'digest',
+        type: SecurityType.HTTP,
+        scheme: HttpScheme.DIGEST,
+      },
+    ],
+    defaultService: 'test-service',
+  };
+
   beforeEach(() => {
     mockLoadSync.mockReturnValue(ok(mockSuperJson));
     SuperJson.loadSync = mockLoadSync;
@@ -93,7 +127,7 @@ describe('UseCase', () => {
       const mockBoundProfileProvider = new BoundProfileProvider(
         mockProfileDocument,
         mockMapDocument,
-        'test',
+        mockProviderJson,
         { services: ServiceSelector.withDefaultUrl(''), security: [] }
       );
       const mockClient = new SuperfaceClient();
@@ -105,8 +139,8 @@ describe('UseCase', () => {
       const mockProfile = new Profile(mockClient, mockProfileConfiguration);
 
       const mockProviderConfiguration = new ProviderConfiguration(
-        'test-provider',
-        []
+        'test-provider'
+        // []
       );
       const mockProvider = new Provider(mockClient, mockProviderConfiguration);
 
@@ -138,12 +172,7 @@ describe('UseCase', () => {
       expect(cacheBoundProfileProviderSpy).toHaveBeenCalledTimes(1);
       expect(cacheBoundProfileProviderSpy).toHaveBeenCalledWith(
         mockProfileConfiguration,
-        new ProviderConfiguration('test-provider', [
-          {
-            id: 'test',
-            apikey: 'key',
-          },
-        ])
+        new ProviderConfiguration('test-provider')
       );
     });
 
@@ -151,7 +180,7 @@ describe('UseCase', () => {
       const mockBoundProfileProvider = new BoundProfileProvider(
         mockProfileDocument,
         mockMapDocument,
-        'test',
+        mockProviderJson,
         { services: ServiceSelector.withDefaultUrl(''), security: [] }
       );
       const mockClient = new SuperfaceClient();
@@ -163,8 +192,7 @@ describe('UseCase', () => {
       const mockProfile = new Profile(mockClient, mockProfileConfiguration);
 
       const mockProviderConfiguration = new ProviderConfiguration(
-        'test-provider',
-        []
+        'test-provider'
       );
       const mockProvider = new Provider(mockClient, mockProviderConfiguration);
 
@@ -193,7 +221,7 @@ describe('UseCase', () => {
       const mockBoundProfileProvider = new BoundProfileProvider(
         mockProfileDocument,
         mockMapDocument,
-        'test',
+        mockProviderJson,
         { services: ServiceSelector.withDefaultUrl(''), security: [] }
       );
       const mockClient = new SuperfaceClient();
@@ -205,8 +233,7 @@ describe('UseCase', () => {
       const mockProfile = new Profile(mockClient, mockProfileConfiguration);
 
       const mockProviderConfiguration = new ProviderConfiguration(
-        'test-provider',
-        []
+        'test-provider'
       );
       const mockProvider = new Provider(mockClient, mockProviderConfiguration);
 
@@ -237,6 +264,7 @@ describe('UseCase', () => {
       expect(performSpy).toHaveBeenCalledTimes(1);
       expect(performSpy).toHaveBeenCalledWith(
         'test-usecase',
+        undefined,
         undefined,
         undefined
       );

--- a/src/internal/interpreter/map-interpreter.ts
+++ b/src/internal/interpreter/map-interpreter.ts
@@ -153,6 +153,7 @@ export class MapInterpreter<TInput extends NonPrimitive | undefined>
   ) {
     this.http = new HttpClient(fetchInstance);
     this.externalHandler = externalHandler ?? {};
+    console.log('used', parameters.security);
   }
 
   async perform(

--- a/src/internal/interpreter/map-interpreter.ts
+++ b/src/internal/interpreter/map-interpreter.ts
@@ -153,8 +153,6 @@ export class MapInterpreter<TInput extends NonPrimitive | undefined>
   ) {
     this.http = new HttpClient(fetchInstance);
     this.externalHandler = externalHandler ?? {};
-    //TODO: remove
-    console.log('used', parameters.security);
   }
 
   async perform(

--- a/src/internal/interpreter/map-interpreter.ts
+++ b/src/internal/interpreter/map-interpreter.ts
@@ -153,6 +153,7 @@ export class MapInterpreter<TInput extends NonPrimitive | undefined>
   ) {
     this.http = new HttpClient(fetchInstance);
     this.externalHandler = externalHandler ?? {};
+    //TODO: remove
     console.log('used', parameters.security);
   }
 

--- a/src/lib/events.test.ts
+++ b/src/lib/events.test.ts
@@ -1,7 +1,11 @@
 import {
+  ApiKeyPlacement,
   AstMetadata,
+  HttpScheme,
   MapDocumentNode,
   ProfileDocumentNode,
+  ProviderJson,
+  SecurityType,
 } from '@superfaceai/ast';
 import { getLocal } from 'mockttp';
 
@@ -129,6 +133,36 @@ const mockMapDocument: MapDocumentNode = {
   ],
 };
 
+const mockProviderJson = (name: string): ProviderJson => ({
+  name,
+  services: [{ id: 'test-service', baseUrl: 'service/base/url' }],
+  securitySchemes: [
+    {
+      type: SecurityType.HTTP,
+      id: 'basic',
+      scheme: HttpScheme.BASIC,
+    },
+    {
+      id: 'api',
+      type: SecurityType.APIKEY,
+      in: ApiKeyPlacement.HEADER,
+      name: 'Authorization',
+    },
+    {
+      id: 'bearer',
+      type: SecurityType.HTTP,
+      scheme: HttpScheme.BEARER,
+      bearerFormat: 'some',
+    },
+    {
+      id: 'digest',
+      type: SecurityType.HTTP,
+      scheme: HttpScheme.DIGEST,
+    },
+  ],
+  defaultService: 'test-service',
+});
+
 const mockServer = getLocal();
 
 describe('events', () => {
@@ -147,7 +181,7 @@ describe('events', () => {
     const profile = new BoundProfileProvider(
       mockProfileDocument,
       mockMapDocument,
-      'provider',
+      mockProviderJson('provider'),
       {
         services: ServiceSelector.withDefaultUrl(mockServer.url),
         security: [],
@@ -187,7 +221,7 @@ describe('events', () => {
     const profile = new BoundProfileProvider(
       mockProfileDocument,
       mockMapDocument,
-      'someprovider',
+      mockProviderJson('someprovider'),
       {
         services: ServiceSelector.withDefaultUrl(
           'https://unreachable.localhost'
@@ -225,7 +259,7 @@ describe('events', () => {
     const profile = new BoundProfileProvider(
       mockProfileDocument,
       mockMapDocument,
-      'provider',
+      mockProviderJson('provider'),
       {
         services: ServiceSelector.withDefaultUrl(mockServer.url),
         security: [],
@@ -255,7 +289,7 @@ describe('events', () => {
     const profile = new BoundProfileProvider(
       mockProfileDocument,
       mockMapDocument,
-      'provider',
+      mockProviderJson('provider'),
       {
         services: ServiceSelector.withDefaultUrl(mockServer.url),
         security: [],
@@ -285,7 +319,7 @@ describe('events', () => {
     const profile = new BoundProfileProvider(
       mockProfileDocument,
       mockMapDocument,
-      'provider',
+      mockProviderJson('provider'),
       {
         services: ServiceSelector.withDefaultUrl(mockServer.url),
         security: [],

--- a/src/lib/reporter.test.ts
+++ b/src/lib/reporter.test.ts
@@ -1,9 +1,13 @@
 import {
+  ApiKeyPlacement,
   AstMetadata,
   BackoffKind,
+  HttpScheme,
   MapDocumentNode,
   OnFail,
   ProfileDocumentNode,
+  ProviderJson,
+  SecurityType,
 } from '@superfaceai/ast';
 import { getLocal, MockedEndpoint } from 'mockttp';
 
@@ -231,6 +235,36 @@ const mockMapDocumentFailure: (provider?: string) => MapDocumentNode = (
   ],
 });
 
+const mockProviderJson = (name: string): ProviderJson => ({
+  name,
+  services: [{ id: 'test-service', baseUrl: 'service/base/url' }],
+  securitySchemes: [
+    {
+      type: SecurityType.HTTP,
+      id: 'basic',
+      scheme: HttpScheme.BASIC,
+    },
+    {
+      id: 'api',
+      type: SecurityType.APIKEY,
+      in: ApiKeyPlacement.HEADER,
+      name: 'Authorization',
+    },
+    {
+      id: 'bearer',
+      type: SecurityType.HTTP,
+      scheme: HttpScheme.BEARER,
+      bearerFormat: 'some',
+    },
+    {
+      id: 'digest',
+      type: SecurityType.HTTP,
+      scheme: HttpScheme.DIGEST,
+    },
+  ],
+  defaultService: 'test-service',
+});
+
 const mockServer = getLocal();
 
 describe('MetricReporter', () => {
@@ -281,7 +315,7 @@ describe('MetricReporter', () => {
     const mockBoundProfileProvider = new BoundProfileProvider(
       mockProfileDocument,
       mockMapDocumentSuccess,
-      'provider',
+      mockProviderJson('provider'),
       {
         services: ServiceSelector.withDefaultUrl(mockServer.url),
         security: [],
@@ -339,7 +373,7 @@ describe('MetricReporter', () => {
     const mockBoundProfileProvider = new BoundProfileProvider(
       mockProfileDocument,
       mockMapDocumentFailure(),
-      'testprovider',
+      mockProviderJson('testprovider'),
       {
         services: ServiceSelector.withDefaultUrl('https://unavai.lable'),
         security: [],
@@ -426,7 +460,7 @@ describe('MetricReporter', () => {
     const mockBoundProfileProvider = new BoundProfileProvider(
       mockProfileDocument,
       mockMapDocumentSuccess,
-      'provider',
+      mockProviderJson('provider'),
       {
         services: ServiceSelector.withDefaultUrl(mockServer.url),
         security: [],
@@ -461,7 +495,7 @@ describe('MetricReporter', () => {
     const mockBoundProfileProvider = new BoundProfileProvider(
       mockProfileDocument,
       mockMapDocumentSuccess,
-      'provider',
+      mockProviderJson('provider'),
       {
         services: ServiceSelector.withDefaultUrl(mockServer.url),
         security: [],
@@ -508,7 +542,7 @@ describe('MetricReporter', () => {
     const mockBoundProfileProvider = new BoundProfileProvider(
       mockProfileDocument,
       mockMapDocumentSuccess,
-      'provider',
+      mockProviderJson('provider'),
       {
         services: ServiceSelector.withDefaultUrl(mockServer.url),
         security: [],
@@ -580,7 +614,7 @@ describe('MetricReporter', () => {
     const mockBoundProfileProvider = new BoundProfileProvider(
       mockProfileDocument,
       mockMapDocumentSuccess,
-      'provider',
+      mockProviderJson('provider'),
       {
         services: ServiceSelector.withDefaultUrl(mockServer.url),
         security: [],
@@ -654,7 +688,7 @@ describe('MetricReporter', () => {
     const mockBoundProfileProvider = new BoundProfileProvider(
       mockProfileDocument,
       mockMapDocumentSuccess,
-      'testprovider',
+      mockProviderJson('testprovider'),
       {
         services: ServiceSelector.withDefaultUrl('https://unavail.able'),
         security: [],
@@ -664,7 +698,7 @@ describe('MetricReporter', () => {
     const mockBoundProfileProvider2 = new BoundProfileProvider(
       mockProfileDocument,
       mockMapDocumentFailure('testprovider2'),
-      'testprovider2',
+      mockProviderJson('testprovider2'),
       {
         services: ServiceSelector.withDefaultUrl('https://unavail.able'),
         security: [],


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->
This PR refactors passing of security through perform. It removes security from bind, now passed security is used directly in perform.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [ ] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
