### PR TITLE
feat: get provider options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pass `mapVariant` and `mapRevision` values in `perform`
 - **BREAKING CHANGE**: .supr files are no longer allowed
 - Optionally pass `version` to `getProfile`
+- Pass `security` and `parameters` values in `getProvider`
+
 
 ## [1.5.2] - 2022-06-15
 ### Fixed

--- a/src/core/interfaces/client.ts
+++ b/src/core/interfaces/client.ts
@@ -1,10 +1,20 @@
+import { SecurityValues } from '@superfaceai/ast';
+
 import { Events } from '../events';
 import { Profile } from '../profile';
 import { Provider } from '../provider';
 
 export interface ISuperfaceClient {
   getProfile(profileId: string): Promise<Profile>;
-  getProvider(providerName: string): Promise<Provider>;
+  getProvider(
+    providerName: string,
+    options?: {
+      parameters?: Record<string, string>;
+      security?:
+        | SecurityValues[]
+        | { [id: string]: Omit<SecurityValues, 'id'> };
+    }
+  ): Promise<Provider>;
   getProviderForProfile(profileId: string): Promise<Provider>;
   on(...args: Parameters<Events['on']>): void;
 }

--- a/src/core/profile-provider/profile-provider.ts
+++ b/src/core/profile-provider/profile-provider.ts
@@ -68,7 +68,10 @@ export async function bindProfileProvider(
     fetchInstance,
     logger
   );
-  const boundProfileProvider = await profileProvider.bind();
+  const boundProfileProvider = await profileProvider.bind({
+    // TODO: resolve security in more readable way
+    security: providerConfig.security,
+  });
   const expiresAt =
     Math.floor(timers.now() / 1000) + config.superfaceCacheTimeout;
 

--- a/src/core/profile-provider/profile-provider.ts
+++ b/src/core/profile-provider/profile-provider.ts
@@ -69,8 +69,9 @@ export async function bindProfileProvider(
     logger
   );
   const boundProfileProvider = await profileProvider.bind({
-    // TODO: resolve security in more readable way
+    // TODO: resolve security and parameters in more readable way
     security: providerConfig.security,
+    parameters: providerConfig.parameters,
   });
   const expiresAt =
     Math.floor(timers.now() / 1000) + config.superfaceCacheTimeout;
