### PR TITLE
feat: cache property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Pass `cache` flag to SuperfaceClient constructor
 
 ## [1.5.2] - 2022-06-15
 ### Fixed

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -36,7 +36,7 @@ export const DEFAULT_CACHE_PATH = (fileSystem: FSPath): string =>
   fileSystem.path.join(fileSystem.path.cwd(), 'superface', '.cache');
 export const DEFAULT_SANDBOX_TIMEOUT = 100;
 export const DEFAULT_DISABLE_REPORTING = false;
-export const DEFAULT_CACHE = false;
+export const DEFAULT_CACHE = true;
 // 1 hour
 export const DEFAULT_BOUND_PROVIDER_TIMEOUT = 60 * 60;
 

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -36,6 +36,7 @@ export const DEFAULT_CACHE_PATH = (fileSystem: FSPath): string =>
   fileSystem.path.join(fileSystem.path.cwd(), 'superface', '.cache');
 export const DEFAULT_SANDBOX_TIMEOUT = 100;
 export const DEFAULT_DISABLE_REPORTING = false;
+export const DEFAULT_CACHE = false;
 // 1 hour
 export const DEFAULT_BOUND_PROVIDER_TIMEOUT = 60 * 60;
 
@@ -49,6 +50,7 @@ const DEFAULTS = (fileSystem: FSPath): IConfig => ({
   superfaceApiUrl: DEFAULT_API_URL,
   superfaceCacheTimeout: DEFAULT_BOUND_PROVIDER_TIMEOUT,
   superfacePath: DEFAULT_SUPERFACE_PATH(fileSystem),
+  cache: DEFAULT_CACHE,
 });
 
 // Extraction functions
