### PR TITLE
refactor: Make AuthCache tied to configuration

### DIFF
--- a/src/core/client/client.internal.ts
+++ b/src/core/client/client.internal.ts
@@ -8,7 +8,7 @@ import {
 } from '../errors';
 import { Events, Interceptable } from '../events';
 import { ICrypto, IFileSystem, ILogger, ITimers } from '../interfaces';
-import { AuthCache, FetchInstance } from '../interpreter';
+import { AuthCache, IFetch } from '../interpreter';
 import { Profile, ProfileConfiguration } from '../profile';
 import { IBoundProfileProvider } from '../profile-provider';
 
@@ -24,7 +24,7 @@ export class InternalClient {
       expiresAt: number;
     }>,
     private readonly crypto: ICrypto,
-    private readonly fetchInstance: FetchInstance & Interceptable & AuthCache,
+    private readonly fetchInstance: IFetch & Interceptable & AuthCache,
     private readonly logger?: ILogger
   ) {}
 

--- a/src/core/events/events.test.ts
+++ b/src/core/events/events.test.ts
@@ -11,7 +11,7 @@ import { getLocal } from 'mockttp';
 
 import { err } from '../../lib';
 import { MockTimers } from '../../mock';
-import { CrossFetch, NodeCrypto, NodeFileSystem } from '../../node';
+import { NodeCrypto, NodeFetch, NodeFileSystem } from '../../node';
 import { Config } from '../config';
 import { BoundProfileProvider } from '../profile-provider';
 import { ServiceSelector } from '../services';
@@ -194,7 +194,7 @@ describe('events', () => {
         security: [],
       },
       crypto,
-      new CrossFetch(timers),
+      new NodeFetch(timers),
       undefined,
       events
     );
@@ -240,7 +240,7 @@ describe('events', () => {
         security: [],
       },
       crypto,
-      new CrossFetch(timers),
+      new NodeFetch(timers),
       undefined,
       events
     );
@@ -280,7 +280,7 @@ describe('events', () => {
         security: [],
       },
       crypto,
-      new CrossFetch(timers),
+      new NodeFetch(timers),
       undefined,
       events
     );
@@ -314,7 +314,7 @@ describe('events', () => {
         security: [],
       },
       crypto,
-      new CrossFetch(timers),
+      new NodeFetch(timers),
       undefined,
       events
     );
@@ -348,7 +348,7 @@ describe('events', () => {
         security: [],
       },
       crypto,
-      new CrossFetch(timers),
+      new NodeFetch(timers),
       undefined,
       events
     );

--- a/src/core/events/events.ts
+++ b/src/core/events/events.ts
@@ -6,7 +6,7 @@
 
 import { UnexpectedError } from '../errors';
 import { ILogger, ITimers, LogFunction } from '../interfaces';
-import { FetchInstance, HttpResponse, RequestParameters } from '../interpreter';
+import { HttpResponse, IFetch, RequestParameters } from '../interpreter';
 import { UseCase } from '../usecase';
 import { HooksContext } from './failure/event-adapter';
 import { MapInterpreterEventAdapter } from './failure/map-interpreter-adapter';
@@ -134,7 +134,7 @@ type EventTypes = {
     InstanceType<typeof UseCase>['performBoundUsecase'],
     PerformContext
   ];
