### PR TITLE
feat: early remote profile resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pass `cache` flag to SuperfaceClient constructor
 - Pass `debug` flag to SuperfaceClient constructor
 - Pass `mapVariant` and `mapRevision` values in `perform`
+- **BREAKING CHANGE**: .supr files are no longer allowed
 
 ## [1.5.2] - 2022-06-15
 ### Fixed

--- a/src/core/client/client.internal.ts
+++ b/src/core/client/client.internal.ts
@@ -12,8 +12,9 @@ import {
   profileFileNotFoundError,
   profileNotFoundError,
   profileNotInstalledError,
-  SDKExecutionError,
+  sourceFileExtensionFoundError,
   unconfiguredProviderInPriorityError,
+  unsupportedFileExtensionError,
 } from '../errors';
 import { Events, Interceptable } from '../events';
 import { ICrypto, IFileSystem, ILogger, ITimers } from '../interfaces';
@@ -81,23 +82,11 @@ export class InternalClient {
       logFunction?.('Reading possible profile file: %S', filepath);
       // check extensions
       if (filepath.endsWith(EXTENSIONS.profile.source)) {
-        // TODO: add to error helpers?
         // FIX:  SDKExecutionError is used to ensure correct formatting. Improve formatting of UnexpectedError
-        throw new SDKExecutionError(
-          `${EXTENSIONS.profile.source} extension found.`,
-          [],
-          [
-            `${EXTENSIONS.profile.source} files needs to be compiled with Superface CLI.`,
-          ]
-        );
+        throw sourceFileExtensionFoundError(EXTENSIONS.profile.source);
       } else if (!filepath.endsWith(EXTENSIONS.profile.build)) {
-        // TODO: add to error helperss?
         // FIX:  SDKExecutionError is used to ensure correct formatting. Improve formatting of UnexpectedError
-        throw new SDKExecutionError(
-          `File paths ${filepath} contains unsupported extension.`,
-          [],
-          [`Use file with ${EXTENSIONS.profile.build} extension.`]
-        );
+        throw unsupportedFileExtensionError(filepath, EXTENSIONS.profile.build);
       }
 
       return await loadProfileAstFile(filepath);

--- a/src/core/client/client.internal.ts
+++ b/src/core/client/client.internal.ts
@@ -91,20 +91,22 @@ export class InternalClient {
 
       return await loadProfileAstFile(filepath);
     }
-    // assumed to be in grid folder
-    // TODO: look in other place (.cache) use config.cachePath?
-    // FIX: super.json path - when we use in code super.json it is resolving path incorrectly
-    filepath = this.superJson.resolvePath(
-      this.fileSystem.path.join(
-        'grid',
-        `${profileId}@${profileSettings.version}`
-      )
+    // assumed to be in grid folder under superface directory
+    const gridPath = this.fileSystem.path.join(
+      'grid',
+      `${profileId}@${profileSettings.version}`
     );
+    const superfaceFolderPath = this.fileSystem.path.dirname(
+      this.config.superfacePath
+    );
+
+    filepath =
+      this.fileSystem.path.resolve(superfaceFolderPath, gridPath) +
+      EXTENSIONS.profile.build;
 
     logFunction?.('Reading possible profile file: %S', filepath);
     try {
-      // TODO: cache this somewhere (in memory)?
-      return await loadProfileAstFile(filepath + EXTENSIONS.profile.build);
+      return await loadProfileAstFile(filepath);
     } catch (error) {
       logFunction?.(
         'Reading of possible profile file failed with error %O',
@@ -116,7 +118,6 @@ export class InternalClient {
     logFunction?.('Fetching profile file from registry');
 
     // Fallback to remote
-    // TODO: cache this somewhere (similar to CLI - .cache, config.cachePath, in memory)?
     return fetchProfileAst(
       `${profileId}@${profileSettings.version}`,
       this.config,

--- a/src/core/client/client.internal.ts
+++ b/src/core/client/client.internal.ts
@@ -34,7 +34,7 @@ export class InternalClient {
     private readonly crypto: ICrypto,
     private readonly fetchInstance: FetchInstance & Interceptable & AuthCache,
     private readonly logger?: ILogger
-  ) { }
+  ) {}
 
   /**
    * Resolves profile AST file.

--- a/src/core/client/client.internal.ts
+++ b/src/core/client/client.internal.ts
@@ -1,4 +1,5 @@
 import { ProfileDocumentNode } from '@superfaceai/ast';
+
 import { SuperCache } from '../../lib';
 import { SuperJson } from '../../schema-tools';
 import { Config } from '../config';
@@ -29,21 +30,24 @@ export class InternalClient {
     private readonly crypto: ICrypto,
     private readonly fetchInstance: FetchInstance & Interceptable & AuthCache,
     private readonly logger?: ILogger
-  ) { }
+  ) {}
 
-  //TODO: Move to SuperfaceClientBase? 
-  //TODO: Fetch AST directly?
-  //TODO: Fallback to the grid?
-  //TODO: Try to load it from cache?
+  // TODO: Move to SuperfaceClientBase?
+  // TODO: Fetch AST directly?
+  // TODO: Fallback to the grid?
+  // TODO: Try to load it from cache?
   public async resolveProfileAst(
     profileConfiguration: ProfileConfiguration
   ): Promise<ProfileDocumentNode> {
     let scope: string | undefined;
-    let [scopeOrProfileName, profileName] = profileConfiguration.id.split('/');
+    let profileName: string;
+    const [scopeOrProfileName, resolvedProfileName] =
+      profileConfiguration.id.split('/');
 
-    if (profileName === undefined) {
+    if (resolvedProfileName === undefined) {
       profileName = scopeOrProfileName;
     } else {
+      profileName = resolvedProfileName;
       scope = scopeOrProfileName;
     }
 
@@ -84,7 +88,7 @@ export class InternalClient {
         );
       }
     }
-    //Fallback to remote
+    // Fallback to remote
     const profileSource = await fetchProfileSource(
       `${profileConfiguration.id}@${profileConfiguration.version}`,
       this.config,

--- a/src/core/client/client.internal.ts
+++ b/src/core/client/client.internal.ts
@@ -4,7 +4,7 @@ import {
   ProfileDocumentNode,
 } from '@superfaceai/ast';
 
-import { profileAstId, SuperCache } from '../../lib';
+import { profileAstId, SuperCache, versionToString } from '../../lib';
 import { SuperJson } from '../../schema-tools';
 import { Config } from '../config';
 import {
@@ -154,13 +154,6 @@ export class InternalClient {
       throw profileNotInstalledError(profileId);
     }
 
-    // TODO: use/create some util?
-    let version = `${ast.header.version.major}.${ast.header.version.minor}.${ast.header.version.patch}`;
-
-    if (ast.header.version.label !== undefined) {
-      version += `-${ast.header.version.label}`;
-    }
-
     // TODO: load priority and add it to ProfileConfiguration?
     const priority = profileSettings.priority;
     if (!priority.every(p => this.superJson.normalized.providers[p])) {
@@ -171,6 +164,9 @@ export class InternalClient {
       );
     }
 
-    return new ProfileConfiguration(profileId, version);
+    return new ProfileConfiguration(
+      profileId,
+      versionToString(ast.header.version)
+    );
   }
 }

--- a/src/core/errors/errors.helpers.ts
+++ b/src/core/errors/errors.helpers.ts
@@ -63,6 +63,27 @@ export function noConfiguredProviderError(
   );
 }
 
+export function unsupportedFileExtensionError(
+  filepath: string,
+  correctExtension: string
+): SDKExecutionError {
+  return new SDKExecutionError(
+    `File paths ${filepath} contains unsupported extension.`,
+    [],
+    [`Use file with ${correctExtension} extension.`]
+  );
+}
+
+export function sourceFileExtensionFoundError(
+  extension: string
+): SDKExecutionError {
+  return new SDKExecutionError(
+    `${extension} extension found.`,
+    [],
+    [`${extension} files needs to be compiled with Superface CLI.`]
+  );
+}
+
 export function profileNotInstalledError(profileId: string): SDKExecutionError {
   return new SDKExecutionError(
     `Profile not installed: ${profileId}`,

--- a/src/core/events/failure/event-adapter.test.ts
+++ b/src/core/events/failure/event-adapter.test.ts
@@ -420,6 +420,22 @@ const thirdMockMapDocument: MapDocumentNode = {
 const mockServer = getLocal();
 
 describe('event-adapter', () => {
+  const superJson = new SuperJson({
+    profiles: {
+      ['starwars/character-information']: {
+        version: '1.0.0',
+        providers: {
+          provider: {},
+        },
+      },
+    },
+    providers: {
+      provider: {
+        security: [],
+      },
+    },
+  });
+
   beforeEach(async () => {
     await mockServer.start();
   });
@@ -428,37 +444,33 @@ describe('event-adapter', () => {
     await mockServer.stop();
   });
 
-  const setupReadFileOverride = (ast: ProfileDocumentNode) => ({
-    fileSystemOverride: {
-      readFile: (): Promise<Result<string, FileSystemError>> =>
-        Promise.resolve(ok(JSON.stringify(ast))),
-    },
-  });
+  const createClient = (
+    overrideSuperJson?: SuperJson,
+    overrideAst?: ProfileDocumentNode
+  ): MockClient => {
+    return new MockClient(
+      overrideSuperJson !== undefined ? overrideSuperJson : superJson,
+      {
+        fileSystemOverride: {
+          readFile: (): Promise<Result<string, FileSystemError>> =>
+            Promise.resolve(
+              ok(
+                JSON.stringify(
+                  overrideAst !== undefined
+                    ? overrideAst
+                    : firstMockProfileDocument
+                )
+              )
+            ),
+        },
+      }
+    );
+  };
 
   // Without retry policy
   it('does not use retry policy - returns after HTTP 200', async () => {
     const endpoint = await mockServer.get('/first').thenJson(200, {});
-
-    const superJson = new SuperJson({
-      profiles: {
-        ['starwars/character-information']: {
-          version: '1.0.0',
-          providers: {
-            provider: {},
-          },
-        },
-      },
-      providers: {
-        provider: {
-          security: [],
-        },
-      },
-    });
-
-    const client = new MockClient(
-      superJson,
-      setupReadFileOverride(firstMockProfileDocument)
-    );
+    const client = createClient();
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -478,26 +490,8 @@ describe('event-adapter', () => {
 
   it('does not use retry policy - aborts after HTTP 500', async () => {
     const endpoint = await mockServer.get('/first').thenJson(500, {});
-    const superJson = new SuperJson({
-      profiles: {
-        ['starwars/character-information']: {
-          version: '1.0.0',
-          providers: {
-            provider: {},
-          },
-        },
-      },
-      providers: {
-        provider: {
-          security: [],
-        },
-      },
-    });
+    const client = createClient();
 
-    const client = new MockClient(
-      superJson,
-      setupReadFileOverride(firstMockProfileDocument)
-    );
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -517,26 +511,8 @@ describe('event-adapter', () => {
 
   it('does not use retry policy - aborts after closed connection', async () => {
     await mockServer.get('/first').thenCloseConnection();
-    const superJson = new SuperJson({
-      profiles: {
-        ['starwars/character-information']: {
-          version: '1.0.0',
-          providers: {
-            provider: {},
-          },
-        },
-      },
-      providers: {
-        provider: {
-          security: [],
-        },
-      },
-    });
+    const client = createClient();
 
-    const client = new MockClient(
-      superJson,
-      setupReadFileOverride(firstMockProfileDocument)
-    );
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -554,26 +530,8 @@ describe('event-adapter', () => {
 
   it('does not use retry policy - aborts after timeout', async () => {
     await mockServer.get('/first').thenTimeout();
-    const superJson = new SuperJson({
-      profiles: {
-        ['starwars/character-information']: {
-          version: '1.0.0',
-          providers: {
-            provider: {},
-          },
-        },
-      },
-      providers: {
-        provider: {
-          security: [],
-        },
-      },
-    });
+    const client = createClient();
 
-    const client = new MockClient(
-      superJson,
-      setupReadFileOverride(firstMockProfileDocument)
-    );
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -619,10 +577,7 @@ describe('event-adapter', () => {
       },
     });
 
-    const client = new MockClient(
-      superJson,
-      setupReadFileOverride(firstMockProfileDocument)
-    );
+    const client = createClient(superJson);
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -696,10 +651,7 @@ describe('event-adapter', () => {
       },
     });
 
-    const client = new MockClient(
-      superJson,
-      setupReadFileOverride(firstMockProfileDocument)
-    );
+    const client = createClient(superJson);
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -765,10 +717,8 @@ describe('event-adapter', () => {
       },
     });
 
-    const client = new MockClient(
-      superJson,
-      setupReadFileOverride(firstMockProfileDocument)
-    );
+    const client = createClient(superJson);
+
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -834,10 +784,8 @@ describe('event-adapter', () => {
       },
     });
 
-    const client = new MockClient(
-      superJson,
-      setupReadFileOverride(firstMockProfileDocument)
-    );
+    const client = createClient(superJson);
+
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -902,10 +850,8 @@ describe('event-adapter', () => {
       },
     });
 
-    const client = new MockClient(
-      superJson,
-      setupReadFileOverride(firstMockProfileDocument)
-    );
+    const client = createClient(superJson);
+
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -970,10 +916,8 @@ describe('event-adapter', () => {
       },
     });
 
-    const client = new MockClient(
-      superJson,
-      setupReadFileOverride(firstMockProfileDocument)
-    );
+    const client = createClient(superJson);
+
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -1050,10 +994,8 @@ describe('event-adapter', () => {
       },
     });
 
-    const client = new MockClient(
-      superJson,
-      setupReadFileOverride(firstMockProfileDocument)
-    );
+    const client = createClient(superJson);
+
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -1134,10 +1076,8 @@ describe('event-adapter', () => {
       },
     });
 
-    const client = new MockClient(
-      superJson,
-      setupReadFileOverride(firstMockProfileDocument)
-    );
+    const client = createClient(superJson);
+
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -1221,10 +1161,8 @@ describe('event-adapter', () => {
       },
     });
 
-    const client = new MockClient(
-      superJson,
-      setupReadFileOverride(firstMockProfileDocument)
-    );
+    const client = createClient(superJson);
+
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -1426,10 +1364,8 @@ describe('event-adapter', () => {
       },
     });
 
-    const client = new MockClient(
-      superJson,
-      setupReadFileOverride(firstMockProfileDocument)
-    );
+    const client = createClient(superJson);
+
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -1853,10 +1789,8 @@ describe('event-adapter', () => {
       },
     });
 
-    const client = new MockClient(
-      superJson,
-      setupReadFileOverride(firstMockProfileDocument)
-    );
+    const client = createClient(superJson);
+
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -1953,10 +1887,8 @@ describe('event-adapter', () => {
     });
 
     {
-      const client = new MockClient(
-        superJson,
-        setupReadFileOverride(firstMockProfileDocument)
-      );
+      const client = createClient(superJson);
+
       client.addBoundProfileProvider(
         firstMockProfileDocument,
         firstMockMapDocument,
@@ -1981,10 +1913,8 @@ describe('event-adapter', () => {
     }
 
     {
-      const client = new MockClient(
-        superJson,
-        setupReadFileOverride(firstMockProfileDocument)
-      );
+      const client = createClient(superJson);
+
       client.addBoundProfileProvider(
         firstMockProfileDocument,
         firstMockMapDocument,

--- a/src/core/events/failure/event-adapter.test.ts
+++ b/src/core/events/failure/event-adapter.test.ts
@@ -1507,6 +1507,9 @@ describe('event-adapter', () => {
 
     const client = new MockClient(superJson, {
       fileSystemOverride: {
+        path: {
+          resolve: (...pathSegments: string[]) => pathSegments.join(),
+        },
         readFile: async (path: string | string[]) => {
           if (
             path.includes('starwars/character-information@1.0.0.supr.ast.json')
@@ -1586,6 +1589,9 @@ describe('event-adapter', () => {
 
     const client = new MockClient(superJson, {
       fileSystemOverride: {
+        path: {
+          resolve: (...pathSegments: string[]) => pathSegments.join(),
+        },
         readFile: async path => {
           if (
             path.includes('starwars/character-information@1.0.0.supr.ast.json')
@@ -1666,6 +1672,9 @@ describe('event-adapter', () => {
 
     const client = new MockClient(superJson, {
       fileSystemOverride: {
+        path: {
+          resolve: (...pathSegments: string[]) => pathSegments.join(),
+        },
         readFile: async path => {
           if (
             path.includes('starwars/character-information@1.0.0.supr.ast.json')
@@ -1757,6 +1766,9 @@ describe('event-adapter', () => {
 
     const client = new MockClient(superJson, {
       fileSystemOverride: {
+        path: {
+          resolve: (...pathSegments: string[]) => pathSegments.join(),
+        },
         readFile: async path => {
           if (
             path.includes('starwars/character-information@1.0.0.supr.ast.json')

--- a/src/core/events/failure/event-adapter.test.ts
+++ b/src/core/events/failure/event-adapter.test.ts
@@ -7,10 +7,14 @@ import {
 } from '@superfaceai/ast';
 import { getLocal } from 'mockttp';
 
-import { err, ok } from '../../../lib';
+import { err, ok, Result } from '../../../lib';
 import { MockClient } from '../../../mock';
 import { getProvider, SuperJson } from '../../../schema-tools';
-import { bindResponseError, NotFoundError } from '../../errors';
+import {
+  bindResponseError,
+  FileSystemError,
+  NotFoundError,
+} from '../../errors';
 
 const astMetadata: AstMetadata = {
   sourceChecksum: 'checksum',
@@ -424,9 +428,17 @@ describe('event-adapter', () => {
     await mockServer.stop();
   });
 
+  const setupReadFileOverride = (ast: ProfileDocumentNode) => ({
+    fileSystemOverride: {
+      readFile: (): Promise<Result<string, FileSystemError>> =>
+        Promise.resolve(ok(JSON.stringify(ast))),
+    },
+  });
+
   // Without retry policy
   it('does not use retry policy - returns after HTTP 200', async () => {
     const endpoint = await mockServer.get('/first').thenJson(200, {});
+
     const superJson = new SuperJson({
       profiles: {
         ['starwars/character-information']: {
@@ -443,7 +455,10 @@ describe('event-adapter', () => {
       },
     });
 
-    const client = new MockClient(superJson);
+    const client = new MockClient(
+      superJson,
+      setupReadFileOverride(firstMockProfileDocument)
+    );
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -479,7 +494,10 @@ describe('event-adapter', () => {
       },
     });
 
-    const client = new MockClient(superJson);
+    const client = new MockClient(
+      superJson,
+      setupReadFileOverride(firstMockProfileDocument)
+    );
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -515,7 +533,10 @@ describe('event-adapter', () => {
       },
     });
 
-    const client = new MockClient(superJson);
+    const client = new MockClient(
+      superJson,
+      setupReadFileOverride(firstMockProfileDocument)
+    );
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -549,7 +570,10 @@ describe('event-adapter', () => {
       },
     });
 
-    const client = new MockClient(superJson);
+    const client = new MockClient(
+      superJson,
+      setupReadFileOverride(firstMockProfileDocument)
+    );
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -595,7 +619,10 @@ describe('event-adapter', () => {
       },
     });
 
-    const client = new MockClient(superJson);
+    const client = new MockClient(
+      superJson,
+      setupReadFileOverride(firstMockProfileDocument)
+    );
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -669,7 +696,10 @@ describe('event-adapter', () => {
       },
     });
 
-    const client = new MockClient(superJson);
+    const client = new MockClient(
+      superJson,
+      setupReadFileOverride(firstMockProfileDocument)
+    );
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -735,7 +765,10 @@ describe('event-adapter', () => {
       },
     });
 
-    const client = new MockClient(superJson);
+    const client = new MockClient(
+      superJson,
+      setupReadFileOverride(firstMockProfileDocument)
+    );
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -801,7 +834,10 @@ describe('event-adapter', () => {
       },
     });
 
-    const client = new MockClient(superJson);
+    const client = new MockClient(
+      superJson,
+      setupReadFileOverride(firstMockProfileDocument)
+    );
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -866,7 +902,10 @@ describe('event-adapter', () => {
       },
     });
 
-    const client = new MockClient(superJson);
+    const client = new MockClient(
+      superJson,
+      setupReadFileOverride(firstMockProfileDocument)
+    );
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -931,7 +970,10 @@ describe('event-adapter', () => {
       },
     });
 
-    const client = new MockClient(superJson);
+    const client = new MockClient(
+      superJson,
+      setupReadFileOverride(firstMockProfileDocument)
+    );
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -1008,7 +1050,10 @@ describe('event-adapter', () => {
       },
     });
 
-    const client = new MockClient(superJson);
+    const client = new MockClient(
+      superJson,
+      setupReadFileOverride(firstMockProfileDocument)
+    );
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -1089,7 +1134,10 @@ describe('event-adapter', () => {
       },
     });
 
-    const client = new MockClient(superJson);
+    const client = new MockClient(
+      superJson,
+      setupReadFileOverride(firstMockProfileDocument)
+    );
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -1173,7 +1221,10 @@ describe('event-adapter', () => {
       },
     });
 
-    const client = new MockClient(superJson);
+    const client = new MockClient(
+      superJson,
+      setupReadFileOverride(firstMockProfileDocument)
+    );
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -1266,7 +1317,18 @@ describe('event-adapter', () => {
       },
     });
 
-    const client = new MockClient(superJson);
+    const client = new MockClient(superJson, {
+      fileSystemOverride: {
+        readFile: jest
+          .fn()
+          .mockImplementationOnce(() =>
+            Promise.resolve(ok(JSON.stringify(firstMockProfileDocument)))
+          )
+          .mockImplementationOnce(() =>
+            Promise.resolve(ok(JSON.stringify(secondMockProfileDocument)))
+          ),
+      },
+    });
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -1364,7 +1426,10 @@ describe('event-adapter', () => {
       },
     });
 
-    const client = new MockClient(superJson);
+    const client = new MockClient(
+      superJson,
+      setupReadFileOverride(firstMockProfileDocument)
+    );
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -1776,7 +1841,10 @@ describe('event-adapter', () => {
       },
     });
 
-    const client = new MockClient(superJson);
+    const client = new MockClient(
+      superJson,
+      setupReadFileOverride(firstMockProfileDocument)
+    );
     client.addBoundProfileProvider(
       firstMockProfileDocument,
       firstMockMapDocument,
@@ -1873,7 +1941,10 @@ describe('event-adapter', () => {
     });
 
     {
-      const client = new MockClient(superJson);
+      const client = new MockClient(
+        superJson,
+        setupReadFileOverride(firstMockProfileDocument)
+      );
       client.addBoundProfileProvider(
         firstMockProfileDocument,
         firstMockMapDocument,
@@ -1898,7 +1969,10 @@ describe('event-adapter', () => {
     }
 
     {
-      const client = new MockClient(superJson);
+      const client = new MockClient(
+        superJson,
+        setupReadFileOverride(firstMockProfileDocument)
+      );
       client.addBoundProfileProvider(
         firstMockProfileDocument,
         firstMockMapDocument,

--- a/src/core/events/reporter/reporter.test.ts
+++ b/src/core/events/reporter/reporter.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@superfaceai/ast';
 import { getLocal, MockedEndpoint } from 'mockttp';
 
+import { ok } from '../../../lib';
 import { MockClient } from '../../../mock';
 import { SuperJson } from '../../../schema-tools';
 import { FailoverReason } from './reporter';
@@ -289,6 +290,10 @@ describe('MetricReporter', () => {
 
   it('should report success', async () => {
     const client = new MockClient(mockSuperJsonSingle, {
+      fileSystemOverride: {
+        readFile: () =>
+          Promise.resolve(ok(JSON.stringify(mockProfileDocument))),
+      },
       configOverride: {
         disableReporting: false,
         superfaceApiUrl: mockServer.url,
@@ -331,6 +336,10 @@ describe('MetricReporter', () => {
 
   it('should report failure and unsuccessful switch', async () => {
     const client = new MockClient(mockSuperJsonSingleFailure, {
+      fileSystemOverride: {
+        readFile: () =>
+          Promise.resolve(ok(JSON.stringify(mockProfileDocument))),
+      },
       configOverride: {
         disableReporting: false,
         superfaceApiUrl: mockServer.url,
@@ -400,6 +409,10 @@ describe('MetricReporter', () => {
 
   it('should report success with a delay', async () => {
     const client = new MockClient(mockSuperJsonSingle, {
+      fileSystemOverride: {
+        readFile: () =>
+          Promise.resolve(ok(JSON.stringify(mockProfileDocument))),
+      },
       configOverride: {
         disableReporting: false,
         superfaceApiUrl: mockServer.url,
@@ -439,6 +452,10 @@ describe('MetricReporter', () => {
 
   it('should report multiple successes', async () => {
     const client = new MockClient(mockSuperJsonSingle, {
+      fileSystemOverride: {
+        readFile: () =>
+          Promise.resolve(ok(JSON.stringify(mockProfileDocument))),
+      },
       configOverride: {
         disableReporting: false,
         superfaceApiUrl: mockServer.url,
@@ -483,6 +500,10 @@ describe('MetricReporter', () => {
 
   it('should report multiple successes with a delay', async () => {
     const client = new MockClient(mockSuperJsonSingle, {
+      fileSystemOverride: {
+        readFile: () =>
+          Promise.resolve(ok(JSON.stringify(mockProfileDocument))),
+      },
       configOverride: {
         disableReporting: false,
         superfaceApiUrl: mockServer.url,
@@ -551,6 +572,10 @@ describe('MetricReporter', () => {
       .spyOn(Date, 'now')
       .mockImplementation(() => currentTime);
     const client = new MockClient(mockSuperJsonSingle, {
+      fileSystemOverride: {
+        readFile: () =>
+          Promise.resolve(ok(JSON.stringify(mockProfileDocument))),
+      },
       configOverride: {
         disableReporting: false,
         superfaceApiUrl: mockServer.url,
@@ -620,6 +645,10 @@ describe('MetricReporter', () => {
       .spyOn(Date, 'now')
       .mockImplementation(() => currentTime);
     const client = new MockClient(mockSuperJsonFailover, {
+      fileSystemOverride: {
+        readFile: () =>
+          Promise.resolve(ok(JSON.stringify(mockProfileDocument))),
+      },
       configOverride: {
         disableReporting: false,
         superfaceApiUrl: mockServer.url,
@@ -703,5 +732,5 @@ describe('MetricReporter', () => {
     });
 
     systemTimeMock.mockRestore();
-  });
+  }, 10000);
 });

--- a/src/core/profile-provider/profile-provider.test.ts
+++ b/src/core/profile-provider/profile-provider.test.ts
@@ -20,7 +20,6 @@ import { localProviderAndRemoteMapError } from '../errors';
 import { Events } from '../events';
 import { IFileSystem } from '../interfaces';
 import { Parser } from '../parser';
-import { ProfileConfiguration } from '../profile';
 import { ProviderConfiguration } from '../provider';
 import { fetchBind, fetchMapSource, fetchProviderInfo } from '../registry';
 import { ServiceSelector } from '../services';
@@ -341,7 +340,7 @@ describe('profile provider', () => {
 
         const mockProfileProvider = new ProfileProvider(
           superJson,
-          'test-profile',
+          mockProfileDocument,
           mockProviderConfiguration,
           mockConfig,
           new Events(timers),
@@ -377,7 +376,7 @@ describe('profile provider', () => {
 
         const mockProfileProvider = new ProfileProvider(
           superJson,
-          new ProfileConfiguration('test-profile', '1.0.0'),
+          mockProfileDocument,
           mockProviderConfiguration,
           mockConfig,
           new Events(timers),
@@ -425,7 +424,7 @@ describe('profile provider', () => {
 
         const mockProfileProvider = new ProfileProvider(
           superJson,
-          new ProfileConfiguration('test-profile', '1.0.0'),
+          mockProfileDocument,
           mockProviderConfiguration,
           mockConfig,
           new Events(timers),
@@ -464,13 +463,12 @@ describe('profile provider', () => {
 
         fileSystem.readFile = jest
           .fn()
-          .mockResolvedValueOnce(ok(JSON.stringify(mockProfileDocument)))
           .mockResolvedValueOnce(ok(JSON.stringify(mockProviderJson)))
           .mockResolvedValueOnce(ok(JSON.stringify(mockMapDocument)));
 
         const mockProfileProvider = new ProfileProvider(
           superJson,
-          'test-profile',
+          mockProfileDocument,
           mockProviderConfiguration,
           mockConfig,
           new Events(timers),
@@ -488,7 +486,6 @@ describe('profile provider', () => {
         mocked(fetchBind).mockResolvedValue(mockFetchResponse);
         fileSystem.readFile = jest
           .fn()
-          .mockResolvedValueOnce(ok(JSON.stringify(mockProfileDocument)))
           .mockResolvedValueOnce(ok(JSON.stringify(mockProviderJson)))
           .mockResolvedValueOnce(ok(JSON.stringify(mockMapDocument)));
         const superJson = new SuperJson({
@@ -513,7 +510,7 @@ describe('profile provider', () => {
 
         const mockProfileProvider = new ProfileProvider(
           superJson,
-          'test-profile',
+          mockProfileDocument,
           mockProviderConfiguration,
           mockConfig,
           new Events(timers),
@@ -525,39 +522,6 @@ describe('profile provider', () => {
         const result = await mockProfileProvider.bind();
 
         expect(result).toMatchObject(expectedBoundProfileProvider);
-      });
-
-      it('throws error without profile settings', async () => {
-        mocked(fetchBind).mockResolvedValue(mockFetchResponse);
-        const superJson = new SuperJson({
-          profiles: {},
-          providers: {
-            test: {
-              file: 'file://some/file',
-              security: [],
-            },
-          },
-        });
-
-        fileSystem.readFile = jest
-          .fn()
-          .mockResolvedValueOnce(ok(JSON.stringify(mockProfileDocument)))
-          .mockResolvedValueOnce(ok(JSON.stringify(mockProviderJson)))
-          .mockResolvedValueOnce(ok(JSON.stringify(mockMapDocument)));
-
-        const mockProfileProvider = new ProfileProvider(
-          superJson,
-          'test-profile',
-          'test',
-          mockConfig,
-          new Events(timers),
-          fileSystem,
-          crypto,
-          new CrossFetch(timers)
-        );
-        await expect(mockProfileProvider.bind()).rejects.toThrow(
-          'Hint: Profiles can be installed using the superface cli tool: `superface install --help` for more info'
-        );
       });
 
       it('returns new BoundProfileProvider when map is provided locally but provider is not', async () => {
@@ -583,14 +547,13 @@ describe('profile provider', () => {
 
         fileSystem.readFile = jest
           .fn()
-          .mockResolvedValueOnce(ok(JSON.stringify(mockProfileDocument)))
           .mockResolvedValueOnce(ok(JSON.stringify(mockMapDocument)));
 
         mocked(fetchProviderInfo).mockResolvedValue(mockProviderJson);
 
         const mockProfileProvider = new ProfileProvider(
           superJson,
-          'test-profile',
+          mockProfileDocument,
           mockProviderConfiguration,
           mockConfig,
           new Events(timers),
@@ -632,7 +595,6 @@ describe('profile provider', () => {
 
         fileSystem.readFile = jest
           .fn()
-          .mockResolvedValueOnce(ok(JSON.stringify(mockProfileDocument)))
           .mockResolvedValueOnce(ok(JSON.stringify(mockMapDocument)))
           .mockResolvedValueOnce(ok(JSON.stringify(mockProviderJson)));
 
@@ -640,7 +602,7 @@ describe('profile provider', () => {
 
         const mockProfileProvider = new ProfileProvider(
           superJson,
-          'test-profile',
+          mockProfileDocument,
           mockProviderConfiguration,
           mockConfig,
           new Events(timers),
@@ -651,7 +613,7 @@ describe('profile provider', () => {
         const result = await mockProfileProvider.bind();
 
         expect(result).toMatchObject(expectedBoundProfileProvider);
-        expect(fileSystem.readFile).toHaveBeenCalledTimes(3);
+        expect(fileSystem.readFile).toHaveBeenCalledTimes(2);
       });
 
       it('throws when both fetch and cache read fails', async () => {
@@ -677,7 +639,6 @@ describe('profile provider', () => {
 
         fileSystem.readFile = jest
           .fn()
-          .mockResolvedValueOnce(ok(JSON.stringify(mockProfileDocument)))
           .mockResolvedValueOnce(ok(JSON.stringify(mockMapDocument)))
           .mockRejectedValueOnce(err('denied!'));
 
@@ -685,7 +646,7 @@ describe('profile provider', () => {
 
         const mockProfileProvider = new ProfileProvider(
           superJson,
-          'test-profile',
+          mockProfileDocument,
           mockProviderConfiguration,
           mockConfig,
           new Events(timers),
@@ -697,7 +658,7 @@ describe('profile provider', () => {
         await expect(() => mockProfileProvider.bind()).rejects.toMatchObject({
           error: 'denied!',
         });
-        expect(fileSystem.readFile).toHaveBeenCalledTimes(3);
+        expect(fileSystem.readFile).toHaveBeenCalledTimes(2);
       });
 
       it('throws error when provider is provided locally but map is not', async () => {
@@ -720,14 +681,13 @@ describe('profile provider', () => {
 
         fileSystem.readFile = jest
           .fn()
-          .mockResolvedValueOnce(ok(JSON.stringify(mockProfileDocument)))
           .mockResolvedValueOnce(ok(JSON.stringify(mockProviderJson)));
 
         mocked(fetchProviderInfo).mockResolvedValue(mockProviderJson);
 
         const mockProfileProvider = new ProfileProvider(
           superJson,
-          'test-profile',
+          mockProfileDocument,
           mockProviderConfiguration,
           mockConfig,
           new Events(timers),
@@ -769,7 +729,7 @@ describe('profile provider', () => {
 
         const mockProfileProvider = new ProfileProvider(
           superJson,
-          'test-profile',
+          mockProfileDocument,
           mockProviderConfiguration,
           mockConfig,
           new Events(timers),
@@ -1071,7 +1031,6 @@ but http scheme requires: digest`
         });
 
         mocked(fileSystem.readFile)
-          .mockResolvedValueOnce(ok(JSON.stringify(mockProfileDocument)))
           .mockResolvedValueOnce(ok(JSON.stringify(mockProviderJson)))
           .mockResolvedValueOnce(ok(JSON.stringify(mockMapDocument)));
 
@@ -1082,7 +1041,7 @@ but http scheme requires: digest`
 
         const mockProfileProvider = new ProfileProvider(
           superJson,
-          'test-profile',
+          mockProfileDocument,
           providerConfiguration,
           mockConfig,
           new Events(timers),
@@ -1141,13 +1100,12 @@ but http scheme requires: digest`
 
         fileSystem.readFile = jest
           .fn()
-          .mockResolvedValueOnce(ok(JSON.stringify(mockProfileDocument)))
           .mockResolvedValueOnce(ok(JSON.stringify(mockProviderJson)))
           .mockResolvedValueOnce(ok(JSON.stringify(mockMapDocumentBoop)));
 
         const mockProfileProvider = new ProfileProvider(
           superJson,
-          'test-profile',
+          mockProfileDocument,
           mockProviderConfiguration,
           mockConfig,
           new Events(timers),

--- a/src/core/profile-provider/profile-provider.ts
+++ b/src/core/profile-provider/profile-provider.ts
@@ -131,7 +131,7 @@ export class ProfileProvider {
     configuration?: BindConfiguration
   ): Promise<BoundProfileProvider> {
     // resolve profile locally
-    const profileAst = this.profile
+    const profileAst = this.profile;
     // if (profileAst === undefined) {
     //   throw invalidProfileError(this.profileId);
     // }
@@ -249,7 +249,7 @@ export class ProfileProvider {
         ),
         profileProviderSettings:
           this.superJson.normalized.profiles[profileId]?.providers[
-          providerInfo.name
+            providerInfo.name
           ],
         security: securityConfiguration,
         parameters: this.resolveIntegrationParameters(

--- a/src/core/profile-provider/profile-provider.ts
+++ b/src/core/profile-provider/profile-provider.ts
@@ -130,11 +130,9 @@ export class ProfileProvider {
   public async bind(
     configuration?: BindConfiguration
   ): Promise<BoundProfileProvider> {
-    // resolve profile locally
+    // profile is resolved during getProfile
     const profileAst = this.profile;
-    // if (profileAst === undefined) {
-    //   throw invalidProfileError(this.profileId);
-    // }
+
     const profileId = profileAstId(profileAst);
 
     // resolve provider from parameters or defer until later
@@ -394,62 +392,6 @@ export class ProfileProvider {
       );
     }
   }
-
-  // private async resolveProfileAst(): Promise<ProfileDocumentNode | undefined> {
-  //   let resolveInput = this.profile;
-  //   if (resolveInput instanceof ProfileConfiguration) {
-  //     resolveInput = resolveInput.id;
-  //   }
-
-  //   const profileAst = await ProfileProvider.resolveValue(
-  //     resolveInput,
-  //     async (fileContents, fileName) => {
-  //       // If we have profile source, we parse
-  //       if (fileName !== undefined && isProfileFile(fileName)) {
-  //         return Parser.parseProfile(
-  //           fileContents,
-  //           fileName,
-  //           {
-  //             profileName: this.profileName,
-  //             scope: this.scope,
-  //           },
-  //           this.config.cachePath,
-  //           this.fileSystem
-  //         );
-  //       }
-
-  //       // Otherwise we return parsed
-  //       return assertProfileDocumentNode(JSON.parse(fileContents));
-  //     },
-  //     profileId => {
-  //       const profileSettings = this.superJson.normalized.profiles[profileId];
-  //       if (profileSettings === undefined) {
-  //         // not found at all
-  //         return undefined;
-  //       } else if ('file' in profileSettings) {
-  //         // assumed right next to source file
-  //         return (
-  //           FILE_URI_PROTOCOL + this.superJson.resolvePath(profileSettings.file)
-  //         );
-  //       } else {
-  //         // assumed to be in grid folder
-  //         return (
-  //           FILE_URI_PROTOCOL +
-  //           this.superJson.resolvePath(
-  //             this.fileSystem.path.join(
-  //               'grid',
-  //               `${profileId}@${profileSettings.version}.supr`
-  //             )
-  //           )
-  //         );
-  //       }
-  //     },
-  //     this.fileSystem,
-  //     ['.ast.json', '']
-  //   );
-
-  //   return profileAst;
-  // }
 
   private async resolveProviderInfo(): Promise<{
     providerInfo?: ProviderJson;

--- a/src/core/profile/index.ts
+++ b/src/core/profile/index.ts
@@ -1,3 +1,4 @@
 export * from './profile';
 export * from './profile.typed';
 export * from './profile-configuration';
+export * from './resolve-profile-ast';

--- a/src/core/profile/profile.test.ts
+++ b/src/core/profile/profile.test.ts
@@ -5,6 +5,7 @@ import { mockProfileDocumentNode, MockTimers } from '../../mock';
 import { NodeCrypto, NodeFetch, NodeFileSystem } from '../../node';
 import { SuperJson } from '../../schema-tools';
 import { Config } from '../config';
+import { usecaseNotFoundError } from '../errors';
 import { Events } from '../events';
 import { IBoundProfileProvider } from '../profile-provider';
 import { Profile } from './profile';
@@ -38,19 +39,37 @@ function createProfile(superJson: SuperJsonDocument): Profile {
 }
 
 describe('Profile', () => {
-  it('should call getUseCases correctly', async () => {
-    const superJson = {
-      profiles: {
-        test: {
-          version: '1.0.0',
+  describe('when calling getUseCases', () => {
+    it('should retrun new UseCase', async () => {
+      const superJson = {
+        profiles: {
+          test: {
+            version: '1.0.0',
+          },
         },
-      },
-      providers: {},
-    };
-    const profile = createProfile(superJson);
+        providers: {},
+      };
+      const profile = createProfile(superJson);
 
-    expect(profile.getUseCase('sayHello')).toMatchObject({
-      name: 'sayHello',
+      expect(profile.getUseCase('sayHello')).toMatchObject({
+        name: 'sayHello',
+      });
+    });
+
+    it('should throw on non existent use case name', async () => {
+      const superJson = {
+        profiles: {
+          test: {
+            version: '1.0.0',
+          },
+        },
+        providers: {},
+      };
+      const profile = createProfile(superJson);
+
+      expect(() => profile.getUseCase('made-up')).toThrow(
+        usecaseNotFoundError('made-up', ['sayHello'])
+      );
     });
   });
 

--- a/src/core/profile/profile.test.ts
+++ b/src/core/profile/profile.test.ts
@@ -1,7 +1,7 @@
 import { SuperJsonDocument } from '@superfaceai/ast';
 
 import { SuperCache } from '../../lib';
-import { MockTimers } from '../../mock';
+import { mockProfileDocumentNode, MockTimers } from '../../mock';
 import { CrossFetch, NodeCrypto, NodeFileSystem } from '../../node';
 import { SuperJson } from '../../schema-tools';
 import { Config } from '../config';
@@ -20,10 +20,12 @@ function createProfile(superJson: SuperJsonDocument): Profile {
     expiresAt: number;
   }>();
   const config = new Config(NodeFileSystem);
+  const ast = mockProfileDocumentNode({ usecaseName: 'sayHello' });
   const configuration = new ProfileConfiguration('test', '1.0.0');
 
   return new Profile(
     configuration,
+    ast,
     events,
     new SuperJson(superJson),
     config,
@@ -49,7 +51,6 @@ describe('Profile', () => {
 
     expect(profile.getUseCase('sayHello')).toMatchObject({
       name: 'sayHello',
-      profileConfiguration: profile.configuration,
     });
   });
 

--- a/src/core/profile/profile.ts
+++ b/src/core/profile/profile.ts
@@ -1,4 +1,5 @@
 import { ProfileDocumentNode } from '@superfaceai/ast';
+
 import { SuperCache } from '../../lib';
 import { SuperJson } from '../../schema-tools';
 import { Events, Interceptable } from '../events';
@@ -24,7 +25,7 @@ export abstract class ProfileBase {
     protected readonly crypto: ICrypto,
     protected readonly fetchInstance: FetchInstance & Interceptable & AuthCache,
     protected readonly logger?: ILogger
-  ) { }
+  ) {}
 
   public getConfiguredProviders(): string[] {
     return Object.keys(

--- a/src/core/profile/profile.ts
+++ b/src/core/profile/profile.ts
@@ -1,7 +1,8 @@
-import { ProfileDocumentNode } from '@superfaceai/ast';
+import { isUseCaseDefinitionNode, ProfileDocumentNode } from '@superfaceai/ast';
 
 import { SuperCache } from '../../lib';
 import { SuperJson } from '../../schema-tools';
+import { usecaseNotFoundError } from '../errors';
 import { Events, Interceptable } from '../events';
 import { IConfig, ICrypto, IFileSystem, ILogger, ITimers } from '../interfaces';
 import { AuthCache, IFetch } from '../interpreter';
@@ -36,7 +37,12 @@ export abstract class ProfileBase {
 
 export class Profile extends ProfileBase {
   public getUseCase(name: string): UseCase {
-    // TODO: Check if usecase exists
+    const supportedUsecaseNames = this.ast.definitions
+      .filter(isUseCaseDefinitionNode)
+      .map(u => u.useCaseName);
+    if (!supportedUsecaseNames.includes(name)) {
+      throw usecaseNotFoundError(name, supportedUsecaseNames);
+    }
 
     return new UseCase(
       this,

--- a/src/core/profile/profile.ts
+++ b/src/core/profile/profile.ts
@@ -1,3 +1,4 @@
+import { ProfileDocumentNode } from '@superfaceai/ast';
 import { SuperCache } from '../../lib';
 import { SuperJson } from '../../schema-tools';
 import { Events, Interceptable } from '../events';
@@ -10,6 +11,7 @@ import { ProfileConfiguration } from './profile-configuration';
 export abstract class ProfileBase {
   constructor(
     public readonly configuration: ProfileConfiguration,
+    public readonly ast: ProfileDocumentNode,
     protected readonly events: Events,
     protected readonly superJson: SuperJson,
     protected readonly config: IConfig,
@@ -22,7 +24,7 @@ export abstract class ProfileBase {
     protected readonly crypto: ICrypto,
     protected readonly fetchInstance: FetchInstance & Interceptable & AuthCache,
     protected readonly logger?: ILogger
-  ) {}
+  ) { }
 
   public getConfiguredProviders(): string[] {
     return Object.keys(
@@ -36,7 +38,7 @@ export class Profile extends ProfileBase {
     // TODO: Check if usecase exists
 
     return new UseCase(
-      this.configuration,
+      this,
       name,
       this.events,
       this.config,

--- a/src/core/profile/profile.typed.test.ts
+++ b/src/core/profile/profile.typed.test.ts
@@ -1,5 +1,9 @@
 import { SuperCache } from '../../lib';
-import { MockFileSystem, MockTimers } from '../../mock';
+import {
+  MockFileSystem,
+  mockProfileDocumentNode,
+  MockTimers,
+} from '../../mock';
 import { CrossFetch, NodeCrypto, NodeFileSystem } from '../../node';
 import { SuperJson } from '../../schema-tools';
 import { Config } from '../config';
@@ -21,6 +25,7 @@ describe('TypedProfile', () => {
     providers: {},
   });
   const mockProfileConfiguration = new ProfileConfiguration('test', '1.0.0');
+  const ast = mockProfileDocumentNode();
 
   const timers = new MockTimers();
   const events = new Events(timers);
@@ -35,6 +40,7 @@ describe('TypedProfile', () => {
     it('should get usecase correctly', async () => {
       const typedProfile = new TypedProfile(
         mockProfileConfiguration,
+        ast,
         events,
         mockSuperJson,
         cache,
@@ -48,7 +54,7 @@ describe('TypedProfile', () => {
 
       expect(typedProfile.getUseCase('sayHello')).toEqual(
         new UseCase(
-          mockProfileConfiguration,
+          typedProfile,
           'sayHello',
           events,
           config,
@@ -65,6 +71,7 @@ describe('TypedProfile', () => {
     it('should throw when usecase is not found', async () => {
       const typedProfile = new TypedProfile(
         mockProfileConfiguration,
+        mockProfileDocumentNode(),
         events,
         mockSuperJson,
         cache,

--- a/src/core/profile/profile.typed.ts
+++ b/src/core/profile/profile.typed.ts
@@ -1,3 +1,4 @@
+import { ProfileDocumentNode } from '@superfaceai/ast';
 import { SuperCache } from '../../lib';
 import { SuperJson } from '../../schema-tools';
 import { UnexpectedError, usecaseNotFoundError } from '../errors';
@@ -14,9 +15,9 @@ export type UsecaseType<
   TInput extends NonPrimitive | undefined = any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TOutput = any
-> = {
-  [name: string]: [TInput, TOutput];
-};
+  > = {
+    [name: string]: [TInput, TOutput];
+  };
 
 export type KnownUsecase<TUsecase extends UsecaseType> = {
   [name in keyof TUsecase]: TypedUseCase<TUsecase[name][0], TUsecase[name][1]>;
@@ -25,11 +26,12 @@ export type KnownUsecase<TUsecase extends UsecaseType> = {
 export class TypedProfile<
   // TKnownUsecases extends KnownUsecase<string, NonPrimitive, unknown>
   TUsecaseTypes extends UsecaseType
-> extends ProfileBase {
+  > extends ProfileBase {
   private readonly knownUsecases: KnownUsecase<TUsecaseTypes>;
 
   constructor(
     public override readonly configuration: ProfileConfiguration,
+    public override readonly ast: ProfileDocumentNode,
     protected override readonly events: Events,
     protected override readonly superJson: SuperJson,
     protected override readonly boundProfileProviderCache: SuperCache<{
@@ -48,6 +50,7 @@ export class TypedProfile<
   ) {
     super(
       configuration,
+      ast,
       events,
       superJson,
       config,
@@ -65,7 +68,7 @@ export class TypedProfile<
           TUsecaseTypes[typeof usecase][0],
           TUsecaseTypes[typeof usecase][1]
         >(
-          configuration,
+          this,
           usecase as string,
           events,
           config,

--- a/src/core/profile/profile.typed.ts
+++ b/src/core/profile/profile.typed.ts
@@ -1,4 +1,5 @@
 import { ProfileDocumentNode } from '@superfaceai/ast';
+
 import { SuperCache } from '../../lib';
 import { SuperJson } from '../../schema-tools';
 import { UnexpectedError, usecaseNotFoundError } from '../errors';
@@ -15,9 +16,9 @@ export type UsecaseType<
   TInput extends NonPrimitive | undefined = any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TOutput = any
-  > = {
-    [name: string]: [TInput, TOutput];
-  };
+> = {
+  [name: string]: [TInput, TOutput];
+};
 
 export type KnownUsecase<TUsecase extends UsecaseType> = {
   [name in keyof TUsecase]: TypedUseCase<TUsecase[name][0], TUsecase[name][1]>;
@@ -26,7 +27,7 @@ export type KnownUsecase<TUsecase extends UsecaseType> = {
 export class TypedProfile<
   // TKnownUsecases extends KnownUsecase<string, NonPrimitive, unknown>
   TUsecaseTypes extends UsecaseType
-  > extends ProfileBase {
+> extends ProfileBase {
   private readonly knownUsecases: KnownUsecase<TUsecaseTypes>;
 
   constructor(

--- a/src/core/profile/resolve-profile-ast.test.ts
+++ b/src/core/profile/resolve-profile-ast.test.ts
@@ -49,15 +49,6 @@ const mockSuperJson = new SuperJson({
   },
 });
 
-// const mockSuperJsonCustomPath = new SuperJson({
-//   profiles: {
-//     test: '2.1.0',
-//   },
-//   providers: {
-//     quz: {},
-//   },
-// });
-
 describe('resolveProfileAst', () => {
   const logger = new NodeLogger();
   const crypto = new NodeCrypto();

--- a/src/core/profile/resolve-profile-ast.test.ts
+++ b/src/core/profile/resolve-profile-ast.test.ts
@@ -1,0 +1,449 @@
+import { EXTENSIONS } from '@superfaceai/ast';
+import { mocked } from 'ts-jest/utils';
+
+import { err, ok } from '../../lib';
+import {
+  MockFileSystem,
+  mockProfileDocumentNode,
+  MockTimers,
+} from '../../mock';
+import { NodeCrypto, NodeFetch, NodeLogger } from '../../node';
+import { SuperJson } from '../../schema-tools';
+import { Config } from '../config';
+import {
+  NotFoundError,
+  profileFileNotFoundError,
+  sourceFileExtensionFoundError,
+  unsupportedFileExtensionError,
+} from '../errors';
+import { fetchProfileAst } from '../registry';
+import { resolveProfileAst } from './resolve-profile-ast';
+
+jest.mock('../../core/registry');
+
+const mockSuperJson = new SuperJson({
+  profiles: {
+    'testy/mctestface': '0.1.0',
+    foo: 'file://../foo.supr.ast.json',
+    'evil/foo': 'file://../foo.supr',
+    'bad/foo': 'file://../foo.ts',
+    bar: {
+      file: '../bar.supr.ast.json',
+      providers: {
+        quz: {},
+      },
+    },
+    baz: {
+      version: '1.2.3',
+      providers: {
+        quz: {},
+      },
+    },
+  },
+  providers: {
+    fooder: {
+      file: '../fooder.provider.json',
+      security: [],
+    },
+    quz: {},
+  },
+});
+
+// const mockSuperJsonCustomPath = new SuperJson({
+//   profiles: {
+//     test: '2.1.0',
+//   },
+//   providers: {
+//     quz: {},
+//   },
+// });
+
+describe('resolveProfileAst', () => {
+  const logger = new NodeLogger();
+  const crypto = new NodeCrypto();
+  const timers = new MockTimers();
+  let fileSystem = MockFileSystem();
+  const fetchInstance = new NodeFetch(timers);
+  const config = new Config(fileSystem, {
+    disableReporting: true,
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.resetAllMocks();
+  });
+
+  it('rejects when profile does not exists', async () => {
+    await expect(
+      resolveProfileAst({
+        profileId: 'does/not-exist',
+        superJson: mockSuperJson,
+        config,
+        crypto,
+        fileSystem,
+        fetchInstance,
+        logger,
+      })
+    ).rejects.toThrow('Profile "does/not-exist" not found in super.json');
+  });
+
+  describe('when using entry with version only', () => {
+    it('returns a valid profile when profile is found in grid', async () => {
+      fileSystem = MockFileSystem({
+        path: {
+          resolve: (...pathSegments: string[]) => pathSegments.join(''),
+        },
+        readFile: jest.fn(path => {
+          expect(path).toMatch('testy/mctestface@0.1.0.supr.ast.json');
+
+          return Promise.resolve(
+            ok(
+              JSON.stringify(
+                mockProfileDocumentNode({
+                  name: 'mctestface',
+                  scope: 'testy',
+                  version: {
+                    major: 0,
+                    minor: 1,
+                    patch: 0,
+                  },
+                })
+              )
+            )
+          );
+        }),
+      });
+
+      const ast = await resolveProfileAst({
+        profileId: 'testy/mctestface',
+        superJson: mockSuperJson,
+        config,
+        crypto,
+        fileSystem,
+        fetchInstance,
+        logger,
+      });
+
+      expect(ast.header.version).toEqual({ major: 0, minor: 1, patch: 0 });
+    });
+
+    it('returns a valid profile when profile is found in registry', async () => {
+      mocked(fetchProfileAst).mockResolvedValue(
+        mockProfileDocumentNode({
+          name: 'mctestface',
+          scope: 'testy',
+          version: {
+            major: 0,
+            minor: 1,
+            patch: 0,
+          },
+        })
+      );
+      fileSystem = MockFileSystem({
+        path: {
+          resolve: (...pathSegments: string[]) => pathSegments.join(''),
+        },
+        readFile: jest.fn(path => {
+          expect(path).toMatch('testy/mctestface@0.1.0.supr.ast.json');
+
+          return Promise.resolve(err(new NotFoundError('test')));
+        }),
+      });
+
+      const ast = await resolveProfileAst({
+        profileId: 'testy/mctestface',
+        superJson: mockSuperJson,
+        config,
+        crypto,
+        fileSystem,
+        fetchInstance,
+        logger,
+      });
+
+      expect(ast.header.version).toEqual({ major: 0, minor: 1, patch: 0 });
+      expect(fetchProfileAst).toHaveBeenCalledWith(
+        'testy/mctestface@0.1.0',
+        config,
+        crypto,
+        fetchInstance,
+        logger
+      );
+    });
+  });
+
+  describe('when using entry with filepath only', () => {
+    it('rejects when profile points to a non-existent path', async () => {
+      const mockError = profileFileNotFoundError('../foo.supr.ast.json', 'foo');
+      fileSystem = MockFileSystem({
+        readFile: () => Promise.resolve(err(mockError)),
+      });
+
+      await expect(
+        resolveProfileAst({
+          profileId: 'foo',
+          superJson: mockSuperJson,
+          config,
+          crypto,
+          fileSystem,
+          fetchInstance,
+          logger,
+        })
+      ).rejects.toThrow(mockError);
+    });
+
+    it('rejects when profile points to a path with .supr extension', async () => {
+      fileSystem = MockFileSystem();
+
+      await expect(
+        resolveProfileAst({
+          profileId: 'evil/foo',
+          superJson: mockSuperJson,
+          config,
+          crypto,
+          fileSystem,
+          fetchInstance,
+          logger,
+        })
+      ).rejects.toThrow(
+        sourceFileExtensionFoundError(EXTENSIONS.profile.source)
+      );
+    });
+
+    it('rejects when profile points to a path with unsupported extension', async () => {
+      fileSystem = MockFileSystem();
+
+      await expect(
+        resolveProfileAst({
+          profileId: 'bad/foo',
+          superJson: mockSuperJson,
+          config,
+          crypto,
+          fileSystem,
+          fetchInstance,
+          logger,
+        })
+      ).rejects.toThrow(
+        unsupportedFileExtensionError(
+          mockSuperJson.resolvePath('../foo.ts'),
+          EXTENSIONS.profile.build
+        )
+      );
+    });
+
+    it('returns a valid profile when it points to existing path', async () => {
+      fileSystem = MockFileSystem({
+        readFile: jest.fn(path => {
+          expect(path).toMatch('foo.supr.ast.json');
+
+          return Promise.resolve(
+            ok(
+              JSON.stringify(
+                mockProfileDocumentNode({
+                  name: 'foo',
+                  version: {
+                    major: 1,
+                    minor: 0,
+                    patch: 1,
+                    label: 'test',
+                  },
+                })
+              )
+            )
+          );
+        }),
+      });
+
+      const ast = await resolveProfileAst({
+        profileId: 'foo',
+        superJson: mockSuperJson,
+        config,
+        crypto,
+        fileSystem,
+        fetchInstance,
+        logger,
+      });
+      expect(ast.header.version).toEqual({
+        major: 1,
+        minor: 0,
+        patch: 1,
+        label: 'test',
+      });
+    });
+
+    it('rejects when loaded file is not valid ProfileDocumentNode', async () => {
+      const invalidAst: any = mockProfileDocumentNode({ name: 'foo' });
+      invalidAst.kind = 'broken';
+      fileSystem = MockFileSystem({
+        readFile: () => Promise.resolve(ok(JSON.stringify(invalidAst))),
+      });
+
+      await expect(
+        resolveProfileAst({
+          profileId: 'bad/foo',
+          superJson: mockSuperJson,
+          config,
+          crypto,
+          fileSystem,
+          fetchInstance,
+          logger,
+        })
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('when using version property', () => {
+    it('returns a valid profile when profile is found in grid', async () => {
+      fileSystem = MockFileSystem({
+        path: {
+          resolve: (...pathSegments: string[]) => pathSegments.join(''),
+        },
+        readFile: jest.fn(path => {
+          expect(path).toMatch('baz@1.2.3.supr.ast.json');
+
+          return Promise.resolve(
+            ok(
+              JSON.stringify(
+                mockProfileDocumentNode({
+                  name: 'baz',
+                  version: {
+                    major: 1,
+                    minor: 2,
+                    patch: 3,
+                  },
+                })
+              )
+            )
+          );
+        }),
+      });
+
+      const ast = await resolveProfileAst({
+        profileId: 'baz',
+        superJson: mockSuperJson,
+        config,
+        crypto,
+        fileSystem,
+        fetchInstance,
+        logger,
+      });
+      expect(ast.header.version).toEqual({ major: 1, minor: 2, patch: 3 });
+    });
+
+    it('returns a valid profile when profile is found in registry', async () => {
+      mocked(fetchProfileAst).mockResolvedValue(
+        mockProfileDocumentNode({
+          name: 'baz',
+          version: {
+            major: 1,
+            minor: 2,
+            patch: 3,
+          },
+        })
+      );
+      fileSystem = MockFileSystem({
+        path: {
+          resolve: (...pathSegments: string[]) => pathSegments.join(''),
+        },
+        readFile: jest.fn(path => {
+          expect(path).toMatch('baz@1.2.3.supr.ast.json');
+
+          return Promise.resolve(err(new NotFoundError('test')));
+        }),
+      });
+
+      const ast = await resolveProfileAst({
+        profileId: 'baz',
+        superJson: mockSuperJson,
+        config,
+        crypto,
+        fileSystem,
+        fetchInstance,
+        logger,
+      });
+      expect(ast.header.version).toEqual({ major: 1, minor: 2, patch: 3 });
+
+      expect(fetchProfileAst).toHaveBeenCalledWith(
+        'baz@1.2.3',
+        config,
+        crypto,
+        fetchInstance,
+        logger
+      );
+    });
+  });
+
+  describe('when using file property', () => {
+    it('rejects when profile points to a non-existent path', async () => {
+      const mockError = profileFileNotFoundError('../bar.supr.ast.json', 'bar');
+      fileSystem = MockFileSystem({
+        readFile: () => Promise.resolve(err(mockError)),
+      });
+
+      await expect(
+        resolveProfileAst({
+          profileId: 'bar',
+          superJson: mockSuperJson,
+          config,
+          crypto,
+          fileSystem,
+          fetchInstance,
+          logger,
+        })
+      ).rejects.toThrow(mockError);
+    });
+
+    it('returns a valid profile when it points to existing path', async () => {
+      fileSystem = MockFileSystem({
+        readFile: jest.fn(path => {
+          expect(path).toMatch('bar.supr.ast.json');
+
+          return Promise.resolve(
+            ok(
+              JSON.stringify(
+                mockProfileDocumentNode({
+                  name: 'bar',
+                  version: {
+                    major: 1,
+                    minor: 0,
+                    patch: 1,
+                  },
+                })
+              )
+            )
+          );
+        }),
+      });
+
+      const ast = await resolveProfileAst({
+        profileId: 'bar',
+        superJson: mockSuperJson,
+        config,
+        crypto,
+        fileSystem,
+        fetchInstance,
+        logger,
+      });
+      expect(ast.header.version).toEqual({ major: 1, minor: 0, patch: 1 });
+    });
+
+    it('rejects when loaded file is not valid ProfileDocumentNode', async () => {
+      const invalidAst: any = mockProfileDocumentNode({ name: 'bar' });
+      invalidAst.kind = 'broken';
+      fileSystem = MockFileSystem({
+        readFile: () => Promise.resolve(ok(JSON.stringify(invalidAst))),
+      });
+
+      await expect(
+        resolveProfileAst({
+          profileId: 'bar',
+          superJson: mockSuperJson,
+          config,
+          crypto,
+          fileSystem,
+          fetchInstance,
+          logger,
+        })
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/src/core/profile/resolve-profile-ast.ts
+++ b/src/core/profile/resolve-profile-ast.ts
@@ -1,0 +1,118 @@
+import {
+  assertProfileDocumentNode,
+  EXTENSIONS,
+  ProfileDocumentNode,
+} from '@superfaceai/ast';
+
+import { SuperJson } from '../../schema-tools';
+import {
+  NotFoundError,
+  profileFileNotFoundError,
+  profileNotFoundError,
+  sourceFileExtensionFoundError,
+  unsupportedFileExtensionError,
+} from '../errors';
+import { Interceptable } from '../events';
+import { IConfig, ICrypto, IFileSystem, ILogger } from '../interfaces';
+import { AuthCache, IFetch } from '../interpreter';
+import { fetchProfileAst } from '../registry';
+
+const DEBUG_NAMESPACE = 'profile-ast-resolution';
+
+/**
+ * Resolves profile AST file.
+ * File property:
+ *  - loads directly passed file
+ *  - can point only to .supr.ast.json file
+ *  - throws if file not found or not valid ProfileDocumentNode
+ * Version property:
+ *  - looks for [profileId]@[version].supr.ast.json file in superface/grid
+ *  - if not found it tries to fetch profile AST from Registry
+ * @returns ProfileDocumentNode
+ */
+export async function resolveProfileAst({
+  profileId,
+  logger,
+  superJson,
+  fileSystem,
+  config,
+  crypto,
+  fetchInstance,
+}: {
+  profileId: string;
+  logger?: ILogger;
+  superJson: SuperJson;
+  fileSystem: IFileSystem;
+  config: IConfig;
+  crypto: ICrypto;
+  fetchInstance: IFetch & Interceptable & AuthCache;
+}): Promise<ProfileDocumentNode> {
+  const logFunction = logger?.log(DEBUG_NAMESPACE);
+
+  const loadProfileAstFile = async (
+    fileNameWithExtension: string
+  ): Promise<ProfileDocumentNode> => {
+    const contents = await fileSystem.readFile(fileNameWithExtension);
+    if (contents.isErr()) {
+      if (contents.error instanceof NotFoundError) {
+        throw profileFileNotFoundError(fileNameWithExtension, profileId);
+      }
+      throw contents.error;
+    }
+
+    return assertProfileDocumentNode(JSON.parse(contents.value));
+  };
+
+  const profileSettings = superJson.normalized.profiles[profileId];
+
+  if (profileSettings === undefined) {
+    throw profileNotFoundError(profileId);
+  }
+  let filepath: string;
+  if ('file' in profileSettings) {
+    filepath = superJson.resolvePath(profileSettings.file);
+    logFunction?.('Reading possible profile file: %S', filepath);
+    // check extensions
+    if (filepath.endsWith(EXTENSIONS.profile.source)) {
+      // FIX:  SDKExecutionError is used to ensure correct formatting. Improve formatting of UnexpectedError
+      throw sourceFileExtensionFoundError(EXTENSIONS.profile.source);
+    } else if (!filepath.endsWith(EXTENSIONS.profile.build)) {
+      // FIX:  SDKExecutionError is used to ensure correct formatting. Improve formatting of UnexpectedError
+      throw unsupportedFileExtensionError(filepath, EXTENSIONS.profile.build);
+    }
+
+    return await loadProfileAstFile(filepath);
+  }
+  // assumed to be in grid folder under superface directory
+  const gridPath = fileSystem.path.join(
+    'grid',
+    `${profileId}@${profileSettings.version}`
+  );
+  const superfaceFolderPath = fileSystem.path.dirname(config.superfacePath);
+
+  filepath =
+    fileSystem.path.resolve(superfaceFolderPath, gridPath) +
+    EXTENSIONS.profile.build;
+
+  logFunction?.('Reading possible profile file: %S', filepath);
+  try {
+    return await loadProfileAstFile(filepath);
+  } catch (error) {
+    logFunction?.(
+      'Reading of possible profile file failed with error %O',
+      error
+    );
+    void error;
+  }
+
+  logFunction?.('Fetching profile file from registry');
+
+  // Fallback to remote
+  return fetchProfileAst(
+    `${profileId}@${profileSettings.version}`,
+    config,
+    crypto,
+    fetchInstance,
+    logger
+  );
+}

--- a/src/core/registry/registry.ts
+++ b/src/core/registry/registry.ts
@@ -246,6 +246,30 @@ export async function fetchBind(
   );
 }
 
+//TODO: fetch source or AST? Send AST/parser version to brain and let it deal with version matching?
+export async function fetchProfileSource(
+  profileId: string,
+  config: IConfig,
+  crypto: ICrypto,
+  fetchInstance: FetchInstance,
+  logger?: ILogger
+): Promise<string> {
+  const http = new HttpClient(fetchInstance, crypto, logger);
+  const sdkToken = config.sdkAuthToken;
+  logger?.log(DEBUG_NAMESPACE, `Getting source of profile: "${profileId}"`);
+
+  const { body } = await http.request(`/${profileId}`, {
+    method: 'GET',
+    headers: sdkToken
+      ? [`Authorization: SUPERFACE-SDK-TOKEN ${sdkToken}`]
+      : undefined,
+    baseUrl: config.superfaceApiUrl,
+    accept: 'application/vnd.superface.profile',
+  });
+
+  return body as string;
+}
+
 export async function fetchMapSource(
   mapId: string,
   config: IConfig,

--- a/src/core/registry/registry.ts
+++ b/src/core/registry/registry.ts
@@ -1,8 +1,10 @@
 import {
   assertMapDocumentNode,
+  assertProfileDocumentNode,
   assertProviderJson,
   isProviderJson,
   MapDocumentNode,
+  ProfileDocumentNode,
   ProviderJson,
 } from '@superfaceai/ast';
 
@@ -246,14 +248,13 @@ export async function fetchBind(
   );
 }
 
-// TODO: fetch source or AST? Send AST/parser version to brain and let it deal with version matching?
-export async function fetchProfileSource(
+export async function fetchProfileAst(
   profileId: string,
   config: IConfig,
   crypto: ICrypto,
   fetchInstance: FetchInstance,
   logger?: ILogger
-): Promise<string> {
+): Promise<ProfileDocumentNode> {
   const http = new HttpClient(fetchInstance, crypto, logger);
   const sdkToken = config.sdkAuthToken;
   logger?.log(DEBUG_NAMESPACE, `Getting source of profile: "${profileId}"`);
@@ -265,10 +266,14 @@ export async function fetchProfileSource(
         ? [`Authorization: SUPERFACE-SDK-TOKEN ${sdkToken}`]
         : undefined,
     baseUrl: config.superfaceApiUrl,
-    accept: 'application/vnd.superface.profile',
+    accept: 'application/vnd.superface.profile+json',
   });
 
-  return body as string;
+  if (typeof body === 'string') {
+    return assertProfileDocumentNode(JSON.parse(body));
+  }
+
+  throw new Error('TODO Invalid profile AST errr');
 }
 
 export async function fetchMapSource(

--- a/src/core/registry/registry.ts
+++ b/src/core/registry/registry.ts
@@ -257,7 +257,7 @@ export async function fetchProfileAst(
 ): Promise<ProfileDocumentNode> {
   const http = new HttpClient(fetchInstance, crypto, logger);
   const sdkToken = config.sdkAuthToken;
-  logger?.log(DEBUG_NAMESPACE, `Getting source of profile: "${profileId}"`);
+  logger?.log(DEBUG_NAMESPACE, `Getting AST of profile: "${profileId}"`);
 
   const { body } = await http.request(`/${profileId}`, {
     method: 'GET',

--- a/src/core/registry/registry.ts
+++ b/src/core/registry/registry.ts
@@ -269,11 +269,7 @@ export async function fetchProfileAst(
     accept: 'application/vnd.superface.profile+json',
   });
 
-  if (typeof body === 'string') {
-    return assertProfileDocumentNode(JSON.parse(body));
-  }
-
-  throw new Error('TODO Invalid profile AST errr');
+  return assertProfileDocumentNode(JSON.parse(body as string));
 }
 
 export async function fetchMapSource(

--- a/src/core/registry/registry.ts
+++ b/src/core/registry/registry.ts
@@ -246,7 +246,7 @@ export async function fetchBind(
   );
 }
 
-//TODO: fetch source or AST? Send AST/parser version to brain and let it deal with version matching?
+// TODO: fetch source or AST? Send AST/parser version to brain and let it deal with version matching?
 export async function fetchProfileSource(
   profileId: string,
   config: IConfig,
@@ -260,9 +260,10 @@ export async function fetchProfileSource(
 
   const { body } = await http.request(`/${profileId}`, {
     method: 'GET',
-    headers: sdkToken
-      ? [`Authorization: SUPERFACE-SDK-TOKEN ${sdkToken}`]
-      : undefined,
+    headers:
+      sdkToken !== undefined
+        ? [`Authorization: SUPERFACE-SDK-TOKEN ${sdkToken}`]
+        : undefined,
     baseUrl: config.superfaceApiUrl,
     accept: 'application/vnd.superface.profile',
   });

--- a/src/core/usecase/usecase.test.ts
+++ b/src/core/usecase/usecase.test.ts
@@ -1,11 +1,15 @@
 import { SuperCache } from '../../lib';
-import { MockFileSystem, MockTimers } from '../../mock';
+import {
+  MockFileSystem,
+  mockProfileDocumentNode,
+  MockTimers,
+} from '../../mock';
 import { CrossFetch, NodeCrypto, NodeFileSystem } from '../../node';
 import { SuperJson } from '../../schema-tools';
 import * as utils from '../../schema-tools/superjson/utils';
 import { Config } from '../config';
 import { Events, registerHooks } from '../events';
-import { ProfileConfiguration } from '../profile';
+import { Profile, ProfileBase, ProfileConfiguration } from '../profile';
 import { IBoundProfileProvider } from '../profile-provider';
 import { Provider, ProviderConfiguration } from '../provider';
 import { UseCase } from './usecase';
@@ -38,14 +42,28 @@ function createUseCase(cacheExpire?: number) {
 
   const mockProfileConfiguration = new ProfileConfiguration('test', '1.0.0');
 
-  const mockBoundProfileProvider2 = {
-    perform: jest.fn(),
-  };
-
   const cache = new SuperCache<{
     provider: IBoundProfileProvider;
     expiresAt: number;
   }>();
+
+  const profile: ProfileBase = new Profile(
+    mockProfileConfiguration,
+    mockProfileDocumentNode(),
+    events,
+    mockSuperJson,
+    new Config(MockFileSystem()),
+    timers,
+    MockFileSystem(),
+    cache,
+    crypto,
+    new CrossFetch(timers)
+  );
+
+  const mockBoundProfileProvider2 = {
+    perform: jest.fn(),
+  };
+
   cache.getCached(
     mockProfileConfiguration.cacheKey +
       new ProviderConfiguration('test-provider', []).cacheKey,
@@ -68,7 +86,7 @@ function createUseCase(cacheExpire?: number) {
   const config = new Config(NodeFileSystem);
 
   const usecase = new UseCase(
-    mockProfileConfiguration,
+    profile,
     'test-usecase',
     events,
     config,

--- a/src/core/usecase/usecase.ts
+++ b/src/core/usecase/usecase.ts
@@ -128,7 +128,7 @@ export abstract class UseCaseBase implements Interceptable {
     const { provider, expiresAt } =
       await this.boundProfileProviderCache.getCached(cacheKey, () =>
         bindProfileProvider(
-          this.profile,
+          this.profile.ast,
           providerConfig,
           this.superJson,
           this.config,

--- a/src/core/usecase/usecase.ts
+++ b/src/core/usecase/usecase.ts
@@ -236,8 +236,10 @@ export abstract class UseCaseBase implements Interceptable {
       console.warn(
         `Super.json sets provider failover priority to: "${profileEntry.priority.join(
           ', '
-        )}" but provider failover is not allowed for usecase "${this.name
-        }".\nTo allow provider failover please set property "providerFailover" in "${profileId}.defaults[${this.name
+        )}" but provider failover is not allowed for usecase "${
+          this.name
+        }".\nTo allow provider failover please set property "providerFailover" in "${profileId}.defaults[${
+          this.name
         }]" to true`
       );
     }
@@ -311,7 +313,7 @@ export abstract class UseCaseBase implements Interceptable {
       policy = new CircuitBreakerPolicy(
         usecaseInfo,
         retryPolicyConfig.maxContiguousRetries ??
-        RetryPolicy.DEFAULT_MAX_CONTIGUOUS_RETRIES,
+          RetryPolicy.DEFAULT_MAX_CONTIGUOUS_RETRIES,
         retryPolicyConfig.openTime ?? CircuitBreakerPolicy.DEFAULT_OPEN_TIME,
         retryPolicyConfig.requestTimeout ?? RetryPolicy.DEFAULT_REQUEST_TIMEOUT,
         backoff
@@ -320,7 +322,7 @@ export abstract class UseCaseBase implements Interceptable {
       policy = new RetryPolicy(
         usecaseInfo,
         retryPolicyConfig.maxContiguousRetries ??
-        RetryPolicy.DEFAULT_MAX_CONTIGUOUS_RETRIES,
+          RetryPolicy.DEFAULT_MAX_CONTIGUOUS_RETRIES,
         retryPolicyConfig.requestTimeout ?? RetryPolicy.DEFAULT_REQUEST_TIMEOUT,
         new ConstantBackoff(0)
       );

--- a/src/lib/utils/utils.ts
+++ b/src/lib/utils/utils.ts
@@ -6,4 +6,19 @@ export function profileAstId(ast: ProfileDocumentNode): string {
     : ast.header.name;
 }
 
+export function versionToString(version: {
+  major: number;
+  minor: number;
+  patch: number;
+  label?: string;
+}): string {
+  let versionString = `${version.major}.${version.minor}.${version.patch}`;
+
+  if (version.label !== undefined) {
+    versionString += `-${version.label}`;
+  }
+  
+return versionString;
+}
+
 export function forceCast<T>(_: unknown): asserts _ is T {}

--- a/src/lib/utils/utils.ts
+++ b/src/lib/utils/utils.ts
@@ -17,8 +17,8 @@ export function versionToString(version: {
   if (version.label !== undefined) {
     versionString += `-${version.label}`;
   }
-  
-return versionString;
+
+  return versionString;
 }
 
 export function forceCast<T>(_: unknown): asserts _ is T {}

--- a/src/mock/client.ts
+++ b/src/mock/client.ts
@@ -31,7 +31,7 @@ import { SuperCache } from '../lib/cache';
 import { NodeCrypto, NodeFetch, NodeFileSystem, NodeLogger } from '../node';
 import { getProvider, getProviderForProfile, SuperJson } from '../schema-tools';
 import { MockEnvironment } from './environment';
-import { MockFileSystem } from './filesystem';
+import { IPartialFileSystem, MockFileSystem } from './filesystem';
 import { MockTimers } from './timers';
 
 const mockProviderJson = (name: string): ProviderJson => ({
@@ -64,7 +64,7 @@ export class MockClient implements ISuperfaceClient {
     public superJson: SuperJson,
     parameters?: {
       configOverride?: Partial<IConfig>;
-      fileSystemOverride?: Partial<IFileSystem>;
+      fileSystemOverride?: IPartialFileSystem;
     }
   ) {
     // TODO: test logger?
@@ -97,14 +97,9 @@ export class MockClient implements ISuperfaceClient {
       expiresAt: number;
     }>();
 
-    let fileSystem: IFileSystem = MockFileSystem();
-
-    if (parameters?.fileSystemOverride !== undefined) {
-      fileSystem = {
-        ...fileSystem,
-        ...parameters.fileSystemOverride,
-      };
-    }
+    const fileSystem: IFileSystem = MockFileSystem(
+      parameters?.fileSystemOverride
+    );
 
     this.internalClient = new InternalClient(
       this.events,

--- a/src/mock/filesystem.ts
+++ b/src/mock/filesystem.ts
@@ -1,43 +1,51 @@
 import { FileSystemError, IFileSystem } from '../core';
 import { ok, Result } from '../lib/result/result';
 
-export const MockFileSystem: () => IFileSystem = () => ({
+export type IPartialFileSystem = Partial<Omit<IFileSystem, 'path' | 'sync'>> & {
+  path?: Partial<IFileSystem['path']>;
+  sync?: Partial<IFileSystem['sync']>;
+};
+export const MockFileSystem = (
+  fileSystem?: IPartialFileSystem
+): IFileSystem => ({
   sync: {
-    exists: jest.fn(() => true),
-    isAccessible: jest.fn(() => true),
-    isDirectory: jest.fn(() => false),
-    isFile: jest.fn(() => true),
-    mkdir: jest.fn(() => ok(undefined)),
-    readFile: jest.fn(() => ok('')),
-    readdir: jest.fn(() => ok([])),
-    rm: jest.fn(() => ok(undefined)),
-    writeFile: jest.fn(() => ok(undefined)),
+    exists: fileSystem?.sync?.exists ?? jest.fn(() => true),
+    isAccessible: fileSystem?.sync?.isAccessible ?? jest.fn(() => true),
+    isDirectory: fileSystem?.sync?.isDirectory ?? jest.fn(() => false),
+    isFile: fileSystem?.sync?.isFile ?? jest.fn(() => true),
+    mkdir: fileSystem?.sync?.mkdir ?? jest.fn(() => ok(undefined)),
+    readFile: fileSystem?.sync?.readFile ?? jest.fn(() => ok('')),
+    readdir: fileSystem?.sync?.readdir ?? jest.fn(() => ok([])),
+    rm: fileSystem?.sync?.rm ?? jest.fn(() => ok(undefined)),
+    writeFile: fileSystem?.sync?.writeFile ?? jest.fn(() => ok(undefined)),
   },
   path: {
-    cwd: jest.fn(() => '.'),
-    dirname: jest.fn(() => ''),
-    join: jest.fn((...strings: string[]) => strings.join('/')),
-    normalize: jest.fn((path: string) => path),
-    resolve: jest.fn(() => ''),
-    relative: jest.fn(() => ''),
+    cwd: fileSystem?.path?.cwd ?? jest.fn(() => '.'),
+    dirname: fileSystem?.path?.dirname ?? jest.fn(() => ''),
+    join:
+      fileSystem?.path?.join ??
+      jest.fn((...strings: string[]) => strings.join('/')),
+    normalize: fileSystem?.path?.normalize ?? jest.fn((path: string) => path),
+    resolve: fileSystem?.path?.resolve ?? jest.fn(() => ''),
+    relative: fileSystem?.path?.relative ?? jest.fn(() => ''),
   },
-  exists: jest.fn(async () => true),
-  isAccessible: jest.fn(async () => true),
-  isDirectory: jest.fn(async () => true),
-  isFile: jest.fn(async () => true),
-  mkdir: jest.fn(
-    async (): Promise<Result<void, FileSystemError>> => ok(undefined)
-  ),
-  readFile: jest.fn(
-    async (): Promise<Result<string, FileSystemError>> => ok('')
-  ),
-  readdir: jest.fn(
-    async (): Promise<Result<string[], FileSystemError>> => ok([])
-  ),
-  rm: jest.fn(
-    async (): Promise<Result<void, FileSystemError>> => ok(undefined)
-  ),
-  writeFile: jest.fn(
-    async (): Promise<Result<void, FileSystemError>> => ok(undefined)
-  ),
+  exists: fileSystem?.exists ?? jest.fn(async () => true),
+  isAccessible: fileSystem?.isAccessible ?? jest.fn(async () => true),
+  isDirectory: fileSystem?.isDirectory ?? jest.fn(async () => true),
+  isFile: fileSystem?.isFile ?? jest.fn(async () => true),
+  mkdir:
+    fileSystem?.mkdir ??
+    jest.fn(async (): Promise<Result<void, FileSystemError>> => ok(undefined)),
+  readFile:
+    fileSystem?.readFile ??
+    jest.fn(async (): Promise<Result<string, FileSystemError>> => ok('')),
+  readdir:
+    fileSystem?.readdir ??
+    jest.fn(async (): Promise<Result<string[], FileSystemError>> => ok([])),
+  rm:
+    fileSystem?.rm ??
+    jest.fn(async (): Promise<Result<void, FileSystemError>> => ok(undefined)),
+  writeFile:
+    fileSystem?.writeFile ??
+    jest.fn(async (): Promise<Result<void, FileSystemError>> => ok(undefined)),
 });

--- a/src/mock/index.ts
+++ b/src/mock/index.ts
@@ -2,3 +2,4 @@ export * from './client';
 export * from './environment';
 export * from './filesystem';
 export * from './timers';
+export * from './profile-document-node';

--- a/src/mock/profile-document-node.ts
+++ b/src/mock/profile-document-node.ts
@@ -1,0 +1,66 @@
+import { ProfileDocumentNode } from '@superfaceai/ast';
+
+export const mockProfileDocumentNode = (options?: {
+  name?: string;
+  scope?: string;
+  version?: {
+    major: number;
+    minor: number;
+    patch: number;
+    label?: string;
+  };
+  usecaseName?: string;
+}): ProfileDocumentNode => ({
+  kind: 'ProfileDocument',
+  astMetadata: {
+    sourceChecksum: 'checksum',
+    astVersion: {
+      major: 1,
+      minor: 0,
+      patch: 0,
+    },
+    parserVersion: {
+      major: 1,
+      minor: 0,
+      patch: 0,
+    },
+  },
+  header: {
+    kind: 'ProfileHeader',
+    scope: options?.scope,
+    name: options?.name ?? 'test',
+    version: {
+      major: options?.version?.major ?? 1,
+      minor: options?.version?.minor ?? 0,
+      patch: options?.version?.patch ?? 0,
+      label: options?.version?.label,
+    },
+  },
+  definitions: [
+    {
+      kind: 'UseCaseDefinition',
+      useCaseName: options?.usecaseName ?? 'Test',
+      safety: 'safe',
+      result: {
+        kind: 'UseCaseSlotDefinition',
+        value: {
+          kind: 'ObjectDefinition',
+          fields: [
+            {
+              kind: 'FieldDefinition',
+              fieldName: 'message',
+              required: true,
+              type: {
+                kind: 'NonNullDefinition',
+                type: {
+                  kind: 'PrimitiveTypeName',
+                  name: 'string',
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+  ],
+});

--- a/src/node/client/client.integration.test.ts
+++ b/src/node/client/client.integration.test.ts
@@ -1,7 +1,7 @@
 import { ProviderJson } from '@superfaceai/ast';
 import { parseMap, parseProfile, Source } from '@superfaceai/parser';
 
-import { ProfileProvider } from '../../core';
+import { InternalClient, ProfileProvider } from '../../core';
 import { ok } from '../../lib';
 import { SuperJson } from '../../schema-tools';
 import { SuperfaceClient } from './client';
@@ -91,7 +91,7 @@ describe('SuperfaceClient integration test', () => {
     // Let .bind happen with mocked inputs
     // Mocking private property of ProfileProvider
     jest
-      .spyOn(ProfileProvider.prototype as any, 'resolveProfileAst')
+      .spyOn(InternalClient.prototype, 'resolveProfileAst')
       .mockResolvedValue(mockProfileDocument);
     jest
       .spyOn(ProfileProvider.prototype as any, 'resolveProviderInfo')
@@ -116,7 +116,7 @@ describe('SuperfaceClient integration test', () => {
     // Let .bind happen with mocked inputs
     // Mocking private property of ProfileProvider
     jest
-      .spyOn(ProfileProvider.prototype as any, 'resolveProfileAst')
+      .spyOn(InternalClient.prototype, 'resolveProfileAst')
       .mockResolvedValue(mockProfileDocument);
     jest
       .spyOn(ProfileProvider.prototype as any, 'resolveProviderInfo')
@@ -140,7 +140,7 @@ describe('SuperfaceClient integration test', () => {
   describe('typed client', () => {
     it('should perform successfully', async () => {
       jest
-        .spyOn(ProfileProvider.prototype as any, 'resolveProfileAst')
+        .spyOn(InternalClient.prototype, 'resolveProfileAst')
         .mockResolvedValue(mockProfileDocument);
       jest
         .spyOn(ProfileProvider.prototype as any, 'resolveProviderInfo')

--- a/src/node/client/client.integration.test.ts
+++ b/src/node/client/client.integration.test.ts
@@ -1,11 +1,14 @@
 import { ProviderJson } from '@superfaceai/ast';
 import { parseMap, parseProfile, Source } from '@superfaceai/parser';
+import { mocked } from 'ts-jest/utils';
 
-import { InternalClient, ProfileProvider } from '../../core';
+import { ProfileProvider, resolveProfileAst } from '../../core';
 import { ok } from '../../lib';
 import { SuperJson } from '../../schema-tools';
 import { SuperfaceClient } from './client';
 import { createTypedClient, typeHelper } from './client.typed';
+
+jest.mock('../../core/profile/resolve-profile-ast');
 
 const parseMapFromSource = (source: string) =>
   parseMap(
@@ -89,10 +92,8 @@ describe('SuperfaceClient integration test', () => {
     const client = new SuperfaceClient();
 
     // Let .bind happen with mocked inputs
+    mocked(resolveProfileAst).mockResolvedValue(mockProfileDocument);
     // Mocking private property of ProfileProvider
-    jest
-      .spyOn(InternalClient.prototype, 'resolveProfileAst')
-      .mockResolvedValue(mockProfileDocument);
     jest
       .spyOn(ProfileProvider.prototype as any, 'resolveProviderInfo')
       .mockResolvedValue({
@@ -114,10 +115,8 @@ describe('SuperfaceClient integration test', () => {
     const client = new SuperfaceClient();
 
     // Let .bind happen with mocked inputs
+    mocked(resolveProfileAst).mockResolvedValue(mockProfileDocument);
     // Mocking private property of ProfileProvider
-    jest
-      .spyOn(InternalClient.prototype, 'resolveProfileAst')
-      .mockResolvedValue(mockProfileDocument);
     jest
       .spyOn(ProfileProvider.prototype as any, 'resolveProviderInfo')
       .mockResolvedValue({
@@ -139,9 +138,8 @@ describe('SuperfaceClient integration test', () => {
 
   describe('typed client', () => {
     it('should perform successfully', async () => {
-      jest
-        .spyOn(InternalClient.prototype, 'resolveProfileAst')
-        .mockResolvedValue(mockProfileDocument);
+      mocked(resolveProfileAst).mockResolvedValue(mockProfileDocument);
+      // Mocking private property of ProfileProvider
       jest
         .spyOn(ProfileProvider.prototype as any, 'resolveProviderInfo')
         .mockResolvedValue({

--- a/src/node/client/client.test.ts
+++ b/src/node/client/client.test.ts
@@ -1,10 +1,24 @@
+import { ProfileDocumentNode } from '@superfaceai/ast';
+import { mocked } from 'ts-jest/utils';
+
+import { NotFoundError } from '../../core';
+import { fetchProfileAst } from '../../core/registry';
+import { err, ok } from '../../lib';
 import { MockClient } from '../../mock';
 import { getProviderForProfile, SuperJson } from '../../schema-tools';
 
 const mockSuperJson = new SuperJson({
   profiles: {
     'testy/mctestface': '0.1.0',
-    foo: 'file://../foo.supr',
+    foo: 'file://../foo.supr.ast.json',
+    'evil/foo': 'file://../foo.supr',
+    'bad/foo': 'file://../foo.ts',
+    bar: {
+      file: '../bar.supr.ast.json',
+      providers: {
+        quz: {},
+      },
+    },
     baz: {
       version: '1.2.3',
       providers: {
@@ -29,11 +43,77 @@ const mockSuperJsonCustomPath = new SuperJson({
     quz: {},
   },
 });
+// TODO: move to some fixtures?
+const mockProfileDocument = (
+  name: string,
+  scope?: string,
+  version?: {
+    major: number;
+    minor: number;
+    patch: number;
+    label?: string;
+  }
+): ProfileDocumentNode => ({
+  kind: 'ProfileDocument',
+  astMetadata: {
+    sourceChecksum: 'checksum',
+    astVersion: {
+      major: 1,
+      minor: 0,
+      patch: 0,
+    },
+    parserVersion: {
+      major: 1,
+      minor: 0,
+      patch: 0,
+    },
+  },
+  header: {
+    kind: 'ProfileHeader',
+    scope,
+    name,
+    version: {
+      major: version?.major ?? 1,
+      minor: version?.minor ?? 0,
+      patch: version?.patch ?? 0,
+      label: version?.label,
+    },
+  },
+  definitions: [
+    {
+      kind: 'UseCaseDefinition',
+      useCaseName: 'Test',
+      safety: 'safe',
+      result: {
+        kind: 'UseCaseSlotDefinition',
+        value: {
+          kind: 'ObjectDefinition',
+          fields: [
+            {
+              kind: 'FieldDefinition',
+              fieldName: 'message',
+              required: true,
+              type: {
+                kind: 'NonNullDefinition',
+                type: {
+                  kind: 'PrimitiveTypeName',
+                  name: 'string',
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+  ],
+});
 
 afterEach(() => {
   jest.useRealTimers();
+  jest.resetAllMocks();
 });
 
+jest.mock('../../core/registry');
 jest.mock('../../core/events/failure/event-adapter');
 
 describe('superface client', () => {
@@ -46,43 +126,233 @@ describe('superface client', () => {
       );
     });
 
-    it('rejects when profile points to a non-existent path', async () => {
-      const client = new MockClient(mockSuperJson, {
-        fileSystemOverride: {
-          exists: jest.fn(async (path: string) => {
-            expect(path).toMatch('foo.supr');
+    describe('when using entry with version only', () => {
+      it('returns a valid profile when profile is found in grid', async () => {
+        const client = new MockClient(mockSuperJson, {
+          fileSystemOverride: {
+            readFile: jest.fn(path => {
+              expect(path).toMatch('testy/mctestface@0.1.0.supr.ast.json');
 
-            return false;
-          }),
-        },
+              return Promise.resolve(
+                ok(
+                  JSON.stringify(
+                    mockProfileDocument('mctestface', 'testy', {
+                      major: 0,
+                      minor: 1,
+                      patch: 0,
+                    })
+                  )
+                )
+              );
+            }),
+          },
+        });
+
+        const profile = await client.getProfile('testy/mctestface');
+        expect(profile.configuration.version).toBe('0.1.0');
       });
 
-      await expect(client.getProfile('foo')).rejects.toThrow(
-        `Profile "foo" specifies a file path "../foo.supr" in super.json
-but this path does not exist or is not accessible`
-      );
+      it('returns a valid profile when profile is found in registry', async () => {
+        mocked(fetchProfileAst).mockResolvedValue(
+          mockProfileDocument('mctestface', 'testy', {
+            major: 0,
+            minor: 1,
+            patch: 0,
+          })
+        );
+        const client = new MockClient(mockSuperJson, {
+          fileSystemOverride: {
+            readFile: jest.fn(path => {
+              expect(path).toMatch('testy/mctestface@0.1.0.supr.ast.json');
+
+              return Promise.resolve(err(new NotFoundError('test')));
+            }),
+          },
+        });
+
+        const profile = await client.getProfile('testy/mctestface');
+        expect(profile.configuration.version).toBe('0.1.0');
+        expect(fetchProfileAst).toHaveBeenCalledWith(
+          'testy/mctestface@0.1.0',
+          client.config,
+          client.crypto,
+          expect.anything(),
+          expect.anything()
+        );
+      });
     });
 
-    it('returns a valid profile when it points to existing path', async () => {
-      const client = new MockClient(mockSuperJson, {
-        fileSystemOverride: {
-          exists: jest.fn(async (path: string) => {
-            expect(path).toMatch('foo.supr');
+    describe('when using entry with filepath only', () => {
+      it('rejects when profile points to a non-existent path', async () => {
+        const mockError = new NotFoundError('test');
+        const client = new MockClient(mockSuperJson, {
+          fileSystemOverride: {
+            readFile: () => Promise.resolve(err(mockError)),
+          },
+        });
 
-            return true;
-          }),
-        },
+        await expect(client.getProfile('foo')).rejects.toThrow(mockError);
       });
 
-      const profile = await client.getProfile('foo');
-      expect(profile.configuration.version).toBe('unknown');
+      it('rejects when profile points to a path with .supr extension', async () => {
+        const client = new MockClient(mockSuperJson);
+
+        await expect(client.getProfile('evil/foo')).rejects.toThrow(
+          new Error('TODO invalid extenstion err -needs to be compiled')
+        );
+      });
+
+      it('rejects when profile points to a path with unsupported extension', async () => {
+        const client = new MockClient(mockSuperJson);
+
+        await expect(client.getProfile('bad/foo')).rejects.toThrow(
+          new Error('TODO invalid extenstion err')
+        );
+      });
+
+      it('returns a valid profile when it points to existing path', async () => {
+        const client = new MockClient(mockSuperJson, {
+          fileSystemOverride: {
+            readFile: jest.fn(path => {
+              expect(path).toMatch('foo.supr.ast.json');
+
+              return Promise.resolve(
+                ok(
+                  JSON.stringify(
+                    mockProfileDocument('foo', undefined, {
+                      major: 1,
+                      minor: 0,
+                      patch: 1,
+                      label: 'test',
+                    })
+                  )
+                )
+              );
+            }),
+          },
+        });
+
+        const profile = await client.getProfile('foo');
+        expect(profile.configuration.version).toBe('1.0.1-test');
+      });
+
+      it('rejects when loaded file is not valid ProfileDocumentNode', async () => {
+        const invalidAst: any = mockProfileDocument('foo');
+        invalidAst.kind = 'broken';
+        const client = new MockClient(mockSuperJson, {
+          fileSystemOverride: {
+            readFile: () => Promise.resolve(ok(JSON.stringify(invalidAst))),
+          },
+        });
+
+        await expect(client.getProfile('foo')).rejects.toThrow();
+      });
     });
 
-    it('returns a valid profile when it points to existing path - known version', async () => {
-      const client = new MockClient(mockSuperJson);
+    describe('when using version property', () => {
+      it('returns a valid profile when profile is found in grid', async () => {
+        const client = new MockClient(mockSuperJson, {
+          fileSystemOverride: {
+            readFile: jest.fn(path => {
+              expect(path).toMatch('baz@1.2.3.supr.ast.json');
 
-      const profile = await client.getProfile('baz');
-      expect(profile.configuration.version).toBe('1.2.3');
+              return Promise.resolve(
+                ok(
+                  JSON.stringify(
+                    mockProfileDocument('baz', undefined, {
+                      major: 1,
+                      minor: 2,
+                      patch: 3,
+                    })
+                  )
+                )
+              );
+            }),
+          },
+        });
+
+        const profile = await client.getProfile('baz');
+        expect(profile.configuration.version).toBe('1.2.3');
+      });
+
+      it('returns a valid profile when profile is found in registry', async () => {
+        mocked(fetchProfileAst).mockResolvedValue(
+          mockProfileDocument('baz', undefined, {
+            major: 1,
+            minor: 2,
+            patch: 3,
+          })
+        );
+        const client = new MockClient(mockSuperJson, {
+          fileSystemOverride: {
+            readFile: jest.fn(path => {
+              expect(path).toMatch('baz@1.2.3.supr.ast.json');
+
+              return Promise.resolve(err(new NotFoundError('test')));
+            }),
+          },
+        });
+
+        const profile = await client.getProfile('baz');
+        expect(profile.configuration.version).toBe('1.2.3');
+        expect(fetchProfileAst).toHaveBeenCalledWith(
+          'baz@1.2.3',
+          client.config,
+          client.crypto,
+          expect.anything(),
+          expect.anything()
+        );
+      });
+    });
+
+    describe('when using file property', () => {
+      it('rejects when profile points to a non-existent path', async () => {
+        const mockError = new NotFoundError('test');
+        const client = new MockClient(mockSuperJson, {
+          fileSystemOverride: {
+            readFile: () => Promise.resolve(err(mockError)),
+          },
+        });
+
+        await expect(client.getProfile('bar')).rejects.toThrow(mockError);
+      });
+
+      it('returns a valid profile when it points to existing path', async () => {
+        const client = new MockClient(mockSuperJson, {
+          fileSystemOverride: {
+            readFile: jest.fn(path => {
+              expect(path).toMatch('bar.supr.ast.json');
+
+              return Promise.resolve(
+                ok(
+                  JSON.stringify(
+                    mockProfileDocument('bar', undefined, {
+                      major: 1,
+                      minor: 0,
+                      patch: 1,
+                    })
+                  )
+                )
+              );
+            }),
+          },
+        });
+
+        const profile = await client.getProfile('bar');
+        expect(profile.configuration.version).toBe('1.0.1');
+      });
+
+      it('rejects when loaded file is not valid ProfileDocumentNode', async () => {
+        const invalidAst: any = mockProfileDocument('bar');
+        invalidAst.kind = 'broken';
+        const client = new MockClient(mockSuperJson, {
+          fileSystemOverride: {
+            readFile: () => Promise.resolve(ok(JSON.stringify(invalidAst))),
+          },
+        });
+
+        await expect(client.getProfile('bar')).rejects.toThrow();
+      });
     });
   });
 

--- a/src/node/client/client.test.ts
+++ b/src/node/client/client.test.ts
@@ -1,10 +1,9 @@
-import { ProfileDocumentNode } from '@superfaceai/ast';
 import { mocked } from 'ts-jest/utils';
 
 import { NotFoundError } from '../../core';
 import { fetchProfileAst } from '../../core/registry';
 import { err, ok } from '../../lib';
-import { MockClient } from '../../mock';
+import { MockClient, mockProfileDocumentNode } from '../../mock';
 import { getProviderForProfile, SuperJson } from '../../schema-tools';
 
 const mockSuperJson = new SuperJson({
@@ -43,70 +42,6 @@ const mockSuperJsonCustomPath = new SuperJson({
     quz: {},
   },
 });
-// TODO: move to some fixtures?
-const mockProfileDocument = (
-  name: string,
-  scope?: string,
-  version?: {
-    major: number;
-    minor: number;
-    patch: number;
-    label?: string;
-  }
-): ProfileDocumentNode => ({
-  kind: 'ProfileDocument',
-  astMetadata: {
-    sourceChecksum: 'checksum',
-    astVersion: {
-      major: 1,
-      minor: 0,
-      patch: 0,
-    },
-    parserVersion: {
-      major: 1,
-      minor: 0,
-      patch: 0,
-    },
-  },
-  header: {
-    kind: 'ProfileHeader',
-    scope,
-    name,
-    version: {
-      major: version?.major ?? 1,
-      minor: version?.minor ?? 0,
-      patch: version?.patch ?? 0,
-      label: version?.label,
-    },
-  },
-  definitions: [
-    {
-      kind: 'UseCaseDefinition',
-      useCaseName: 'Test',
-      safety: 'safe',
-      result: {
-        kind: 'UseCaseSlotDefinition',
-        value: {
-          kind: 'ObjectDefinition',
-          fields: [
-            {
-              kind: 'FieldDefinition',
-              fieldName: 'message',
-              required: true,
-              type: {
-                kind: 'NonNullDefinition',
-                type: {
-                  kind: 'PrimitiveTypeName',
-                  name: 'string',
-                },
-              },
-            },
-          ],
-        },
-      },
-    },
-  ],
-});
 
 afterEach(() => {
   jest.useRealTimers();
@@ -136,10 +71,14 @@ describe('superface client', () => {
               return Promise.resolve(
                 ok(
                   JSON.stringify(
-                    mockProfileDocument('mctestface', 'testy', {
-                      major: 0,
-                      minor: 1,
-                      patch: 0,
+                    mockProfileDocumentNode({
+                      name: 'mctestface',
+                      scope: 'testy',
+                      version: {
+                        major: 0,
+                        minor: 1,
+                        patch: 0,
+                      },
                     })
                   )
                 )
@@ -154,10 +93,14 @@ describe('superface client', () => {
 
       it('returns a valid profile when profile is found in registry', async () => {
         mocked(fetchProfileAst).mockResolvedValue(
-          mockProfileDocument('mctestface', 'testy', {
-            major: 0,
-            minor: 1,
-            patch: 0,
+          mockProfileDocumentNode({
+            name: 'mctestface',
+            scope: 'testy',
+            version: {
+              major: 0,
+              minor: 1,
+              patch: 0,
+            },
           })
         );
         const client = new MockClient(mockSuperJson, {
@@ -219,11 +162,14 @@ describe('superface client', () => {
               return Promise.resolve(
                 ok(
                   JSON.stringify(
-                    mockProfileDocument('foo', undefined, {
-                      major: 1,
-                      minor: 0,
-                      patch: 1,
-                      label: 'test',
+                    mockProfileDocumentNode({
+                      name: 'foo',
+                      version: {
+                        major: 1,
+                        minor: 0,
+                        patch: 1,
+                        label: 'test',
+                      },
                     })
                   )
                 )
@@ -237,7 +183,7 @@ describe('superface client', () => {
       });
 
       it('rejects when loaded file is not valid ProfileDocumentNode', async () => {
-        const invalidAst: any = mockProfileDocument('foo');
+        const invalidAst: any = mockProfileDocumentNode({ name: 'foo' });
         invalidAst.kind = 'broken';
         const client = new MockClient(mockSuperJson, {
           fileSystemOverride: {
@@ -259,10 +205,13 @@ describe('superface client', () => {
               return Promise.resolve(
                 ok(
                   JSON.stringify(
-                    mockProfileDocument('baz', undefined, {
-                      major: 1,
-                      minor: 2,
-                      patch: 3,
+                    mockProfileDocumentNode({
+                      name: 'baz',
+                      version: {
+                        major: 1,
+                        minor: 2,
+                        patch: 3,
+                      },
                     })
                   )
                 )
@@ -277,10 +226,13 @@ describe('superface client', () => {
 
       it('returns a valid profile when profile is found in registry', async () => {
         mocked(fetchProfileAst).mockResolvedValue(
-          mockProfileDocument('baz', undefined, {
-            major: 1,
-            minor: 2,
-            patch: 3,
+          mockProfileDocumentNode({
+            name: 'baz',
+            version: {
+              major: 1,
+              minor: 2,
+              patch: 3,
+            },
           })
         );
         const client = new MockClient(mockSuperJson, {
@@ -326,10 +278,13 @@ describe('superface client', () => {
               return Promise.resolve(
                 ok(
                   JSON.stringify(
-                    mockProfileDocument('bar', undefined, {
-                      major: 1,
-                      minor: 0,
-                      patch: 1,
+                    mockProfileDocumentNode({
+                      name: 'bar',
+                      version: {
+                        major: 1,
+                        minor: 0,
+                        patch: 1,
+                      },
                     })
                   )
                 )
@@ -343,7 +298,7 @@ describe('superface client', () => {
       });
 
       it('rejects when loaded file is not valid ProfileDocumentNode', async () => {
-        const invalidAst: any = mockProfileDocument('bar');
+        const invalidAst: any = mockProfileDocumentNode({ name: 'bar' });
         invalidAst.kind = 'broken';
         const client = new MockClient(mockSuperJson, {
           fileSystemOverride: {

--- a/src/node/client/client.test.ts
+++ b/src/node/client/client.test.ts
@@ -4,7 +4,8 @@ import { mocked } from 'ts-jest/utils';
 import {
   NotFoundError,
   profileFileNotFoundError,
-  SDKExecutionError,
+  sourceFileExtensionFoundError,
+  unsupportedFileExtensionError,
 } from '../../core';
 import { fetchProfileAst } from '../../core/registry';
 import { err, ok } from '../../lib';
@@ -149,13 +150,7 @@ describe('superface client', () => {
         const client = new MockClient(mockSuperJson);
 
         await expect(client.getProfile('evil/foo')).rejects.toThrow(
-          new SDKExecutionError(
-            `${EXTENSIONS.profile.source} extension found.`,
-            [],
-            [
-              `${EXTENSIONS.profile.source} files needs to be compiled with Superface CLI.`,
-            ]
-          )
+          sourceFileExtensionFoundError(EXTENSIONS.profile.source)
         );
       });
 
@@ -163,12 +158,9 @@ describe('superface client', () => {
         const client = new MockClient(mockSuperJson);
 
         await expect(client.getProfile('bad/foo')).rejects.toThrow(
-          new SDKExecutionError(
-            `File paths ${mockSuperJson.resolvePath(
-              '../foo.ts'
-            )} contains unsupported extension.`,
-            [],
-            [`Use file with ${EXTENSIONS.profile.build} extension.`]
+          unsupportedFileExtensionError(
+            mockSuperJson.resolvePath('../foo.ts'),
+            EXTENSIONS.profile.build
           )
         );
       });

--- a/src/node/client/client.test.ts
+++ b/src/node/client/client.test.ts
@@ -71,6 +71,9 @@ describe('superface client', () => {
       it('returns a valid profile when profile is found in grid', async () => {
         const client = new MockClient(mockSuperJson, {
           fileSystemOverride: {
+            path: {
+              resolve: (...pathSegments: string[]) => pathSegments.join(''),
+            },
             readFile: jest.fn(path => {
               expect(path).toMatch('testy/mctestface@0.1.0.supr.ast.json');
 
@@ -111,6 +114,9 @@ describe('superface client', () => {
         );
         const client = new MockClient(mockSuperJson, {
           fileSystemOverride: {
+            path: {
+              resolve: (...pathSegments: string[]) => pathSegments.join(''),
+            },
             readFile: jest.fn(path => {
               expect(path).toMatch('testy/mctestface@0.1.0.supr.ast.json');
 
@@ -211,6 +217,9 @@ describe('superface client', () => {
       it('returns a valid profile when profile is found in grid', async () => {
         const client = new MockClient(mockSuperJson, {
           fileSystemOverride: {
+            path: {
+              resolve: (...pathSegments: string[]) => pathSegments.join(''),
+            },
             readFile: jest.fn(path => {
               expect(path).toMatch('baz@1.2.3.supr.ast.json');
 
@@ -249,6 +258,9 @@ describe('superface client', () => {
         );
         const client = new MockClient(mockSuperJson, {
           fileSystemOverride: {
+            path: {
+              resolve: (...pathSegments: string[]) => pathSegments.join(''),
+            },
             readFile: jest.fn(path => {
               expect(path).toMatch('baz@1.2.3.supr.ast.json');
 

--- a/src/node/client/client.test.ts
+++ b/src/node/client/client.test.ts
@@ -1,14 +1,6 @@
-import { EXTENSIONS } from '@superfaceai/ast';
 import { mocked } from 'ts-jest/utils';
 
-import {
-  NotFoundError,
-  profileFileNotFoundError,
-  sourceFileExtensionFoundError,
-  unsupportedFileExtensionError,
-} from '../../core';
-import { fetchProfileAst } from '../../core/registry';
-import { err, ok } from '../../lib';
+import { ProfileConfiguration, resolveProfileAst } from '../../core';
 import { MockClient, mockProfileDocumentNode } from '../../mock';
 import { getProviderForProfile, SuperJson } from '../../schema-tools';
 
@@ -40,308 +32,52 @@ const mockSuperJson = new SuperJson({
   },
 });
 
-const mockSuperJsonCustomPath = new SuperJson({
-  profiles: {
-    test: '2.1.0',
-  },
-  providers: {
-    quz: {},
-  },
-});
-
 afterEach(() => {
   jest.useRealTimers();
   jest.resetAllMocks();
 });
 
 jest.mock('../../core/registry');
+jest.mock('../../core/profile/resolve-profile-ast');
 jest.mock('../../core/events/failure/event-adapter');
 
 describe('superface client', () => {
   describe('getProfile', () => {
-    it('rejects when profile does not exists', async () => {
+    it('retruns Profile instance', async () => {
+      const ast = mockProfileDocumentNode({
+        name: 'testy/mctestface',
+        version: {
+          major: 1,
+          minor: 0,
+          patch: 0,
+        },
+      });
+      mocked(resolveProfileAst).mockResolvedValue(ast);
       const client = new MockClient(mockSuperJson);
 
-      await expect(client.getProfile('does/not-exist')).rejects.toThrow(
-        'Profile "does/not-exist" not found in super.json'
+      const profile = await client.getProfile('testy/mctestface');
+
+      expect(profile.ast).toEqual(ast);
+      expect(profile.configuration).toEqual(
+        new ProfileConfiguration('testy/mctestface', '1.0.0')
       );
-    });
-
-    describe('when using entry with version only', () => {
-      it('returns a valid profile when profile is found in grid', async () => {
-        const client = new MockClient(mockSuperJson, {
-          fileSystemOverride: {
-            path: {
-              resolve: (...pathSegments: string[]) => pathSegments.join(''),
-            },
-            readFile: jest.fn(path => {
-              expect(path).toMatch('testy/mctestface@0.1.0.supr.ast.json');
-
-              return Promise.resolve(
-                ok(
-                  JSON.stringify(
-                    mockProfileDocumentNode({
-                      name: 'mctestface',
-                      scope: 'testy',
-                      version: {
-                        major: 0,
-                        minor: 1,
-                        patch: 0,
-                      },
-                    })
-                  )
-                )
-              );
-            }),
-          },
-        });
-
-        const profile = await client.getProfile('testy/mctestface');
-        expect(profile.configuration.version).toBe('0.1.0');
-      });
-
-      it('returns a valid profile when profile is found in registry', async () => {
-        mocked(fetchProfileAst).mockResolvedValue(
-          mockProfileDocumentNode({
-            name: 'mctestface',
-            scope: 'testy',
-            version: {
-              major: 0,
-              minor: 1,
-              patch: 0,
-            },
-          })
-        );
-        const client = new MockClient(mockSuperJson, {
-          fileSystemOverride: {
-            path: {
-              resolve: (...pathSegments: string[]) => pathSegments.join(''),
-            },
-            readFile: jest.fn(path => {
-              expect(path).toMatch('testy/mctestface@0.1.0.supr.ast.json');
-
-              return Promise.resolve(err(new NotFoundError('test')));
-            }),
-          },
-        });
-
-        const profile = await client.getProfile('testy/mctestface');
-        expect(profile.configuration.version).toBe('0.1.0');
-        expect(fetchProfileAst).toHaveBeenCalledWith(
-          'testy/mctestface@0.1.0',
-          client.config,
-          client.crypto,
-          expect.anything(),
-          expect.anything()
-        );
-      });
-    });
-
-    describe('when using entry with filepath only', () => {
-      it('rejects when profile points to a non-existent path', async () => {
-        const mockError = profileFileNotFoundError(
-          '../foo.supr.ast.json',
-          'foo'
-        );
-        const client = new MockClient(mockSuperJson, {
-          fileSystemOverride: {
-            readFile: () => Promise.resolve(err(mockError)),
-          },
-        });
-
-        await expect(client.getProfile('foo')).rejects.toThrow(mockError);
-      });
-
-      it('rejects when profile points to a path with .supr extension', async () => {
-        const client = new MockClient(mockSuperJson);
-
-        await expect(client.getProfile('evil/foo')).rejects.toThrow(
-          sourceFileExtensionFoundError(EXTENSIONS.profile.source)
-        );
-      });
-
-      it('rejects when profile points to a path with unsupported extension', async () => {
-        const client = new MockClient(mockSuperJson);
-
-        await expect(client.getProfile('bad/foo')).rejects.toThrow(
-          unsupportedFileExtensionError(
-            mockSuperJson.resolvePath('../foo.ts'),
-            EXTENSIONS.profile.build
-          )
-        );
-      });
-
-      it('returns a valid profile when it points to existing path', async () => {
-        const client = new MockClient(mockSuperJson, {
-          fileSystemOverride: {
-            readFile: jest.fn(path => {
-              expect(path).toMatch('foo.supr.ast.json');
-
-              return Promise.resolve(
-                ok(
-                  JSON.stringify(
-                    mockProfileDocumentNode({
-                      name: 'foo',
-                      version: {
-                        major: 1,
-                        minor: 0,
-                        patch: 1,
-                        label: 'test',
-                      },
-                    })
-                  )
-                )
-              );
-            }),
-          },
-        });
-
-        const profile = await client.getProfile('foo');
-        expect(profile.configuration.version).toBe('1.0.1-test');
-      });
-
-      it('rejects when loaded file is not valid ProfileDocumentNode', async () => {
-        const invalidAst: any = mockProfileDocumentNode({ name: 'foo' });
-        invalidAst.kind = 'broken';
-        const client = new MockClient(mockSuperJson, {
-          fileSystemOverride: {
-            readFile: () => Promise.resolve(ok(JSON.stringify(invalidAst))),
-          },
-        });
-
-        await expect(client.getProfile('foo')).rejects.toThrow();
-      });
-    });
-
-    describe('when using version property', () => {
-      it('returns a valid profile when profile is found in grid', async () => {
-        const client = new MockClient(mockSuperJson, {
-          fileSystemOverride: {
-            path: {
-              resolve: (...pathSegments: string[]) => pathSegments.join(''),
-            },
-            readFile: jest.fn(path => {
-              expect(path).toMatch('baz@1.2.3.supr.ast.json');
-
-              return Promise.resolve(
-                ok(
-                  JSON.stringify(
-                    mockProfileDocumentNode({
-                      name: 'baz',
-                      version: {
-                        major: 1,
-                        minor: 2,
-                        patch: 3,
-                      },
-                    })
-                  )
-                )
-              );
-            }),
-          },
-        });
-
-        const profile = await client.getProfile('baz');
-        expect(profile.configuration.version).toBe('1.2.3');
-      });
-
-      it('returns a valid profile when profile is found in registry', async () => {
-        mocked(fetchProfileAst).mockResolvedValue(
-          mockProfileDocumentNode({
-            name: 'baz',
-            version: {
-              major: 1,
-              minor: 2,
-              patch: 3,
-            },
-          })
-        );
-        const client = new MockClient(mockSuperJson, {
-          fileSystemOverride: {
-            path: {
-              resolve: (...pathSegments: string[]) => pathSegments.join(''),
-            },
-            readFile: jest.fn(path => {
-              expect(path).toMatch('baz@1.2.3.supr.ast.json');
-
-              return Promise.resolve(err(new NotFoundError('test')));
-            }),
-          },
-        });
-
-        const profile = await client.getProfile('baz');
-        expect(profile.configuration.version).toBe('1.2.3');
-        expect(fetchProfileAst).toHaveBeenCalledWith(
-          'baz@1.2.3',
-          client.config,
-          client.crypto,
-          expect.anything(),
-          expect.anything()
-        );
-      });
-    });
-
-    describe('when using file property', () => {
-      it('rejects when profile points to a non-existent path', async () => {
-        const mockError = profileFileNotFoundError(
-          '../bar.supr.ast.json',
-          'bar'
-        );
-        const client = new MockClient(mockSuperJson, {
-          fileSystemOverride: {
-            readFile: () => Promise.resolve(err(mockError)),
-          },
-        });
-
-        await expect(client.getProfile('bar')).rejects.toThrow(mockError);
-      });
-
-      it('returns a valid profile when it points to existing path', async () => {
-        const client = new MockClient(mockSuperJson, {
-          fileSystemOverride: {
-            readFile: jest.fn(path => {
-              expect(path).toMatch('bar.supr.ast.json');
-
-              return Promise.resolve(
-                ok(
-                  JSON.stringify(
-                    mockProfileDocumentNode({
-                      name: 'bar',
-                      version: {
-                        major: 1,
-                        minor: 0,
-                        patch: 1,
-                      },
-                    })
-                  )
-                )
-              );
-            }),
-          },
-        });
-
-        const profile = await client.getProfile('bar');
-        expect(profile.configuration.version).toBe('1.0.1');
-      });
-
-      it('rejects when loaded file is not valid ProfileDocumentNode', async () => {
-        const invalidAst: any = mockProfileDocumentNode({ name: 'bar' });
-        invalidAst.kind = 'broken';
-        const client = new MockClient(mockSuperJson, {
-          fileSystemOverride: {
-            readFile: () => Promise.resolve(ok(JSON.stringify(invalidAst))),
-          },
-        });
-
-        await expect(client.getProfile('bar')).rejects.toThrow();
-      });
     });
   });
 
   describe('getProviderForProfile', () => {
     it('throws when providers are not configured', async () => {
       expect(() =>
-        getProviderForProfile(mockSuperJsonCustomPath, 'foo')
+        getProviderForProfile(
+          new SuperJson({
+            profiles: {
+              test: '2.1.0',
+            },
+            providers: {
+              quz: {},
+            },
+          }),
+          'foo'
+        )
       ).toThrow(
         'Profile "foo" needs at least one configured provider for automatic provider selection'
       );

--- a/src/node/client/client.typed.ts
+++ b/src/node/client/client.typed.ts
@@ -29,7 +29,7 @@ export function createTypedClient<TProfiles extends ProfileUseCases<any, any>>(
       const profileConfiguration = await this.internal.getProfileConfiguration(
         profileId as string
       );
-      const ast = await this.internal.resolveProfileAst(profileConfiguration);
+      const ast = await this.internal.resolveProfileAst(profileId as string);
 
       return new TypedProfile(
         profileConfiguration,

--- a/src/node/client/client.typed.ts
+++ b/src/node/client/client.typed.ts
@@ -1,4 +1,9 @@
-import { NonPrimitive, TypedProfile, UsecaseType } from '../../core';
+import {
+  NonPrimitive,
+  resolveProfileAst,
+  TypedProfile,
+  UsecaseType,
+} from '../../core';
 import { NodeFileSystem } from '../filesystem';
 import { SuperfaceClientBase } from './client';
 
@@ -26,7 +31,15 @@ export function createTypedClient<TProfiles extends ProfileUseCases<any, any>>(
     public async getProfile<TProfile extends keyof TProfiles>(
       profileId: TProfile
     ): Promise<TypedProfile<TProfiles[TProfile]>> {
-      const ast = await this.internal.resolveProfileAst(profileId as string);
+      const ast = await resolveProfileAst({
+        profileId: profileId as string,
+        logger: this.logger,
+        fetchInstance: this.fetchInstance,
+        fileSystem: NodeFileSystem,
+        config: this.config,
+        crypto: this.crypto,
+        superJson: this.superJson,
+      });
       const profileConfiguration = await this.internal.getProfileConfiguration(
         ast
       );

--- a/src/node/client/client.typed.ts
+++ b/src/node/client/client.typed.ts
@@ -26,10 +26,10 @@ export function createTypedClient<TProfiles extends ProfileUseCases<any, any>>(
     public async getProfile<TProfile extends keyof TProfiles>(
       profileId: TProfile
     ): Promise<TypedProfile<TProfiles[TProfile]>> {
-      const profileConfiguration = await this.internal.getProfileConfiguration(
-        profileId as string
-      );
       const ast = await this.internal.resolveProfileAst(profileId as string);
+      const profileConfiguration = await this.internal.getProfileConfiguration(
+        ast
+      );
 
       return new TypedProfile(
         profileConfiguration,

--- a/src/node/client/client.typed.ts
+++ b/src/node/client/client.typed.ts
@@ -9,16 +9,16 @@ type ProfileUseCases<TInput extends NonPrimitive | undefined, TOutput> = {
 export type TypedSuperfaceClient<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TProfiles extends ProfileUseCases<any, any>
-  > = SuperfaceClientBase & {
-    getProfile<TProfile extends keyof TProfiles>(
-      profileId: TProfile
-    ): Promise<TypedProfile<TProfiles[TProfile]>>;
-  };
+> = SuperfaceClientBase & {
+  getProfile<TProfile extends keyof TProfiles>(
+    profileId: TProfile
+  ): Promise<TypedProfile<TProfiles[TProfile]>>;
+};
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function createTypedClient<TProfiles extends ProfileUseCases<any, any>>(
   profileDefinitions: TProfiles
-): { new(): TypedSuperfaceClient<TProfiles> } {
+): { new (): TypedSuperfaceClient<TProfiles> } {
   return class TypedSuperfaceClientClass
     extends SuperfaceClientBase
     implements TypedSuperfaceClient<TProfiles>
@@ -29,7 +29,7 @@ export function createTypedClient<TProfiles extends ProfileUseCases<any, any>>(
       const profileConfiguration = await this.internal.getProfileConfiguration(
         profileId as string
       );
-      const ast = await this.internal.resolveProfileAst(profileConfiguration)
+      const ast = await this.internal.resolveProfileAst(profileConfiguration);
 
       return new TypedProfile(
         profileConfiguration,

--- a/src/node/client/client.typed.ts
+++ b/src/node/client/client.typed.ts
@@ -9,16 +9,16 @@ type ProfileUseCases<TInput extends NonPrimitive | undefined, TOutput> = {
 export type TypedSuperfaceClient<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TProfiles extends ProfileUseCases<any, any>
-> = SuperfaceClientBase & {
-  getProfile<TProfile extends keyof TProfiles>(
-    profileId: TProfile
-  ): Promise<TypedProfile<TProfiles[TProfile]>>;
-};
+  > = SuperfaceClientBase & {
+    getProfile<TProfile extends keyof TProfiles>(
+      profileId: TProfile
+    ): Promise<TypedProfile<TProfiles[TProfile]>>;
+  };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function createTypedClient<TProfiles extends ProfileUseCases<any, any>>(
   profileDefinitions: TProfiles
-): { new (): TypedSuperfaceClient<TProfiles> } {
+): { new(): TypedSuperfaceClient<TProfiles> } {
   return class TypedSuperfaceClientClass
     extends SuperfaceClientBase
     implements TypedSuperfaceClient<TProfiles>
@@ -29,9 +29,11 @@ export function createTypedClient<TProfiles extends ProfileUseCases<any, any>>(
       const profileConfiguration = await this.internal.getProfileConfiguration(
         profileId as string
       );
+      const ast = await this.internal.resolveProfileAst(profileConfiguration)
 
       return new TypedProfile(
         profileConfiguration,
+        ast,
         this.events,
         this.superJson,
         this.boundProfileProviderCache,


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

This PR add ability to load profile remotely without CLI installation. It moves profile resolution to `getProfile` method and adds check to ensure that use case exists in profile AST.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [x] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