@@ -164,6 +166,7 @@ export class Config implements IConfig {
   public superfaceApiUrl: string;
   public superfaceCacheTimeout: number;
   public superfacePath: string;
+  public cache: boolean;
 
   constructor(fileSystem: FSPath, config?: Partial<IConfig>) {
     const defaults = DEFAULTS(fileSystem);
@@ -180,6 +183,7 @@ export class Config implements IConfig {
     this.superfaceCacheTimeout =
       config?.superfaceCacheTimeout ?? defaults.superfaceCacheTimeout;
     this.superfacePath = config?.superfacePath ?? defaults.superfacePath;
+    this.cache = config?.cache ?? defaults.cache;
   }
 }
 
@@ -204,6 +208,7 @@ export function mergeConfigs(
       newConfig.disableReporting ?? originalConfig.disableReporting,
     cachePath: newConfig.cachePath ?? originalConfig.cachePath,
     sandboxTimeout: newConfig.sandboxTimeout ?? originalConfig.sandboxTimeout,
+    cache: newConfig.cache ?? originalConfig.cache,
   };
 
   logger?.log(
@@ -255,6 +260,7 @@ export function loadConfigFromCode(
       'sandboxTimeout',
       logFunction
     ),
+    cache: config.cache,
   };
 
   logger?.log(DEBUG_NAMESPACE, 'Loaded config from code: %O', env);

--- a/src/core/interfaces/config.ts
+++ b/src/core/interfaces/config.ts
@@ -8,4 +8,5 @@ export interface IConfig {
   superfaceApiUrl: string;
   superfaceCacheTimeout: number;
   superfacePath: string;
+  cache: boolean;
 }

--- a/src/core/profile-provider/profile-provider.test.ts
+++ b/src/core/profile-provider/profile-provider.test.ts
@@ -244,7 +244,7 @@ describe('profile provider', () => {
         });
         const superJson = new SuperJson({
           profiles: {
-            ['test-profile']: {
+            'test-profile': {
               version: '1.0.0',
               defaults: {},
               providers: {},
@@ -289,7 +289,7 @@ describe('profile provider', () => {
         mocked(fetchBind).mockResolvedValue(mockFetchResponse);
         const superJson = new SuperJson({
           profiles: {
-            ['test-profile']: {
+            'test-profile': {
               version: '1.0.0',
               defaults: {},
               providers: {},
@@ -327,7 +327,7 @@ describe('profile provider', () => {
         mocked(fetchBind).mockResolvedValue(mockFetchResponse);
         const superJson = new SuperJson({
           profiles: {
-            ['test-profile']: {
+            'test-profile': {
               version: '1.0.0',
               defaults: {},
               providers: {},
@@ -361,7 +361,7 @@ describe('profile provider', () => {
         mocked(fetchBind).mockResolvedValue(mockFetchResponse);
         const superJson = new SuperJson({
           profiles: {
-            ['test-profile']: {
+            'test-profile': {
               version: '1.0.0',
               defaults: {},
               providers: {},
@@ -397,7 +397,7 @@ describe('profile provider', () => {
         mocked(fetchBind).mockResolvedValue(mockFetchResponse);
         const superJson = new SuperJson({
           profiles: {
-            ['test-profile']: {
+            'test-profile': {
               version: '1.0.0',
               defaults: {},
               providers: {},
@@ -437,7 +437,7 @@ describe('profile provider', () => {
         });
         const superJson = new SuperJson({
           profiles: {
-            ['test-profile']: {
+            'test-profile': {
               version: '1.0.0',
               defaults: {},
               providers: {
@@ -481,7 +481,7 @@ describe('profile provider', () => {
         mocked(fetchBind).mockResolvedValue(mockFetchResponse);
         const superJson = new SuperJson({
           profiles: {
-            ['test-profile']: {
+            'test-profile': {
               file: 'file://some/file',
               version: '1.0.0',
               defaults: {},
@@ -531,7 +531,7 @@ describe('profile provider', () => {
           .mockResolvedValueOnce(ok(JSON.stringify(mockMapDocument)));
         const superJson = new SuperJson({
           profiles: {
-            ['test-profile']: {
+            'test-profile': {
               version: '1.0.0',
               defaults: {},
               providers: {
@@ -602,7 +602,7 @@ describe('profile provider', () => {
         mocked(fetchBind).mockResolvedValue(mockFetchResponse);
         const superJson = new SuperJson({
           profiles: {
-            ['test-profile']: {
+            'test-profile': {
               version: '1.0.0',
               defaults: {},
               providers: {
@@ -647,7 +647,7 @@ describe('profile provider', () => {
         mocked(fetchBind).mockResolvedValue(mockFetchResponse);
         const superJson = new SuperJson({
           profiles: {
-            ['test-profile']: {
+            'test-profile': {
               version: '1.0.0',
               defaults: {},
               providers: {
@@ -696,7 +696,7 @@ describe('profile provider', () => {
         mocked(fetchBind).mockResolvedValue(mockFetchResponse);
         const superJson = new SuperJson({
           profiles: {
-            ['test-profile']: {
+            'test-profile': {
               version: '1.0.0',
               defaults: {},
               providers: {
@@ -741,7 +741,7 @@ describe('profile provider', () => {
       it('throws error when provider is provided locally but map is not', async () => {
         const superJson = new SuperJson({
           profiles: {
-            ['test-profile']: {
+            'test-profile': {
               version: '1.0.0',
               defaults: {},
               providers: {
@@ -786,7 +786,7 @@ describe('profile provider', () => {
         mocked(fetchBind).mockResolvedValue(mockFetchResponse);
         const superJson = new SuperJson({
           profiles: {
-            ['test-profile']: {
+            'test-profile': {
               file: 'file://some/file',
               version: '1.0.0',
               defaults: {},
@@ -846,7 +846,7 @@ describe('profile provider', () => {
 
         const superJson = new SuperJson({
           profiles: {
-            ['test-profile']: {
+            'test-profile': {
               version: '1.0.0',
               defaults: {},
               providers: {},
@@ -878,7 +878,7 @@ describe('profile provider', () => {
       it('throws error when could not find scheme', async () => {
         const superJson = new SuperJson({
           profiles: {
-            ['test-profile']: {
+            'test-profile': {
               version: '1.0.0',
               defaults: {},
               providers: {
@@ -920,7 +920,7 @@ but a secret value was provided for security scheme: made-up-id`
       it('throws error on invalid api key scheme', async () => {
         const superJson = new SuperJson({
           profiles: {
-            ['test-profile']: {
+            'test-profile': {
               version: '1.0.0',
               defaults: {},
               providers: {
@@ -962,7 +962,7 @@ but apiKey scheme requires: apikey`
       it('throws error on invalid basic auth scheme', async () => {
         const superJson = new SuperJson({
           profiles: {
-            ['test-profile']: {
+            'test-profile': {
               version: '1.0.0',
               defaults: {},
               providers: {
@@ -1004,7 +1004,7 @@ but http scheme requires: username, password`
       it('throws error on invalid bearer auth scheme', async () => {
         const superJson = new SuperJson({
           profiles: {
-            ['test-profile']: {
+            'test-profile': {
               version: '1.0.0',
               defaults: {},
               providers: {
@@ -1046,7 +1046,7 @@ but http scheme requires: token`
       it('throws error on invalid digest auth scheme', async () => {
         const superJson = new SuperJson({
           profiles: {
-            ['test-profile']: {
+            'test-profile': {
               version: '1.0.0',
               defaults: {},
               providers: {
@@ -1089,7 +1089,7 @@ but http scheme requires: digest`
         mocked(fetchBind).mockResolvedValue(mockFetchResponse);
         const superJson = new SuperJson({
           profiles: {
-            ['test-profile']: {
+            'test-profile': {
               file: 'file://some/profile/file',
               version: '1.0.0',
               defaults: {},
@@ -1139,7 +1139,7 @@ but http scheme requires: digest`
 
         const superJson = new SuperJson({
           profiles: {
-            ['test-profile']: {
+            'test-profile': {
               file: 'file://some/profile/file',
               version: '1.0.0',
               defaults: {},

--- a/src/core/profile-provider/profile-provider.test.ts
+++ b/src/core/profile-provider/profile-provider.test.ts
@@ -319,6 +319,44 @@ describe('profile provider', () => {
         expect(fileSystem.writeFile).toHaveBeenCalled();
       });
 
+      it('returns new BoundProfileProvider without caching provider', async () => {
+        const mockConfigWithDisabledCache = new Config(NodeFileSystem, {
+          cache: false,
+        });
+
+        mocked(fetchBind).mockResolvedValue(mockFetchResponse);
+        const superJson = new SuperJson({
+          profiles: {
+            ['test-profile']: {
+              version: '1.0.0',
+              defaults: {},
+              providers: {},
+            },
+          },
+          providers: {
+            test: {
+              security: mockSecurityValues,
+            },
+          },
+        });
+        const mockProfileProvider = new ProfileProvider(
+          superJson,
+          mockProfileDocument,
+          mockProviderConfiguration,
+          mockConfigWithDisabledCache,
+          new Events(timers),
+          fileSystem,
+          crypto,
+          new NodeFetch(timers)
+        );
+
+        const result = await mockProfileProvider.bind();
+
+        expect(result).toMatchObject(expectedBoundProfileProvider);
+        // It should not cache the provider
+        expect(fileSystem.writeFile).not.toHaveBeenCalled();
+      });
+
       it('returns new BoundProfileProvider use profile id', async () => {
         mocked(fetchBind).mockResolvedValue(mockFetchResponse);
         const superJson = new SuperJson({

--- a/src/core/profile-provider/profile-provider.ts
+++ b/src/core/profile-provider/profile-provider.ts
@@ -218,6 +218,7 @@ export class ProfileProvider {
             providerName,
           },
           this.config.cachePath,
+          this.config.cache,
           this.fileSystem
         );
       }
@@ -417,6 +418,7 @@ export class ProfileProvider {
               scope: this.scope,
             },
             this.config.cachePath,
+            this.config.cache,
             this.fileSystem
           );
         }
@@ -517,6 +519,7 @@ export class ProfileProvider {
               scope: this.scope,
             },
             this.config.cachePath,
+            this.config.cache,
             this.fileSystem
           );
         }

--- a/src/core/profile-provider/profile-provider.ts
+++ b/src/core/profile-provider/profile-provider.ts
@@ -385,17 +385,21 @@ export class ProfileProvider {
       this.providersCachePath,
       `${providerJson.name}.json`
     );
-    try {
-      await this.fileSystem.mkdir(this.providersCachePath, { recursive: true });
-      await this.fileSystem.writeFile(
-        providerCachePath,
-        JSON.stringify(providerJson, undefined, 2)
-      );
-    } catch (error) {
-      this.log?.(
-        `Failed to cache provider.json for ${providerJson.name}: %O`,
-        error
-      );
+    if (this.config.cache === true) {
+      try {
+        await this.fileSystem.mkdir(this.providersCachePath, {
+          recursive: true,
+        });
+        await this.fileSystem.writeFile(
+          providerCachePath,
+          JSON.stringify(providerJson, undefined, 2)
+        );
+      } catch (error) {
+        this.log?.(
+          `Failed to cache provider.json for ${providerJson.name}: %O`,
+          error
+        );
+      }
     }
   }
 

--- a/src/node/client/client.ts
+++ b/src/node/client/client.ts
@@ -123,9 +123,10 @@ export abstract class SuperfaceClientBase {
   protected readonly logger?: ILogger;
 
   constructor(
-    options?: { superJson?: SuperJson | SuperJsonDocument } & Partial<
-      Omit<IConfig, 'cachePath'>
-    >
+    options?: {
+      superJson?: SuperJson | SuperJsonDocument;
+      cache?: boolean;
+    } & Partial<Omit<IConfig, 'cachePath'>>
   ) {
     const environment = new NodeEnvironment();
     this.crypto = new NodeCrypto();

--- a/src/node/client/client.ts
+++ b/src/node/client/client.ts
@@ -125,6 +125,9 @@ export abstract class SuperfaceClientBase {
   constructor(
     options?: {
       superJson?: SuperJson | SuperJsonDocument;
+      /**
+       * Flag that can be used to disable caching to filesystem. `true` by default.
+       */
       cache?: boolean;
     } & Partial<Omit<IConfig, 'cachePath'>>
   ) {
@@ -195,8 +198,7 @@ export abstract class SuperfaceClientBase {
 
 export class SuperfaceClient
   extends SuperfaceClientBase
-  implements ISuperfaceClient
-{
+  implements ISuperfaceClient {
   /** Gets a profile from super.json based on `profileId` in format: `[scope/]name`. */
   public async getProfile(profileId: string): Promise<Profile> {
     return this.internal.getProfile(profileId);


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->

This PR adds `cache` property to SuperfaceClient constructor. This property can be used to disable caching (mam and profile AST and provider.json) to filesystem.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [x] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