-  fetch: [FetchInstance['fetch'], EventContextBase];
+  fetch: [IFetch['fetch'], EventContextBase];
   'unhandled-http': [
     InstanceType<typeof MapInterpreterEventAdapter>['unhandledHttp'],
     EventContextBase

--- a/src/core/events/failure/event-adapter.ts
+++ b/src/core/events/failure/event-adapter.ts
@@ -207,7 +207,7 @@ export function registerHooks(
         performContext.queuedAction = undefined;
 
         // ignore the placeholder error we produced in `handleCommonResolution`
-        await res.catch((_err: any) => undefined);
+        await res.catch(_err => undefined);
 
         switch (action.kind) {
           case 'switch-provider': {

--- a/src/core/events/reporter/reporter.ts
+++ b/src/core/events/reporter/reporter.ts
@@ -8,7 +8,7 @@ import {
   ITimers,
   LogFunction,
 } from '../../interfaces';
-import { FetchInstance, JSON_CONTENT, stringBody } from '../../interpreter';
+import { IFetch, JSON_CONTENT, stringBody } from '../../interpreter';
 import { Events, FailureContext, SuccessContext } from '../events';
 import { FailurePolicyReason } from '../failure';
 
@@ -186,7 +186,7 @@ export class MetricReporter {
     superJson: SuperJson,
     private readonly config: IConfig,
     private readonly timers: ITimers,
-    private readonly fetchInstance: FetchInstance,
+    private readonly fetchInstance: IFetch,
     logger?: ILogger
   ) {
     this.sdkToken = config.sdkAuthToken;

--- a/src/core/interpreter/http/filters.test.ts
+++ b/src/core/interpreter/http/filters.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
+import { SuperCache } from '../../../lib';
 import {
   authenticateFilter,
   bodyFilter,
@@ -23,6 +24,7 @@ import {
 describe('HTTP Filters', () => {
   const fetchInstance = {
     fetch: jest.fn().mockResolvedValue({ status: 200, body: '' }),
+    digest: new SuperCache<string>(),
   };
   const defaultResponse = {
     statusCode: 200,

--- a/src/core/interpreter/http/filters.ts
+++ b/src/core/interpreter/http/filters.ts
@@ -8,9 +8,9 @@ import {
   BINARY_CONTENT_TYPES,
   binaryBody,
   FetchBody,
-  FetchInstance,
   FORMDATA_CONTENT,
   formDataBody,
+  IFetch,
   isBinaryBody,
   isFormDataBody,
   isStringBody,
@@ -96,7 +96,7 @@ export const withResponse = (filter: FilterWithResponse): Filter => {
 };
 
 export const fetchFilter: (
-  fetchInstance: FetchInstance & AuthCache,
+  fetchInstance: IFetch & AuthCache,
   logger?: ILogger
 ) => FilterWithRequest =
   (fetchInstance, logger) =>
@@ -128,7 +128,7 @@ export const authenticateFilter: (handler?: ISecurityHandler) => Filter =
 
 // This is handling the cases when we are authenticated but eg. digest credentials expired or OAuth access token is no longer valid
 export const handleResponseFilter: (
-  fetchInstance: FetchInstance & AuthCache,
+  fetchInstance: IFetch & AuthCache,
   logger?: ILogger,
   handler?: ISecurityHandler
 ) => FilterWithResponse =

--- a/src/core/interpreter/http/http.test.ts
+++ b/src/core/interpreter/http/http.test.ts
@@ -1,5 +1,6 @@
 import { getLocal } from 'mockttp';
 
+import { SuperCache } from '../../../lib';
 import { MockTimers } from '../../../mock';
 import { NodeCrypto, NodeFetch } from '../../../node';
 import { Primitive } from '../variables';
@@ -130,6 +131,7 @@ describe('HttpClient', () => {
           httpClient = new HttpClient(
             {
               fetch: fetchMock,
+              digest: new SuperCache<string>(),
             },
             crypto
           );

--- a/src/core/interpreter/http/http.test.ts
+++ b/src/core/interpreter/http/http.test.ts
@@ -1,14 +1,14 @@
 import { getLocal } from 'mockttp';
 
 import { MockTimers } from '../../../mock';
-import { CrossFetch, NodeCrypto } from '../../../node';
+import { NodeCrypto, NodeFetch } from '../../../node';
 import { Primitive } from '../variables';
 import { HttpClient } from './http';
 import { createUrl } from './utils';
 
 const mockServer = getLocal();
 const timers = new MockTimers();
-const fetchInstance = new CrossFetch(timers);
+const fetchInstance = new NodeFetch(timers);
 const crypto = new NodeCrypto();
 const http = new HttpClient(fetchInstance, crypto);
 

--- a/src/core/interpreter/http/http.ts
+++ b/src/core/interpreter/http/http.ts
@@ -16,7 +16,7 @@ import {
   withRequest,
   withResponse,
 } from './filters';
-import { FetchInstance } from './interfaces';
+import { IFetch } from './interfaces';
 import {
   ApiKeyHandler,
   AuthCache,
@@ -34,7 +34,7 @@ export enum NetworkErrors {
 
 export class HttpClient {
   constructor(
-    private fetchInstance: FetchInstance & AuthCache,
+    private fetchInstance: IFetch & AuthCache,
     private readonly crypto: ICrypto,
     private readonly logger?: ILogger
   ) {}
@@ -90,7 +90,7 @@ export class HttpClient {
 }
 
 function createSecurityHandler(
-  fetchInstance: FetchInstance & AuthCache,
+  fetchInstance: IFetch & AuthCache,
   securityConfiguration: SecurityConfiguration[] = [],
   securityRequirements: HttpSecurityRequirement[] = [],
   crypto: ICrypto,

--- a/src/core/interpreter/http/interfaces.ts
+++ b/src/core/interpreter/http/interfaces.ts
@@ -55,7 +55,7 @@ export type FetchResponse = {
   body?: unknown;
 };
 
-export type FetchInstance = {
+export type IFetch = {
   fetch(url: string, parameters: FetchParameters): Promise<FetchResponse>;
 };
 

--- a/src/core/interpreter/http/security/interfaces.ts
+++ b/src/core/interpreter/http/security/interfaces.ts
@@ -10,6 +10,7 @@ import {
   HttpSecurityRequirement,
 } from '@superfaceai/ast';
 
+import { SuperCache } from '../../../../lib';
 import { NonPrimitive, Variables } from '../../variables';
 import { FetchParameters } from '../interfaces';
 import { HttpResponse } from '../types';
@@ -17,7 +18,7 @@ import { HttpResponse } from '../types';
 export const DEFAULT_AUTHORIZATION_HEADER_NAME = 'Authorization';
 
 export type AuthCache = {
-  digest?: string;
+  digest: SuperCache<string>;
 };
 
 /**

--- a/src/core/interpreter/http/utils.ts
+++ b/src/core/interpreter/http/utils.ts
@@ -2,7 +2,7 @@ import { recursiveKeyList } from '../../../lib';
 import { missingPathReplacementError, UnexpectedError } from '../../errors';
 import { ILogger } from '../../interfaces';
 import { getValue, NonPrimitive, variableToString } from '../variables';
-import { FetchInstance } from './interfaces';
+import { IFetch } from './interfaces';
 import { HttpRequest } from './security';
 import { HttpResponse } from './types';
 
@@ -78,7 +78,7 @@ export const createUrl = (
 };
 
 export async function fetchRequest(
-  fetchInstance: FetchInstance,
+  fetchInstance: IFetch,
   request: HttpRequest,
   logger?: ILogger
 ): Promise<HttpResponse> {

--- a/src/core/interpreter/map-interpreter.errors.test.ts
+++ b/src/core/interpreter/map-interpreter.errors.test.ts
@@ -8,7 +8,7 @@ import { parseMap, Source } from '@superfaceai/parser';
 import { getLocal } from 'mockttp';
 
 import { MockTimers } from '../../mock';
-import { CrossFetch, NodeCrypto, NodeFileSystem } from '../../node';
+import { NodeCrypto, NodeFetch, NodeFileSystem } from '../../node';
 import { Config } from '../config';
 import { UnexpectedError } from '../errors';
 import { ServiceSelector } from '../services';
@@ -25,7 +25,7 @@ const config = new Config(NodeFileSystem);
 const mockServer = getLocal();
 const timers = new MockTimers();
 const crypto = new NodeCrypto();
-const fetchInstance = new CrossFetch(timers);
+const fetchInstance = new NodeFetch(timers);
 const header: MapHeaderNode = {
   kind: 'MapHeader',
   profile: {

--- a/src/core/interpreter/map-interpreter.test.ts
+++ b/src/core/interpreter/map-interpreter.test.ts
@@ -3,14 +3,14 @@ import { parseMap, Source } from '@superfaceai/parser';
 import { getLocal } from 'mockttp';
 
 import { MockTimers } from '../../mock';
-import { CrossFetch, NodeCrypto, NodeFileSystem } from '../../node';
+import { NodeCrypto, NodeFetch, NodeFileSystem } from '../../node';
 import { Config } from '../config';
 import { ServiceSelector } from '../services';
 import { MapInterpreter } from './map-interpreter';
 
 const mockServer = getLocal();
 const timers = new MockTimers();
-const fetchInstance = new CrossFetch(timers);
+const fetchInstance = new NodeFetch(timers);
 const config = new Config(NodeFileSystem);
 const crypto = new NodeCrypto();
 

--- a/src/core/interpreter/map-interpreter.ts
+++ b/src/core/interpreter/map-interpreter.ts
@@ -36,7 +36,7 @@ import {
   HttpResponse,
   SecurityConfiguration,
 } from './http';
-import { FetchInstance } from './http/interfaces';
+import { IFetch } from './http/interfaces';
 import {
   HTTPError,
   JessieError,
@@ -153,7 +153,7 @@ export class MapInterpreter<TInput extends NonPrimitive | undefined>
       logger,
       crypto,
     }: {
-      fetchInstance: FetchInstance & AuthCache;
+      fetchInstance: IFetch & AuthCache;
       externalHandler?: MapInterpreterExternalHandler;
       config: IConfig;
       crypto: ICrypto;

--- a/src/core/profile-provider/bound-profile-provider.test.ts
+++ b/src/core/profile-provider/bound-profile-provider.test.ts
@@ -11,7 +11,7 @@ import {
 
 import { err, ok } from '../../lib';
 import { MockTimers } from '../../mock';
-import { CrossFetch, NodeCrypto, NodeFileSystem } from '../../node';
+import { NodeCrypto, NodeFetch, NodeFileSystem } from '../../node';
 import { Config } from '../config';
 import {
   InputValidationError,
@@ -131,7 +131,7 @@ describe('BoundProfileProvider', () => {
           security: [],
         },
         crypto,
-        new CrossFetch(timers)
+        new NodeFetch(timers)
       );
 
       await expect(
@@ -183,7 +183,7 @@ describe('BoundProfileProvider', () => {
           ],
         },
         crypto,
-        new CrossFetch(timers)
+        new NodeFetch(timers)
       );
 
       await expect(
@@ -239,7 +239,7 @@ describe('BoundProfileProvider', () => {
           security: [],
         },
         crypto,
-        new CrossFetch(timers)
+        new NodeFetch(timers)
       );
 
       await expect(
@@ -275,7 +275,7 @@ describe('BoundProfileProvider', () => {
           security: [],
         },
         crypto,
-        new CrossFetch(timers)
+        new NodeFetch(timers)
       );
 
       await expect(
@@ -326,7 +326,7 @@ describe('BoundProfileProvider', () => {
           },
         },
         crypto,
-        new CrossFetch(timers)
+        new NodeFetch(timers)
       );
       await expect(
         mockBoundProfileProvider.perform<undefined, string>('test')

--- a/src/core/profile-provider/bound-profile-provider.ts
+++ b/src/core/profile-provider/bound-profile-provider.ts
@@ -12,7 +12,7 @@ import { IConfig, ICrypto, ILogger, LogFunction } from '../interfaces';
 import {
   AuthCache,
   castToNonPrimitive,
-  FetchInstance,
+  IFetch,
   MapInterpreter,
   MapInterpreterError,
   mergeVariables,
@@ -55,7 +55,7 @@ export class BoundProfileProvider implements IBoundProfileProvider {
       parameters?: Record<string, string>;
     },
     private readonly crypto: ICrypto,
-    private readonly fetchInstance: FetchInstance & Interceptable & AuthCache,
+    private readonly fetchInstance: IFetch & Interceptable & AuthCache,
     private readonly logger?: ILogger,
     events?: Events
   ) {

--- a/src/core/profile-provider/profile-provider.test.ts
+++ b/src/core/profile-provider/profile-provider.test.ts
@@ -12,7 +12,7 @@ import { mocked } from 'ts-jest/utils';
 
 import { err, ok } from '../../lib';
 import { MockFileSystem, MockTimers } from '../../mock';
-import { CrossFetch, NodeCrypto, NodeFileSystem } from '../../node';
+import { NodeCrypto, NodeFetch, NodeFileSystem } from '../../node';
 import { SuperJson } from '../../schema-tools';
 import * as SuperJsonMutate from '../../schema-tools/superjson/mutate';
 import { Config } from '../config';
@@ -270,7 +270,7 @@ describe('profile provider', () => {
           new Events(timers),
           fileSystem,
           crypto,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         );
 
         const result = await mockProfileProvider.bind();
@@ -309,7 +309,7 @@ describe('profile provider', () => {
           new Events(timers),
           fileSystem,
           crypto,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         );
 
         const result = await mockProfileProvider.bind();
@@ -347,7 +347,7 @@ describe('profile provider', () => {
           new Events(timers),
           fileSystem,
           crypto,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         );
 
         const result = await mockProfileProvider.bind();
@@ -383,7 +383,7 @@ describe('profile provider', () => {
           new Events(timers),
           fileSystem,
           crypto,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         );
 
         const result = await mockProfileProvider.bind();
@@ -431,7 +431,7 @@ describe('profile provider', () => {
           new Events(timers),
           fileSystem,
           crypto,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         );
 
         const result = await mockProfileProvider.bind();
@@ -476,7 +476,7 @@ describe('profile provider', () => {
           new Events(timers),
           fileSystem,
           crypto,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         );
 
         const result = await mockProfileProvider.bind();
@@ -519,7 +519,7 @@ describe('profile provider', () => {
           new Events(timers),
           fileSystem,
           crypto,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         );
 
         const result = await mockProfileProvider.bind();
@@ -553,7 +553,7 @@ describe('profile provider', () => {
           new Events(timers),
           fileSystem,
           crypto,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         );
         await expect(mockProfileProvider.bind()).rejects.toThrow(
           'Hint: Profiles can be installed using the superface cli tool: `superface install --help` for more info'
@@ -596,7 +596,7 @@ describe('profile provider', () => {
           new Events(timers),
           fileSystem,
           crypto,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         );
         const result = await mockProfileProvider.bind();
 
@@ -646,7 +646,7 @@ describe('profile provider', () => {
           new Events(timers),
           fileSystem,
           crypto,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         );
         const result = await mockProfileProvider.bind();
 
@@ -691,7 +691,7 @@ describe('profile provider', () => {
           new Events(timers),
           fileSystem,
           crypto,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         );
 
         await expect(() => mockProfileProvider.bind()).rejects.toMatchObject({
@@ -733,7 +733,7 @@ describe('profile provider', () => {
           new Events(timers),
           fileSystem,
           crypto,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         );
 
         await expect(() => mockProfileProvider.bind()).rejects.toThrow(
@@ -775,7 +775,7 @@ describe('profile provider', () => {
           new Events(timers),
           fileSystem,
           crypto,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         );
         const result = await mockProfileProvider.bind();
 
@@ -828,7 +828,7 @@ describe('profile provider', () => {
           new Events(timers),
           fileSystem,
           crypto,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         );
 
         const result = await mockProfileProvider.bind({ security: [] });
@@ -870,7 +870,7 @@ describe('profile provider', () => {
           new Events(timers),
           fileSystem,
           crypto,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         );
 
         await expect(mockProfileProvider.bind()).rejects.toThrow(
@@ -912,7 +912,7 @@ but a secret value was provided for security scheme: made-up-id`
           new Events(timers),
           fileSystem,
           crypto,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         );
 
         await expect(mockProfileProvider.bind()).rejects.toThrow(
@@ -954,7 +954,7 @@ but apiKey scheme requires: apikey`
           new Events(timers),
           fileSystem,
           crypto,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         );
 
         await expect(mockProfileProvider.bind()).rejects.toThrow(
@@ -996,7 +996,7 @@ but http scheme requires: username, password`
           new Events(timers),
           fileSystem,
           crypto,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         );
 
         await expect(mockProfileProvider.bind()).rejects.toThrow(
@@ -1038,7 +1038,7 @@ but http scheme requires: token`
           new Events(timers),
           fileSystem,
           crypto,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         );
 
         await expect(mockProfileProvider.bind()).rejects.toThrow(
@@ -1088,7 +1088,7 @@ but http scheme requires: digest`
           new Events(timers),
           fileSystem,
           crypto,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         );
 
         await expect(mockProfileProvider.bind()).rejects.toThrow(
@@ -1153,7 +1153,7 @@ but http scheme requires: digest`
           new Events(timers),
           fileSystem,
           crypto,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         );
 
         await expect(mockProfileProvider.bind()).rejects.toThrow(

--- a/src/core/profile-provider/profile-provider.ts
+++ b/src/core/profile-provider/profile-provider.ts
@@ -31,7 +31,7 @@ import {
   ITimers,
   LogFunction,
 } from '../interfaces';
-import { AuthCache, FetchInstance } from '../interpreter';
+import { AuthCache, IFetch } from '../interpreter';
 import { Parser } from '../parser';
 import { ProfileConfiguration } from '../profile/profile-configuration';
 import { ProviderConfiguration } from '../provider';
@@ -54,7 +54,7 @@ export async function bindProfileProvider(
   timers: ITimers,
   fileSystem: IFileSystem,
   crypto: ICrypto,
-  fetchInstance: FetchInstance & Interceptable & AuthCache,
+  fetchInstance: IFetch & Interceptable & AuthCache,
   logger?: ILogger
 ): Promise<{ provider: IBoundProfileProvider; expiresAt: number }> {
   const profileProvider = new ProfileProvider(
@@ -99,7 +99,7 @@ export class ProfileProvider {
     private events: Events,
     private readonly fileSystem: IFileSystem,
     private readonly crypto: ICrypto,
-    private readonly fetchInstance: FetchInstance & Interceptable & AuthCache,
+    private readonly fetchInstance: IFetch & Interceptable & AuthCache,
     private readonly logger?: ILogger,
     /** url or ast node */
     private map?: string | MapDocumentNode

--- a/src/core/profile/profile.test.ts
+++ b/src/core/profile/profile.test.ts
@@ -2,7 +2,7 @@ import { SuperJsonDocument } from '@superfaceai/ast';
 
 import { SuperCache } from '../../lib';
 import { MockTimers } from '../../mock';
-import { CrossFetch, NodeCrypto, NodeFileSystem } from '../../node';
+import { NodeCrypto, NodeFetch, NodeFileSystem } from '../../node';
 import { SuperJson } from '../../schema-tools';
 import { Config } from '../config';
 import { Events } from '../events';
@@ -31,7 +31,7 @@ function createProfile(superJson: SuperJsonDocument): Profile {
     NodeFileSystem,
     cache,
     crypto,
-    new CrossFetch(timers)
+    new NodeFetch(timers)
   );
 }
 

--- a/src/core/profile/profile.ts
+++ b/src/core/profile/profile.ts
@@ -2,7 +2,7 @@ import { SuperCache } from '../../lib';
 import { SuperJson } from '../../schema-tools';
 import { Events, Interceptable } from '../events';
 import { IConfig, ICrypto, IFileSystem, ILogger, ITimers } from '../interfaces';
-import { AuthCache, FetchInstance } from '../interpreter';
+import { AuthCache, IFetch } from '../interpreter';
 import { IBoundProfileProvider } from '../profile-provider';
 import { UseCase } from '../usecase';
 import { ProfileConfiguration } from './profile-configuration';
@@ -20,7 +20,7 @@ export abstract class ProfileBase {
       expiresAt: number;
     }>,
     protected readonly crypto: ICrypto,
-    protected readonly fetchInstance: FetchInstance & Interceptable & AuthCache,
+    protected readonly fetchInstance: IFetch & Interceptable & AuthCache,
     protected readonly logger?: ILogger
   ) {}
 

--- a/src/core/profile/profile.typed.test.ts
+++ b/src/core/profile/profile.typed.test.ts
@@ -1,6 +1,6 @@
 import { SuperCache } from '../../lib';
 import { MockFileSystem, MockTimers } from '../../mock';
-import { CrossFetch, NodeCrypto, NodeFileSystem } from '../../node';
+import { NodeCrypto, NodeFetch, NodeFileSystem } from '../../node';
 import { SuperJson } from '../../schema-tools';
 import { Config } from '../config';
 import { Events } from '../events';
@@ -42,7 +42,7 @@ describe('TypedProfile', () => {
         timers,
         fileSystem,
         crypto,
-        new CrossFetch(timers),
+        new NodeFetch(timers),
         ['sayHello']
       );
 
@@ -57,7 +57,7 @@ describe('TypedProfile', () => {
           fileSystem,
           crypto,
           cache,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         )
       );
     });
@@ -72,7 +72,7 @@ describe('TypedProfile', () => {
         timers,
         fileSystem,
         crypto,
-        new CrossFetch(timers),
+        new NodeFetch(timers),
         ['sayHello']
       );
 

--- a/src/core/profile/profile.typed.ts
+++ b/src/core/profile/profile.typed.ts
@@ -3,7 +3,7 @@ import { SuperJson } from '../../schema-tools';
 import { UnexpectedError, usecaseNotFoundError } from '../errors';
 import { Events, Interceptable } from '../events';
 import { IConfig, ICrypto, IFileSystem, ILogger, ITimers } from '../interfaces';
-import { AuthCache, FetchInstance, NonPrimitive } from '../interpreter';
+import { AuthCache, IFetch, NonPrimitive } from '../interpreter';
 import { IBoundProfileProvider } from '../profile-provider';
 import { TypedUseCase } from '../usecase';
 import { ProfileBase } from './profile';
@@ -40,7 +40,7 @@ export class TypedProfile<
     protected override readonly timers: ITimers,
     protected override readonly fileSystem: IFileSystem,
     protected override readonly crypto: ICrypto,
-    protected override readonly fetchInstance: FetchInstance &
+    protected override readonly fetchInstance: IFetch &
       Interceptable &
       AuthCache,
     usecases: (keyof TUsecaseTypes)[],

--- a/src/core/registry/registry.test.ts
+++ b/src/core/registry/registry.test.ts
@@ -6,7 +6,7 @@ import {
 } from '@superfaceai/ast';
 
 import { MockTimers } from '../../mock';
-import { CrossFetch, NodeCrypto, NodeFileSystem } from '../../node';
+import { NodeCrypto, NodeFetch, NodeFileSystem } from '../../node';
 import { Config } from '../config';
 import {
   bindResponseError,
@@ -152,7 +152,7 @@ describe('registry', () => {
       request.mockResolvedValue(mockResponse);
 
       await expect(
-        fetchProviderInfo('test', config, crypto, new CrossFetch(timers))
+        fetchProviderInfo('test', config, crypto, new NodeFetch(timers))
       ).resolves.toEqual(mockProviderJson);
 
       expect(request).toHaveBeenCalledTimes(1);
@@ -182,7 +182,7 @@ describe('registry', () => {
       request.mockResolvedValue(mockResponse);
 
       await expect(
-        fetchProviderInfo('test', config, crypto, new CrossFetch(timers))
+        fetchProviderInfo('test', config, crypto, new NodeFetch(timers))
       ).rejects.toEqual(
         unknownProviderInfoError({
           message: 'Registry responded with invalid body',
@@ -213,7 +213,7 @@ describe('registry', () => {
       request.mockResolvedValue(mockResponse);
 
       await expect(
-        fetchProviderInfo('test', config, crypto, new CrossFetch(timers))
+        fetchProviderInfo('test', config, crypto, new NodeFetch(timers))
       ).rejects.toEqual(
         unknownProviderInfoError({
           message: 'Registry responded with invalid ProviderJson definition',
@@ -266,7 +266,7 @@ describe('registry', () => {
           },
           config,
           crypto,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         )
       ).resolves.toEqual({
         provider: mockProviderJson,
@@ -319,7 +319,7 @@ describe('registry', () => {
           },
           config,
           crypto,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         )
       ).resolves.toEqual({
         provider: mockProviderJson,
@@ -372,7 +372,7 @@ describe('registry', () => {
           },
           config,
           crypto,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         )
       ).rejects.toThrow(
         invalidProviderResponseError(
@@ -413,7 +413,7 @@ describe('registry', () => {
           },
           config,
           crypto,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         )
       ).rejects.toEqual(
         unknownBindResponseError({
@@ -457,7 +457,7 @@ describe('registry', () => {
           },
           config,
           crypto,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         )
       ).rejects.toEqual(
         unknownBindResponseError({
@@ -504,7 +504,7 @@ describe('registry', () => {
           },
           config,
           crypto,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         )
       ).rejects.toEqual(
         bindResponseError({
@@ -552,7 +552,7 @@ describe('registry', () => {
           },
           config,
           crypto,
-          new CrossFetch(timers)
+          new NodeFetch(timers)
         )
       ).resolves.toEqual({
         provider: mockProviderJson,
@@ -590,7 +590,7 @@ describe('registry', () => {
 
       const mapId = 'test-profile-id.test-provider.test-map-variant@1.0.0';
       await expect(
-        fetchMapSource(mapId, config, crypto, new CrossFetch(timers))
+        fetchMapSource(mapId, config, crypto, new NodeFetch(timers))
       ).resolves.toEqual(mockMapSOurce);
 
       expect(request).toHaveBeenCalledTimes(1);
@@ -620,7 +620,7 @@ describe('registry', () => {
 
       const mapId = 'test-profile-id.test-provider@1.0.0';
       await expect(
-        fetchMapSource(mapId, config, crypto, new CrossFetch(timers))
+        fetchMapSource(mapId, config, crypto, new NodeFetch(timers))
       ).resolves.toEqual(mockMapSource);
 
       expect(request).toHaveBeenCalledTimes(1);

--- a/src/core/registry/registry.ts
+++ b/src/core/registry/registry.ts
@@ -14,7 +14,7 @@ import {
   unknownProviderInfoError,
 } from '../errors';
 import { IConfig, ICrypto, ILogger } from '../interfaces';
-import { FetchInstance, HttpClient, HttpResponse } from '../interpreter';
+import { AuthCache, HttpClient, HttpResponse, IFetch } from '../interpreter';
 
 const DEBUG_NAMESPACE = 'registry';
 
@@ -69,7 +69,7 @@ export async function fetchProviderInfo(
   providerName: string,
   config: IConfig,
   crypto: ICrypto,
-  fetchInstance: FetchInstance,
+  fetchInstance: IFetch & AuthCache,
   logger?: ILogger
 ): Promise<ProviderJson> {
   const http = new HttpClient(fetchInstance, crypto, logger);
@@ -213,7 +213,7 @@ export async function fetchBind(
   },
   config: IConfig,
   crypto: ICrypto,
-  fetchInstance: FetchInstance,
+  fetchInstance: IFetch & AuthCache,
   logger?: ILogger
 ): Promise<{
   provider: ProviderJson;
@@ -250,7 +250,7 @@ export async function fetchMapSource(
   mapId: string,
   config: IConfig,
   crypto: ICrypto,
-  fetchInstance: FetchInstance,
+  fetchInstance: IFetch & AuthCache,
   logger?: ILogger
 ): Promise<string> {
   const http = new HttpClient(fetchInstance, crypto, logger);

--- a/src/core/usecase/usecase.test.ts
+++ b/src/core/usecase/usecase.test.ts
@@ -1,6 +1,6 @@
 import { SuperCache } from '../../lib';
 import { MockFileSystem, MockTimers } from '../../mock';
-import { CrossFetch, NodeCrypto, NodeFileSystem } from '../../node';
+import { NodeCrypto, NodeFetch, NodeFileSystem } from '../../node';
 import { SuperJson } from '../../schema-tools';
 import * as utils from '../../schema-tools/superjson/utils';
 import { Config } from '../config';
@@ -77,7 +77,7 @@ function createUseCase(cacheExpire?: number) {
     filesystem,
     crypto,
     cache,
-    new CrossFetch(timers)
+    new NodeFetch(timers)
   );
 
   return {

--- a/src/core/usecase/usecase.ts
+++ b/src/core/usecase/usecase.ts
@@ -32,7 +32,7 @@ import {
 } from '../interfaces';
 import {
   AuthCache,
-  FetchInstance,
+  IFetch,
   MapInterpreterError,
   NonPrimitive,
   ProfileParameterError,
@@ -80,7 +80,7 @@ export abstract class UseCaseBase implements Interceptable {
       provider: IBoundProfileProvider;
       expiresAt: number;
     }>,
-    private readonly fetchInstance: FetchInstance & Interceptable & AuthCache,
+    private readonly fetchInstance: IFetch & Interceptable & AuthCache,
     private readonly logger?: ILogger
   ) {
     this.metadata = {

--- a/src/mock/client.ts
+++ b/src/mock/client.ts
@@ -28,7 +28,7 @@ import {
   ServiceSelector,
 } from '../core';
 import { SuperCache } from '../lib/cache';
-import { CrossFetch, NodeCrypto, NodeFileSystem, NodeLogger } from '../node';
+import { NodeCrypto, NodeFetch, NodeFileSystem, NodeLogger } from '../node';
 import { getProvider, getProviderForProfile, SuperJson } from '../schema-tools';
 import { MockEnvironment } from './environment';
 import { MockFileSystem } from './filesystem';
@@ -86,7 +86,7 @@ export class MockClient implements ISuperfaceClient {
         this.superJson,
         this.config,
         this.timers,
-        new CrossFetch(this.timers),
+        new NodeFetch(this.timers),
         this.logger
       );
       hookMetrics(this.events, this.metricReporter);
@@ -114,7 +114,7 @@ export class MockClient implements ISuperfaceClient {
       fileSystem,
       this.cache,
       this.crypto,
-      new CrossFetch(this.timers),
+      new NodeFetch(this.timers),
       this.logger
     );
   }
@@ -143,7 +143,7 @@ export class MockClient implements ISuperfaceClient {
         security: securityValues,
       },
       this.crypto,
-      new CrossFetch(this.timers),
+      new NodeFetch(this.timers),
       this.logger,
       this.events
     );

--- a/src/node/client/client.ts
+++ b/src/node/client/client.ts
@@ -4,12 +4,12 @@ import {
   AuthCache,
   Config,
   Events,
-  FetchInstance,
   hookMetrics,
   IBoundProfileProvider,
   IConfig,
   ICrypto,
   IEnvironment,
+  IFetch,
   ILogger,
   Interceptable,
   InternalClient,
@@ -29,7 +29,7 @@ import {
 } from '../../schema-tools';
 import { NodeCrypto } from '../crypto';
 import { NodeEnvironment } from '../environment';
-import { CrossFetch } from '../fetch';
+import { NodeFetch } from '../fetch';
 import { NodeFileSystem } from '../filesystem';
 import { NodeLogger } from '../logger';
 import { NodeTimers } from '../timers';
@@ -69,7 +69,7 @@ const setupMetricReporter = (
     superJson,
     config,
     timers,
-    new CrossFetch(timers),
+    new NodeFetch(timers),
     logger
   );
   hookMetrics(events, metricReporter);
@@ -97,7 +97,7 @@ export abstract class SuperfaceClientBase {
   protected readonly config: Config;
   protected readonly timers: ITimers;
   protected readonly crypto: ICrypto;
-  protected readonly fetchInstance: FetchInstance & Interceptable & AuthCache;
+  protected readonly fetchInstance: IFetch & Interceptable & AuthCache;
   protected readonly logger?: ILogger;
 
   constructor(options?: { superJson?: SuperJson | SuperJsonDocument }) {
@@ -106,7 +106,7 @@ export abstract class SuperfaceClientBase {
     this.timers = new NodeTimers();
     this.logger = new NodeLogger();
     this.events = new Events(this.timers, this.logger);
-    this.fetchInstance = new CrossFetch(this.timers);
+    this.fetchInstance = new NodeFetch(this.timers);
     this.config = loadConfigFromEnv(environment, NodeFileSystem, this.logger);
 
     this.boundProfileProviderCache = new SuperCache<{

--- a/src/node/fetch/fetch.node.test.ts
+++ b/src/node/fetch/fetch.node.test.ts
@@ -23,11 +23,11 @@ describe('fetch', () => {
 
   describe('timeout', () => {
     it('timeouts on network timeout', async () => {
-      const { CrossFetch } = await import('./fetch.node');
+      const { NodeFetch } = await import('./fetch.node');
 
       await mockServer.get('/test').thenTimeout();
       const realTimers = new NodeTimers();
-      const fetch = new CrossFetch(realTimers);
+      const fetch = new NodeFetch(realTimers);
 
       await expect(
         fetch.fetch(`${mockServer.url}/test`, { method: 'GET', timeout: 2000 })
@@ -35,10 +35,10 @@ describe('fetch', () => {
     });
 
     it('rejects on rejected connection', async () => {
-      const { CrossFetch } = await import('./fetch.node');
+      const { NodeFetch } = await import('./fetch.node');
 
       await mockServer.get('/test').thenCloseConnection();
-      const fetch = new CrossFetch(timers);
+      const fetch = new NodeFetch(timers);
 
       await expect(
         fetch.fetch(`${mockServer.url}/test`, { method: 'GET', timeout: 2000 })
@@ -46,14 +46,14 @@ describe('fetch', () => {
     });
 
     it('rethrows error if it is string', async () => {
-      const { CrossFetch } = await import('./fetch.node');
+      const { NodeFetch } = await import('./fetch.node');
 
       // We are mocking node-fetch
       const { fetch } = await import('cross-fetch');
       jest.mock('cross-fetch');
       mocked(fetch).mockRejectedValue('something-bad');
 
-      const fetchInstance = new CrossFetch(timers);
+      const fetchInstance = new NodeFetch(timers);
 
       await expect(
         fetchInstance.fetch(`${mockServer.url}/test`, {
@@ -64,14 +64,14 @@ describe('fetch', () => {
     });
 
     it('rethrows error if it does not contain type property', async () => {
-      const { CrossFetch } = await import('./fetch.node');
+      const { NodeFetch } = await import('./fetch.node');
 
       // We are mocking node-fetch
       const { fetch } = await import('cross-fetch');
       jest.mock('cross-fetch');
       mocked(fetch).mockRejectedValue({ some: 'something-bad' });
 
-      const fetchInstance = new CrossFetch(timers);
+      const fetchInstance = new NodeFetch(timers);
 
       await expect(
         fetchInstance.fetch(`${mockServer.url}/test`, {
@@ -82,14 +82,14 @@ describe('fetch', () => {
     });
 
     it('throws request abort if error does not get recognized', async () => {
-      const { CrossFetch } = await import('./fetch.node');
+      const { NodeFetch } = await import('./fetch.node');
 
       // We are mocking node-fetch
       const { fetch } = await import('cross-fetch');
       jest.mock('cross-fetch');
       mocked(fetch).mockRejectedValue({ type: 'something-bad' });
 
-      const fetchInstance = new CrossFetch(timers);
+      const fetchInstance = new NodeFetch(timers);
 
       await expect(
         fetchInstance.fetch(`${mockServer.url}/test`, {
@@ -100,7 +100,7 @@ describe('fetch', () => {
     });
 
     it('throws on dns ENOTFOUND', async () => {
-      const { CrossFetch } = await import('./fetch.node');
+      const { NodeFetch } = await import('./fetch.node');
 
       // We are mocking node-fetch
       const { fetch } = await import('cross-fetch');
@@ -111,7 +111,7 @@ describe('fetch', () => {
         errno: '',
       });
 
-      const fetchInstance = new CrossFetch(timers);
+      const fetchInstance = new NodeFetch(timers);
 
       await expect(
         fetchInstance.fetch(`${mockServer.url}/test`, {
@@ -122,7 +122,7 @@ describe('fetch', () => {
     });
 
     it('throws on dns EAI_AGAIN', async () => {
-      const { CrossFetch } = await import('./fetch.node');
+      const { NodeFetch } = await import('./fetch.node');
 
       // We are mocking node-fetch
       const { fetch } = await import('cross-fetch');
@@ -133,7 +133,7 @@ describe('fetch', () => {
         errno: '',
       });
 
-      const fetchInstance = new CrossFetch(timers);
+      const fetchInstance = new NodeFetch(timers);
 
       await expect(
         fetchInstance.fetch(`${mockServer.url}/test`, {
@@ -166,9 +166,9 @@ describe('fetch', () => {
         json: responseJsonMock,
       } as any);
 
-      const { CrossFetch } = await import('./fetch.node');
+      const { NodeFetch } = await import('./fetch.node');
 
-      const fetchInstance = new CrossFetch(timers);
+      const fetchInstance = new NodeFetch(timers);
 
       result = await fetchInstance.fetch(`${mockServer.url}/test`, {
         method: 'GET',
@@ -207,9 +207,9 @@ describe('fetch', () => {
         text: responseTextMock,
       } as any);
 
-      const { CrossFetch } = await import('./fetch.node');
+      const { NodeFetch } = await import('./fetch.node');
 
-      const fetchInstance = new CrossFetch(timers);
+      const fetchInstance = new NodeFetch(timers);
 
       result = await fetchInstance.fetch(`${mockServer.url}/test`, {
         method: 'GET',
@@ -258,9 +258,9 @@ describe('fetch', () => {
             arrayBuffer: responseArrayBufferMock,
           } as any);
 
-          const { CrossFetch } = await import('./fetch.node');
+          const { NodeFetch } = await import('./fetch.node');
 
-          const fetchInstance = new CrossFetch(timers);
+          const fetchInstance = new NodeFetch(timers);
 
           result = await fetchInstance.fetch(`${mockServer.url}/test`, {
             method: 'GET',
@@ -304,9 +304,9 @@ describe('fetch', () => {
       let result: any;
 
       beforeEach(async () => {
-        const { CrossFetch } = await import('./fetch.node');
+        const { NodeFetch } = await import('./fetch.node');
 
-        const fetchInstance = new CrossFetch(timers);
+        const fetchInstance = new NodeFetch(timers);
 
         result = await fetchInstance.fetch(`${mockServer.url}/test`, {
           method: 'GET',
@@ -329,9 +329,9 @@ describe('fetch', () => {
       let result: any;
 
       beforeEach(async () => {
-        const { CrossFetch } = await import('./fetch.node');
+        const { NodeFetch } = await import('./fetch.node');
 
-        const fetchInstance = new CrossFetch(timers);
+        const fetchInstance = new NodeFetch(timers);
 
         result = await fetchInstance.fetch(`${mockServer.url}/test`, {
           method: 'GET',
@@ -356,7 +356,7 @@ describe('fetch', () => {
       const { fetch } = await import('cross-fetch');
       jest.mock('cross-fetch');
 
-      const { CrossFetch } = await import('./fetch.node');
+      const { NodeFetch } = await import('./fetch.node');
 
       mocked(fetch).mockResolvedValue({
         headers: {
@@ -367,7 +367,7 @@ describe('fetch', () => {
         text: jest.fn(),
       } as any);
 
-      const fetchInstance = new CrossFetch(timers);
+      const fetchInstance = new NodeFetch(timers);
 
       await fetchInstance.fetch(`${mockServer.url}/test`, {
         method: 'POST',

--- a/src/node/fetch/fetch.node.ts
+++ b/src/node/fetch/fetch.node.ts
@@ -4,13 +4,14 @@ import { AbortController } from 'abort-controller';
 import fetch, { Headers } from 'cross-fetch';
 
 import {
+  AuthCache,
   BINARY_CONTENT_REGEXP,
   CrossFetchError,
   Events,
   FetchBody,
-  FetchInstance,
   FetchParameters,
   FetchResponse,
+  IFetch,
   Interceptable,
   InterceptableMetadata,
   isBinaryBody,
@@ -24,10 +25,12 @@ import {
   RequestFetchError,
 } from '../../core';
 import { eventInterceptor } from '../../core/events/events';
+import { SuperCache } from '../../lib';
 
-export class CrossFetch implements FetchInstance, Interceptable {
+export class NodeFetch implements IFetch, Interceptable, AuthCache {
   public metadata: InterceptableMetadata | undefined;
   public events: Events | undefined;
+  public digest: SuperCache<string> = new SuperCache();
 
   constructor(private readonly timers: ITimers) {}
 
@@ -102,7 +105,7 @@ export class CrossFetch implements FetchInstance, Interceptable {
     try {
       return await fetch(url, options);
     } catch (err: unknown) {
-      throw CrossFetch.normalizeError(err);
+      throw NodeFetch.normalizeError(err);
     } finally {
       if (timeoutHandle !== undefined) {
         this.timers.clearTimeout(timeoutHandle);


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
Makes AuthCache tied to specific digest values

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
During refactor, FetchInstance was moved up and therefore it's not instantiated for each Provider 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [x] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