@@ -80,6 +81,7 @@ export async function bindProfileProvider(
 
 export type BindConfiguration = {
   security?: SecurityValues[];
+  parameters?: Record<string, string>;
 };
 
 export class ProfileProvider {
@@ -260,7 +262,9 @@ export class ProfileProvider {
         security: securityConfiguration,
         parameters: this.resolveIntegrationParameters(
           providerInfo,
-          this.superJson.normalized.providers[providerInfo.name]?.parameters
+          // TODO: pass parameters from getProvider?
+          configuration?.parameters ??
+            this.superJson.normalized.providers[providerInfo.name]?.parameters
         ),
       },
       this.crypto,

--- a/src/core/profile-provider/profile-provider.ts
+++ b/src/core/profile-provider/profile-provider.ts
@@ -69,7 +69,7 @@ export async function bindProfileProvider(
     logger
   );
   const boundProfileProvider = await profileProvider.bind({
-    // TODO: resolve security and parameters in more readable way
+    // TODO: resolve security and parameters directly in bind? 
     security: providerConfig.security,
     parameters: providerConfig.parameters,
   });
@@ -98,6 +98,7 @@ export class ProfileProvider {
     public readonly superJson: SuperJson,
     /** profile id, url, ast node or configuration instance */
     private profile: string | ProfileDocumentNode | ProfileConfiguration,
+    // TODO: can thsi be something else than configuration?
     /** provider name, url or configuration instance */
     private provider: string | ProviderJson | ProviderConfiguration,
     private config: IConfig,
@@ -257,14 +258,13 @@ export class ProfileProvider {
         ),
         profileProviderSettings:
           this.superJson.normalized.profiles[profileId]?.providers[
-            providerInfo.name
+          providerInfo.name
           ],
         security: securityConfiguration,
         parameters: this.resolveIntegrationParameters(
           providerInfo,
-          // TODO: pass parameters from getProvider?
           configuration?.parameters ??
-            this.superJson.normalized.providers[providerInfo.name]?.parameters
+          this.superJson.normalized.providers[providerInfo.name]?.parameters
         ),
       },
       this.crypto,

--- a/src/core/profile/profile.test.ts
+++ b/src/core/profile/profile.test.ts
@@ -40,7 +40,7 @@ function createProfile(superJson: SuperJsonDocument): Profile {
 
 describe('Profile', () => {
   describe('when calling getUseCases', () => {
-    it('should retrun new UseCase', async () => {
+    it('should return new UseCase', async () => {
       const superJson = {
         profiles: {
           test: {

--- a/src/core/provider/provider.ts
+++ b/src/core/provider/provider.ts
@@ -5,8 +5,10 @@ import { mergeSecurity } from '../../schema-tools';
 export class ProviderConfiguration {
   constructor(
     public readonly name: string,
+    // TODO: where should we store security and parameters when they are passed to getProvider?
     /** @deprecated only for use in testing library */
-    public readonly security: SecurityValues[]
+    public readonly security: SecurityValues[],
+    public readonly parameters?: Record<string, string>
   ) {}
 
   public get cacheKey(): string {

--- a/src/core/usecase/usecase.test.ts
+++ b/src/core/usecase/usecase.test.ts
@@ -49,11 +49,13 @@ function createUseCase(cacheExpire?: number) {
 
   const mockProviderConfiguration = new ProviderConfiguration(
     'test-provider',
-    []
+    [],
+    {}
   );
   const mockProviderConfiguration2 = new ProviderConfiguration(
     'test-provider2',
-    []
+    [],
+    {}
   );
 
   const cache = new SuperCache<{

--- a/src/core/usecase/usecase.ts
+++ b/src/core/usecase/usecase.ts
@@ -55,6 +55,37 @@ import { Provider, ProviderConfiguration } from '../provider';
 
 const DEBUG_NAMESPACE = 'usecase';
 
+export function resolveSecurityValues(
+  security?: SecurityValues[] | { [id: string]: Omit<SecurityValues, 'id'> },
+  logFunction?: LogFunction
+): SecurityValues[] | undefined {
+  if (security === undefined) {
+    return;
+  }
+
+  if (Array.isArray(security)) {
+    return security;
+  }
+
+  const securityValues: SecurityValues[] = [];
+
+  for (const [id, value] of Object.entries(security)) {
+    const securityValue = { ...value, id };
+    if (
+      isBasicAuthSecurityValues(securityValue) ||
+      isBearerTokenSecurityValues(securityValue) ||
+      isApiKeySecurityValues(securityValue) ||
+      isDigestSecurityValues(securityValue)
+    ) {
+      securityValues.push(securityValue);
+    } else {
+      logFunction?.('Security: %O is not supported', securityValue);
+    }
+  }
+
+  return securityValues;
+}
+
 export type PerformOptions = {
   provider?: Provider | string;
   parameters?: Record<string, string>;
@@ -149,36 +180,6 @@ export abstract class UseCaseBase implements Interceptable {
     return provider;
   }
 
-  private resolveSecurityValues(
-    security?: SecurityValues[] | { [id: string]: Omit<SecurityValues, 'id'> }
-  ): SecurityValues[] | undefined {
-    if (security === undefined) {
-      return;
-    }
-
-    if (Array.isArray(security)) {
-      return security;
-    }
-
-    const securityValues: SecurityValues[] = [];
-
-    for (const [id, value] of Object.entries(security)) {
-      const securityValue = { ...value, id };
-      if (
-        isBasicAuthSecurityValues(securityValue) ||
-        isBearerTokenSecurityValues(securityValue) ||
-        isApiKeySecurityValues(securityValue) ||
-        isDigestSecurityValues(securityValue)
-      ) {
-        securityValues.push(securityValue);
-      } else {
-        this.log?.('Security: %O is not supported', securityValue);
-      }
-    }
-
-    return securityValues;
-  }
-
   private async resolveProviderConfiguration(
     currentProvider: string | undefined,
     options?: PerformOptions
@@ -251,7 +252,7 @@ export abstract class UseCaseBase implements Interceptable {
     return this.performBoundUsecase(
       input,
       options?.parameters,
-      this.resolveSecurityValues(options?.security)
+      resolveSecurityValues(options?.security)
     );
   }
 

--- a/src/mock/client.ts
+++ b/src/mock/client.ts
@@ -2,6 +2,7 @@ import {
   MapDocumentNode,
   ProfileDocumentNode,
   ProviderJson,
+  SecurityValues,
 } from '@superfaceai/ast';
 import { ProfileId, ProfileVersion } from '@superfaceai/parser';
 
@@ -24,6 +25,7 @@ import {
   Provider,
   ProviderConfiguration,
   registerHooks,
+  resolveSecurityValues,
   SecurityConfiguration,
   ServiceSelector,
 } from '../core';
@@ -169,8 +171,24 @@ export class MockClient implements ISuperfaceClient {
     return this.internalClient.getProfile(profileId);
   }
 
-  public async getProvider(providerName: string): Promise<Provider> {
-    return getProvider(this.superJson, providerName);
+  public async getProvider(
+    providerName: string,
+    options?: {
+      parameters?: Record<string, string>;
+      security?:
+        | SecurityValues[]
+        | { [id: string]: Omit<SecurityValues, 'id'> };
+    }
+  ): Promise<Provider> {
+    return getProvider(
+      this.superJson,
+      providerName,
+      resolveSecurityValues(
+        options?.security,
+        this.logger?.log('security-values-resolution')
+      ),
+      options?.parameters
+    );
   }
 
   public async getProviderForProfile(profileId: string): Promise<Provider> {

--- a/src/node/client/client.test.ts
+++ b/src/node/client/client.test.ts
@@ -2,7 +2,7 @@ import { mocked } from 'ts-jest/utils';
 
 import { ProfileConfiguration, resolveProfileAst } from '../../core';
 import { MockClient, mockProfileDocumentNode } from '../../mock';
-import { getProviderForProfile, SuperJson } from '../../schema-tools';
+import { SuperJson } from '../../schema-tools';
 
 const mockSuperJson = new SuperJson({
   profiles: {
@@ -61,31 +61,6 @@ describe('superface client', () => {
       expect(profile.configuration).toEqual(
         new ProfileConfiguration('testy/mctestface', '1.0.0')
       );
-    });
-  });
-
-  describe('getProviderForProfile', () => {
-    it('throws when providers are not configured', async () => {
-      expect(() =>
-        getProviderForProfile(
-          new SuperJson({
-            profiles: {
-              test: '2.1.0',
-            },
-            providers: {
-              quz: {},
-            },
-          }),
-          'foo'
-        )
-      ).toThrow(
-        'Profile "foo" needs at least one configured provider for automatic provider selection'
-      );
-    });
-
-    it('returns a configured provider when present', async () => {
-      const provider = getProviderForProfile(mockSuperJson, 'baz');
-      expect(provider.configuration.name).toBe('quz');
     });
   });
 });

--- a/src/node/client/client.test.ts
+++ b/src/node/client/client.test.ts
@@ -80,7 +80,7 @@ jest.mock('../../core/events/failure/event-adapter');
 
 describe('superface client', () => {
   describe('getProfile', () => {
-    it('retruns Profile instance', async () => {
+    it('returns Profile instance', async () => {
       const ast = mockProfileDocumentNode({
         name: 'testy/mctestface',
         version: {
@@ -102,7 +102,7 @@ describe('superface client', () => {
   });
 
   describe('getProvider', () => {
-    it('retruns Provider instance', async () => {
+    it('returns Provider instance', async () => {
       const client = new MockClient(mockSuperJson);
       const provider = await client.getProvider('test-provider');
 
@@ -115,7 +115,7 @@ describe('superface client', () => {
       );
     });
 
-    it('retruns Provider instance with custom security values and parameters', async () => {
+    it('returns Provider instance with custom security values and parameters', async () => {
       const client = new MockClient(
         new SuperJson({
           providers: {

--- a/src/node/client/client.ts
+++ b/src/node/client/client.ts
@@ -188,13 +188,13 @@ export abstract class SuperfaceClientBase {
         | { [id: string]: Omit<SecurityValues, 'id'> };
     }
   ): Promise<Provider> {
-    // TODO: pass logger
-    const security = resolveSecurityValues(options?.security);
-
     return getProvider(
       this.superJson,
       providerName,
-      security,
+      resolveSecurityValues(
+        options?.security,
+        this.logger?.log('security-values-resolution')
+      ),
       options?.parameters
     );
   }

--- a/src/node/client/client.ts
+++ b/src/node/client/client.ts
@@ -182,6 +182,7 @@ export abstract class SuperfaceClientBase {
   public async getProvider(
     providerName: string,
     options?: {
+      parameters?: Record<string, string>;
       security?:
         | SecurityValues[]
         | { [id: string]: Omit<SecurityValues, 'id'> };
@@ -190,7 +191,12 @@ export abstract class SuperfaceClientBase {
     // TODO: pass logger
     const security = resolveSecurityValues(options?.security);
 
-    return getProvider(this.superJson, providerName, security);
+    return getProvider(
+      this.superJson,
+      providerName,
+      security,
+      options?.parameters
+    );
   }
 
   /** Returns a provider configuration for when no provider is passed to untyped `.perform`. */

--- a/src/node/client/client.ts
+++ b/src/node/client/client.ts
@@ -1,4 +1,4 @@
-import { SuperJsonDocument } from '@superfaceai/ast';
+import { SecurityValues, SuperJsonDocument } from '@superfaceai/ast';
 
 import {
   AuthCache,
@@ -23,6 +23,7 @@ import {
   Profile,
   Provider,
   registerHooks as registerFailoverHooks,
+  resolveSecurityValues,
 } from '../../core';
 import { SuperCache } from '../../lib';
 import {
@@ -178,8 +179,18 @@ export abstract class SuperfaceClientBase {
   }
 
   /** Gets a provider from super.json based on `providerName`. */
-  public async getProvider(providerName: string): Promise<Provider> {
-    return getProvider(this.superJson, providerName);
+  public async getProvider(
+    providerName: string,
+    options?: {
+      security?:
+        | SecurityValues[]
+        | { [id: string]: Omit<SecurityValues, 'id'> };
+    }
+  ): Promise<Provider> {
+    // TODO: pass logger
+    const security = resolveSecurityValues(options?.security);
+
+    return getProvider(this.superJson, providerName, security);
   }
 
   /** Returns a provider configuration for when no provider is passed to untyped `.perform`. */

--- a/src/schema-tools/superjson/utils.test.ts
+++ b/src/schema-tools/superjson/utils.test.ts
@@ -84,7 +84,7 @@ describe('schema-tools utils', () => {
       );
     });
 
-    it('retrun correct provider instance', () => {
+    it('return correct provider instance', () => {
       const superJson = new SuperJson({
         profiles: {
           'test-profile': {
@@ -107,7 +107,7 @@ describe('schema-tools utils', () => {
       );
     });
 
-    it('retrun correct provider instance with custom security and parameters', () => {
+    it('return correct provider instance with custom security and parameters', () => {
       const superJson = new SuperJson({
         profiles: {
           'test-profile': {

--- a/src/schema-tools/superjson/utils.test.ts
+++ b/src/schema-tools/superjson/utils.test.ts
@@ -1,0 +1,95 @@
+import { SecurityValues } from '@superfaceai/ast';
+
+import {
+  Provider,
+  ProviderConfiguration,
+  unconfiguredProviderError,
+} from '../../core';
+import { SuperJson } from './superjson';
+import { getProvider } from './utils';
+
+describe('schema-tools utils', () => {
+  describe('getProvider', () => {
+    const mockSecurityValues: SecurityValues[] = [
+      {
+        username: 'test-username',
+        id: 'basic',
+        password: 'test-password',
+      },
+      {
+        id: 'api',
+        apikey: 'test-api-key',
+      },
+      {
+        id: 'bearer',
+        token: 'test-token',
+      },
+      {
+        id: 'digest',
+        username: 'test-digest-user',
+        password: 'test-digest-password',
+      },
+    ];
+
+    const mockParameters = {
+      first: 'plain value',
+      second: '$TEST_SECOND', // unset env value without default
+      third: '$TEST_THIRD', // unset env value with default
+      // fourth is missing - should be resolved to its default
+    };
+
+    it('throws on unconfigured provider', () => {
+      expect(() => getProvider(new SuperJson(), 'test')).toThrow(
+        unconfiguredProviderError('test')
+      );
+    });
+
+    it('retrun correct provider instance', () => {
+      const superJson = new SuperJson({
+        profiles: {
+          'test-profile': {
+            version: '1.0.0',
+            defaults: {},
+            providers: {},
+          },
+        },
+        providers: {
+          test: {
+            security: mockSecurityValues,
+            parameters: mockParameters,
+          },
+        },
+      });
+      expect(getProvider(superJson, 'test')).toEqual(
+        new Provider(
+          new ProviderConfiguration('test', mockSecurityValues, mockParameters)
+        )
+      );
+    });
+
+    it('retrun correct provider instance with custom security and parameters', () => {
+      const superJson = new SuperJson({
+        profiles: {
+          'test-profile': {
+            version: '1.0.0',
+            defaults: {},
+            providers: {},
+          },
+        },
+        providers: {
+          test: {
+            security: [],
+            parameters: {},
+          },
+        },
+      });
+      expect(
+        getProvider(superJson, 'test', mockSecurityValues, mockParameters)
+      ).toEqual(
+        new Provider(
+          new ProviderConfiguration('test', mockSecurityValues, mockParameters)
+        )
+      );
+    });
+  });
+});

--- a/src/schema-tools/superjson/utils.test.ts
+++ b/src/schema-tools/superjson/utils.test.ts
@@ -6,9 +6,49 @@ import {
   unconfiguredProviderError,
 } from '../../core';
 import { SuperJson } from './superjson';
-import { getProvider } from './utils';
+import { getProvider, getProviderForProfile } from './utils';
 
 describe('schema-tools utils', () => {
+  describe('getProviderForProfile', () => {
+    it('throws when providers are not configured', async () => {
+      expect(() =>
+        getProviderForProfile(
+          new SuperJson({
+            profiles: {
+              test: '2.1.0',
+            },
+            providers: {
+              quz: {},
+            },
+          }),
+          'foo'
+        )
+      ).toThrow(
+        'Profile "foo" needs at least one configured provider for automatic provider selection'
+      );
+    });
+
+    it('returns a configured provider when present', async () => {
+      const provider = getProviderForProfile(
+        new SuperJson({
+          profiles: {
+            baz: {
+              version: '1.2.3',
+              providers: {
+                quz: {},
+              },
+            },
+          },
+          providers: {
+            quz: {},
+          },
+        }),
+        'baz'
+      );
+      expect(provider.configuration.name).toBe('quz');
+    });
+  });
+
   describe('getProvider', () => {
     const mockSecurityValues: SecurityValues[] = [
       {

--- a/src/schema-tools/superjson/utils.ts
+++ b/src/schema-tools/superjson/utils.ts
@@ -41,6 +41,7 @@ export function getProviderForProfile(
     return getProvider(superJson, name);
   }
 
+  // TODO: this case should not happen - covered by super json normalization
   const knownProfileProviders = Object.keys(
     superJson.normalized.profiles[profileId]?.providers ?? {}
   );

--- a/src/schema-tools/superjson/utils.ts
+++ b/src/schema-tools/superjson/utils.ts
@@ -2,6 +2,7 @@ import { SecurityValues } from '@superfaceai/ast';
 
 import {
   noConfiguredProviderError,
+  profileNotFoundError,
   Provider,
   ProviderConfiguration,
   unconfiguredProviderError,
@@ -33,20 +34,16 @@ export function getProviderForProfile(
   superJson: SuperJson,
   profileId: string
 ): Provider {
-  const priorityProviders =
-    superJson.normalized.profiles[profileId]?.priority ?? [];
-  if (priorityProviders.length > 0) {
-    const name = priorityProviders[0];
+  const profileSettings = superJson.normalized.profiles[profileId];
 
-    return getProvider(superJson, name);
+  if (profileSettings === undefined) {
+    throw profileNotFoundError(profileId);
   }
 
-  // TODO: this case should not happen - covered by super json normalization
-  const knownProfileProviders = Object.keys(
-    superJson.normalized.profiles[profileId]?.providers ?? {}
-  );
-  if (knownProfileProviders.length > 0) {
-    const name = knownProfileProviders[0];
+  const priorityProviders = superJson.normalized.profiles[profileId].priority;
+
+  if (priorityProviders.length > 0) {
+    const name = priorityProviders[0];
 
     return getProvider(superJson, name);
   }

--- a/src/schema-tools/superjson/utils.ts
+++ b/src/schema-tools/superjson/utils.ts
@@ -1,3 +1,5 @@
+import { SecurityValues } from '@superfaceai/ast';
+
 import {
   noConfiguredProviderError,
   Provider,
@@ -8,7 +10,8 @@ import { SuperJson } from './superjson';
 
 export function getProvider(
   superJson: SuperJson,
-  providerName: string
+  providerName: string,
+  security?: SecurityValues[]
 ): Provider {
   const providerSettings = superJson.normalized.providers[providerName];
 
@@ -17,7 +20,10 @@ export function getProvider(
   }
 
   return new Provider(
-    new ProviderConfiguration(providerName, providerSettings.security)
+    new ProviderConfiguration(
+      providerName,
+      security ?? providerSettings.security
+    )
   );
 }
 

--- a/src/schema-tools/superjson/utils.ts
+++ b/src/schema-tools/superjson/utils.ts
@@ -11,7 +11,8 @@ import { SuperJson } from './superjson';
 export function getProvider(
   superJson: SuperJson,
   providerName: string,
-  security?: SecurityValues[]
+  security?: SecurityValues[],
+  parameters?: Record<string, string>
 ): Provider {
   const providerSettings = superJson.normalized.providers[providerName];
 
@@ -22,7 +23,8 @@ export function getProvider(
   return new Provider(
     new ProviderConfiguration(
       providerName,
-      security ?? providerSettings.security
+      security ?? providerSettings.security,
+      parameters ?? providerSettings.parameters
     )
   );
 }


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->

This PR adds option to pass `security` and `parameters` to `getProvider` method. Passed values are used in perform (if not overridden by values passed directly to perform)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [x] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
