### PR TITLE
feat: pass version to get profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pass `debug` flag to SuperfaceClient constructor
 - Pass `mapVariant` and `mapRevision` values in `perform`
 - **BREAKING CHANGE**: .supr files are no longer allowed
+- Optionally pass `version` to `getProfile`
 
 ## [1.5.2] - 2022-06-15
 ### Fixed

--- a/src/core/client/client.internal.test.ts
+++ b/src/core/client/client.internal.test.ts
@@ -1,4 +1,4 @@
-import { invalidVersionError } from '../errors';
+import { invalidIdentifierIdError, invalidVersionError } from '../errors';
 import { resolveProfileId } from './client.internal';
 
 describe('InternalClient', () => {
@@ -27,6 +27,18 @@ describe('InternalClient', () => {
       it('throws on missing patch version', async () => {
         expect(() => resolveProfileId('scope/name@1.2')).toThrow(
           invalidVersionError('1.2', 'patch')
+        );
+      });
+
+      it('throws on invalid scope', async () => {
+        expect(() => resolveProfileId('scop:7_!e/name@1.0.0')).toThrow(
+          invalidIdentifierIdError('scop:7_!e', 'Scope')
+        );
+      });
+
+      it('throws on invalid name', async () => {
+        expect(() => resolveProfileId('scope/nam.:_-e@1.0.0')).toThrow(
+          invalidIdentifierIdError('nam.:_-e', 'Name')
         );
       });
     });
@@ -58,6 +70,18 @@ describe('InternalClient', () => {
         expect(() =>
           resolveProfileId({ id: 'scope/name', version: '1.2' })
         ).toThrow(invalidVersionError('1.2', 'patch'));
+      });
+
+      it('throws on invalid scope', async () => {
+        expect(() =>
+          resolveProfileId({ id: 'scop:7_!e/name', version: '1.2.3' })
+        ).toThrow(invalidIdentifierIdError('scop:7_!e', 'Scope'));
+      });
+
+      it('throws on invalid name', async () => {
+        expect(() =>
+          resolveProfileId({ id: 'scope/nam.:_-e', version: '1.2.3' })
+        ).toThrow(invalidIdentifierIdError('nam.:_-e', 'Name'));
       });
     });
   });

--- a/src/core/client/client.internal.test.ts
+++ b/src/core/client/client.internal.test.ts
@@ -1,3 +1,4 @@
+import { invalidVersionError } from '../errors';
 import { resolveProfileId } from './client.internal';
 
 describe('InternalClient', () => {
@@ -18,11 +19,15 @@ describe('InternalClient', () => {
       });
 
       it('throws on missing minor version', async () => {
-        expect(() => resolveProfileId('scope/name@1')).toThrow();
+        expect(() => resolveProfileId('scope/name@1')).toThrow(
+          invalidVersionError('1', 'minor')
+        );
       });
 
       it('throws on missing patch version', async () => {
-        expect(() => resolveProfileId('scope/name@1.2')).toThrow();
+        expect(() => resolveProfileId('scope/name@1.2')).toThrow(
+          invalidVersionError('1.2', 'patch')
+        );
       });
     });
 
@@ -46,13 +51,13 @@ describe('InternalClient', () => {
       it('throws on missing minor version', async () => {
         expect(() =>
           resolveProfileId({ id: 'scope/name', version: '1' })
-        ).toThrow();
+        ).toThrow(invalidVersionError('1', 'minor'));
       });
 
       it('throws on missing patch version', async () => {
         expect(() =>
           resolveProfileId({ id: 'scope/name', version: '1.2' })
-        ).toThrow();
+        ).toThrow(invalidVersionError('1.2', 'patch'));
       });
     });
   });

--- a/src/core/client/client.internal.test.ts
+++ b/src/core/client/client.internal.test.ts
@@ -1,0 +1,59 @@
+import { resolveProfileId } from './client.internal';
+
+describe('InternalClient', () => {
+  describe('resolveProfileId', () => {
+    describe('when passing profileId as string', () => {
+      it('returns correct id and version', async () => {
+        expect(resolveProfileId('scope/name@1.2.3-test')).toEqual({
+          id: 'scope/name',
+          version: '1.2.3-test',
+        });
+      });
+
+      it('returns correct id', async () => {
+        expect(resolveProfileId('scope/name')).toEqual({
+          id: 'scope/name',
+          version: undefined,
+        });
+      });
+
+      it('throws on missing minor version', async () => {
+        expect(() => resolveProfileId('scope/name@1')).toThrow();
+      });
+
+      it('throws on missing patch version', async () => {
+        expect(() => resolveProfileId('scope/name@1.2')).toThrow();
+      });
+    });
+
+    describe('when passing profileId as object', () => {
+      it('returns correct id and version', async () => {
+        expect(
+          resolveProfileId({ id: 'scope/name', version: '1.2.3-test' })
+        ).toEqual({
+          id: 'scope/name',
+          version: '1.2.3-test',
+        });
+      });
+
+      it('returns correct id', async () => {
+        expect(resolveProfileId({ id: 'scope/name' })).toEqual({
+          id: 'scope/name',
+          version: undefined,
+        });
+      });
+
+      it('throws on missing minor version', async () => {
+        expect(() =>
+          resolveProfileId({ id: 'scope/name', version: '1' })
+        ).toThrow();
+      });
+
+      it('throws on missing patch version', async () => {
+        expect(() =>
+          resolveProfileId({ id: 'scope/name', version: '1.2' })
+        ).toThrow();
+      });
+    });
+  });
+});

--- a/src/core/client/client.internal.ts
+++ b/src/core/client/client.internal.ts
@@ -4,6 +4,7 @@ import { profileAstId, SuperCache, versionToString } from '../../lib';
 import { SuperJson } from '../../schema-tools';
 import { Config } from '../config';
 import {
+  invalidVersionError,
   profileNotInstalledError,
   unconfiguredProviderInPriorityError,
 } from '../errors';
@@ -103,12 +104,10 @@ export function resolveProfileId(
   if (version !== undefined) {
     const extracted = extractVersion(version);
     if (extracted.minor === undefined) {
-      // TODO: correct error
-      throw new Error('Minor');
+      throw invalidVersionError(version, 'minor');
     }
     if (extracted.patch === undefined) {
-      // TODO: correct error
-      throw new Error('Patch');
+      throw invalidVersionError(version, 'patch');
     }
   }
 

--- a/src/core/client/client.internal.ts
+++ b/src/core/client/client.internal.ts
@@ -1,4 +1,4 @@
-import { extractVersion , ProfileDocumentNode } from '@superfaceai/ast';
+import { extractVersion, ProfileDocumentNode } from '@superfaceai/ast';
 
 import { profileAstId, SuperCache, versionToString } from '../../lib';
 import { SuperJson } from '../../schema-tools';
@@ -29,9 +29,14 @@ export class InternalClient {
     private readonly logger?: ILogger
   ) {}
 
-  public async getProfile(profileId: string): Promise<Profile> {
+  public async getProfile(
+    profile: string | { id: string; version?: string }
+  ): Promise<Profile> {
+    const { id, version } = resolveProfileId(profile);
+
     const ast = await resolveProfileAst({
-      profileId,
+      profileId: id,
+      version,
       logger: this.logger,
       fetchInstance: this.fetchInstance,
       fileSystem: this.fileSystem,

--- a/src/core/client/client.internal.ts
+++ b/src/core/client/client.internal.ts
@@ -1,9 +1,14 @@
-import { extractVersion, ProfileDocumentNode } from '@superfaceai/ast';
+import {
+  extractVersion,
+  isValidDocumentName,
+  ProfileDocumentNode,
+} from '@superfaceai/ast';
 
 import { profileAstId, SuperCache, versionToString } from '../../lib';
 import { SuperJson } from '../../schema-tools';
 import { Config } from '../config';
 import {
+  invalidIdentifierIdError,
   invalidVersionError,
   profileNotInstalledError,
   unconfiguredProviderInPriorityError,
@@ -101,6 +106,7 @@ export function resolveProfileId(
     version = profile.version;
   }
 
+  // Check if version is full
   if (version !== undefined) {
     const extracted = extractVersion(version);
     if (extracted.minor === undefined) {
@@ -111,6 +117,23 @@ export function resolveProfileId(
     }
   }
 
-  // TODO check if id is valid?
+  // Check scope and name
+  let name: string,
+    scope: string | undefined = undefined;
+  const [scopeOrName, possibleName] = id.split('/');
+  if (possibleName === undefined) {
+    name = scopeOrName;
+  } else {
+    scope = scopeOrName;
+    name = possibleName;
+  }
+  if (scope !== undefined && !isValidDocumentName(scope)) {
+    throw invalidIdentifierIdError(scope, 'Scope');
+  }
+
+  if (!isValidDocumentName(name)) {
+    throw invalidIdentifierIdError(name, 'Name');
+  }
+
   return { id, version };
 }

--- a/src/core/client/client.internal.ts
+++ b/src/core/client/client.internal.ts
@@ -1,3 +1,5 @@
+import { extractVersion } from '@superfaceai/ast';
+
 import { SuperCache } from '../../lib';
 import { SuperJson } from '../../schema-tools';
 import { Config } from '../config';
@@ -78,4 +80,33 @@ export class InternalClient {
 
     return new ProfileConfiguration(profileId, version);
   }
+}
+
+export function resolveProfileId(
+  profile: string | { id: string; version?: string }
+): { id: string; version?: string } {
+  let id: string;
+  let version: string | undefined;
+
+  if (typeof profile === 'string') {
+    [id, version] = profile.split('@');
+  } else {
+    id = profile.id;
+    version = profile.version;
+  }
+
+  if (version !== undefined) {
+    const extracted = extractVersion(version);
+    if (extracted.minor === undefined) {
+      // TODO: correct error
+      throw new Error('Minor');
+    }
+    if (extracted.patch === undefined) {
+      // TODO: correct error
+      throw new Error('Patch');
+    }
+  }
+
+  // TODO check if id is valid?
+  return { id, version };
 }

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -298,7 +298,7 @@ export function loadConfigFromEnv(
     ),
     disableReporting:
       environment.getString('NODE_ENV') === 'test' ||
-        environment.getBoolean(DISABLE_REPORTING) === true
+      environment.getBoolean(DISABLE_REPORTING) === true
         ? true
         : undefined,
     // TODO: add env variable and resolve it?

--- a/src/core/errors/errors.helpers.ts
+++ b/src/core/errors/errors.helpers.ts
@@ -127,6 +127,21 @@ export function unableToResolveProfileError(
   );
 }
 
+export function invalidVersionError(
+  completeVersion: string,
+  problematicPart: 'minor' | 'patch'
+): SDKExecutionError {
+  return new SDKExecutionError(
+    `Version "${completeVersion}" is not valid version. "${problematicPart}" is missing or not a number`,
+    [
+      `Version "${completeVersion}" is not valid version in format major.minor.patch eg. "1.0.0". "${problematicPart}" is missing or not a number`,
+    ],
+    [
+      'Pass valid version string in format major.minor.patch-label (-label is optional) eg. "1.0.0" or "1.2.3-test"',
+    ]
+  );
+}
+
 export function profileNotFoundError(profileName: string): SDKExecutionError {
   return new SDKExecutionError(
     `Profile "${profileName}" not found in super.json`,

--- a/src/core/errors/errors.helpers.ts
+++ b/src/core/errors/errors.helpers.ts
@@ -142,6 +142,17 @@ export function invalidVersionError(
   );
 }
 
+export function versionMismatchError(
+  superJsonVersion: string,
+  getProfileVersion: string
+): SDKExecutionError {
+  return new SDKExecutionError(
+    `Version from super.json (${superJsonVersion}) and getProfile (${getProfileVersion}) does not match.`,
+    ['If version in super.json and in "getProfile" is used thy must match'],
+    ['Use version either in super.json or in "getProfile"']
+  );
+}
+
 export function profileNotFoundError(profileName: string): SDKExecutionError {
   return new SDKExecutionError(
     `Profile "${profileName}" not found in super.json`,

--- a/src/core/errors/errors.helpers.ts
+++ b/src/core/errors/errors.helpers.ts
@@ -127,6 +127,17 @@ export function unableToResolveProfileError(
   );
 }
 
+export function invalidIdentifierIdError(
+  identifier: string,
+  problematicPart: 'Name' | 'Scope'
+): SDKExecutionError {
+  return new SDKExecutionError(
+    `${problematicPart} "${identifier}" is not a valid lowercase .`,
+    [],
+    ['Use valid idetifier']
+  );
+}
+
 export function invalidVersionError(
   completeVersion: string,
   problematicPart: 'minor' | 'patch'

--- a/src/core/errors/errors.helpers.ts
+++ b/src/core/errors/errors.helpers.ts
@@ -112,6 +112,21 @@ export function profileFileNotFoundError(
   );
 }
 
+export function unableToResolveProfileError(
+  profileId: string
+): SDKExecutionError {
+  return new SDKExecutionError(
+    `Profile "${profileId}" not found in super.json and version is not defined in "getProfile"`,
+    [
+      `To resolve correct profile "${profileId}" must be defined in super.json or profile version must be specified in "getProfile" function`,
+    ],
+    [
+      `Profile can be installed to local super.json using the superface cli tool: \`superface install ${profileId}\``,
+      `Optionally full version eg. 1.0.0 can be passed to "getProfile" in format \`${profileId}@version\` or as an obejct: { id: ${profileId}, version: version}`,
+    ]
+  );
+}
+
 export function profileNotFoundError(profileName: string): SDKExecutionError {
   return new SDKExecutionError(
     `Profile "${profileName}" not found in super.json`,

--- a/src/core/interfaces/client.ts
+++ b/src/core/interfaces/client.ts
@@ -3,7 +3,9 @@ import { Profile } from '../profile';
 import { Provider } from '../provider';
 
 export interface ISuperfaceClient {
-  getProfile(profileId: string): Promise<Profile>;
+  getProfile(
+    profile: string | { id: string; version?: string }
+  ): Promise<Profile>;
   getProvider(providerName: string): Promise<Provider>;
   getProviderForProfile(profileId: string): Promise<Provider>;
   on(...args: Parameters<Events['on']>): void;

--- a/src/core/profile/resolve-profile-ast.test.ts
+++ b/src/core/profile/resolve-profile-ast.test.ts
@@ -69,6 +69,7 @@ const createMockFileSystem = (
       if (result instanceof NotFoundError) {
         return Promise.resolve(err(result));
       }
+
       return Promise.resolve(ok(JSON.stringify(result)));
     }),
   });
@@ -101,6 +102,7 @@ describe('resolveProfileAst', () => {
       })
     ).rejects.toThrow(unableToResolveProfileError('does/not-exist'));
   });
+
   describe('when passing version', () => {
     describe('when profile is not defined in super.json', () => {
       it('returns a valid profile when profile is found in grid', async () => {
@@ -411,10 +413,7 @@ describe('resolveProfileAst', () => {
   describe('when using file property', () => {
     it('rejects when profile points to a non-existent path', async () => {
       const mockError = profileFileNotFoundError('../bar.supr.ast.json', 'bar');
-      fileSystem = createMockFileSystem(
-        'bar.supr.ast.json',
-        mockError
-      );
+      fileSystem = createMockFileSystem('bar.supr.ast.json', mockError);
 
       await expect(
         resolveProfileAst({

--- a/src/core/profile/resolve-profile-ast.ts
+++ b/src/core/profile/resolve-profile-ast.ts
@@ -11,6 +11,7 @@ import {
   sourceFileExtensionFoundError,
   unableToResolveProfileError,
   unsupportedFileExtensionError,
+  versionMismatchError,
 } from '../errors';
 import { Interceptable } from '../events';
 import { IConfig, ICrypto, IFileSystem, ILogger } from '../interfaces';
@@ -79,14 +80,11 @@ export async function resolveProfileAst({
     version !== undefined &&
     profileSettings.version !== version
   ) {
-    // TODO throw error instead?
-    logFunction?.(
-      `Version from super.json (${profileSettings.version}) and getProfile (${version}) does not match, using: ${version}`
-    );
+    throw versionMismatchError(profileSettings.version, version);
   }
   let filepath: string;
 
-  // TODO do we wand to check `file` if we have version from getProfile?
+  // TODO do we want to check `file` if we have version from getProfile?
   if (profileSettings !== undefined && 'file' in profileSettings) {
     filepath = superJson.resolvePath(profileSettings.file);
     logFunction?.('Reading possible profile file: %s', filepath);

--- a/src/core/profile/resolve-profile-ast.ts
+++ b/src/core/profile/resolve-profile-ast.ts
@@ -52,7 +52,6 @@ export async function resolveProfileAst({
 }): Promise<ProfileDocumentNode> {
   const logFunction = logger?.log(DEBUG_NAMESPACE);
 
-  // TODO look to cache first
   const loadProfileAstFile = async (
     fileNameWithExtension: string
   ): Promise<ProfileDocumentNode> => {
@@ -114,7 +113,6 @@ export async function resolveProfileAst({
   logFunction?.('Reading possible profile file: %S', filepath);
   try {
     return await loadProfileAstFile(filepath);
-    // TODO cache loaded ast?
   } catch (error) {
     logFunction?.(
       'Reading of possible profile file failed with error %O',
@@ -126,7 +124,6 @@ export async function resolveProfileAst({
   logFunction?.('Fetching profile file from registry');
 
   // Fallback to remote
-  // TODO this should be cached
   return fetchProfileAst(
     `${profileId}@${resolvedVersion}`,
     config,

--- a/src/core/profile/resolve-profile-ast.ts
+++ b/src/core/profile/resolve-profile-ast.ts
@@ -32,6 +32,7 @@ const DEBUG_NAMESPACE = 'profile-ast-resolution';
  */
 export async function resolveProfileAst({
   profileId,
+  version,
   logger,
   superJson,
   fileSystem,
@@ -40,6 +41,7 @@ export async function resolveProfileAst({
   fetchInstance,
 }: {
   profileId: string;
+  version?: string;
   logger?: ILogger;
   superJson: SuperJson;
   fileSystem: IFileSystem;
@@ -65,6 +67,14 @@ export async function resolveProfileAst({
 
   const profileSettings = superJson.normalized.profiles[profileId];
 
+  // TODO what we should do when we don't have profileSettings and version is undefined? -error
+  if (profileSettings === undefined && version === undefined) {
+    // TODO: better error
+    throw new Error('Profile not found in sj and version is missing');
+  }
+
+  // TODO what we should do when we have profileSettings and version is also defined? -error
+
   if (profileSettings === undefined) {
     throw profileNotFoundError(profileId);
   }
@@ -83,6 +93,7 @@ export async function resolveProfileAst({
 
     return await loadProfileAstFile(filepath);
   }
+  // TODO: this should happen also for case with version defined
   // assumed to be in grid folder under superface directory
   const gridPath = fileSystem.path.join(
     'grid',

--- a/src/mock/client.ts
+++ b/src/mock/client.ts
@@ -165,8 +165,10 @@ export class MockClient implements ISuperfaceClient {
     this.events.on(...args);
   }
 
-  public getProfile(profileId: string): Promise<Profile> {
-    return this.internalClient.getProfile(profileId);
+  public getProfile(
+    profile: string | { id: string; version?: string }
+  ): Promise<Profile> {
+    return this.internalClient.getProfile(profile);
   }
 
   public async getProvider(providerName: string): Promise<Provider> {

--- a/src/node/client/client.ts
+++ b/src/node/client/client.ts
@@ -24,6 +24,7 @@ import {
   Profile,
   Provider,
   registerHooks as registerFailoverHooks,
+  resolveProfileId,
 } from '../../core';
 import { SuperCache } from '../../lib';
 import {
@@ -206,8 +207,16 @@ export class SuperfaceClient
   extends SuperfaceClientBase
   implements ISuperfaceClient
 {
-  /** Gets a profile from super.json based on `profileId` in format: `[scope/]name`. */
-  public async getProfile(profileId: string): Promise<Profile> {
-    return this.internal.getProfile(profileId);
+  /** Gets a profile from super.json based on `profile` in format: `[scope/]name@profileVersion`. */
+  public async getProfile(
+    profile: string | { id: string; version?: string }
+  ): Promise<Profile> {
+    // TODO move this inside getProfileConfiguration function
+    const { id, version } = resolveProfileId(profile);
+
+    console.log('id', id, ' version ', version);
+
+    // TODO pass id and version
+    return this.internal.getProfile(id);
   }
 }

--- a/src/node/client/client.ts
+++ b/src/node/client/client.ts
@@ -24,7 +24,6 @@ import {
   Profile,
   Provider,
   registerHooks as registerFailoverHooks,
-  resolveProfileId,
 } from '../../core';
 import { SuperCache } from '../../lib';
 import {
@@ -207,16 +206,10 @@ export class SuperfaceClient
   extends SuperfaceClientBase
   implements ISuperfaceClient
 {
-  /** Gets a profile from super.json based on `profile` in format: `[scope/]name@profileVersion`. */
+  /** Gets a profile from super.json or remote registry based on `profile`. `profile` can be string in format: `[scope/]name@profileVersion` or object with `id` and optional `version` . */
   public async getProfile(
     profile: string | { id: string; version?: string }
   ): Promise<Profile> {
-    // TODO move this inside getProfileConfiguration function
-    const { id, version } = resolveProfileId(profile);
-
-    console.log('id', id, ' version ', version);
-
-    // TODO pass id and version
-    return this.internal.getProfile(id);
+    return this.internal.getProfile(profile);
   }
 }

--- a/src/node/client/client.typed.ts
+++ b/src/node/client/client.typed.ts
@@ -17,7 +17,7 @@ export type TypedSuperfaceClient<
   TProfiles extends ProfileUseCases<any, any>
 > = SuperfaceClientBase & {
   getProfile<TProfile extends keyof TProfiles>(
-    profile: TProfile
+    profile: TProfile | { id: TProfile; version?: string }
   ): Promise<TypedProfile<TProfiles[TProfile]>>;
 };
 

--- a/src/node/client/client.typed.ts
+++ b/src/node/client/client.typed.ts
@@ -1,6 +1,7 @@
 import {
   NonPrimitive,
   resolveProfileAst,
+  resolveProfileId,
   TypedProfile,
   UsecaseType,
 } from '../../core';
@@ -16,7 +17,7 @@ export type TypedSuperfaceClient<
   TProfiles extends ProfileUseCases<any, any>
 > = SuperfaceClientBase & {
   getProfile<TProfile extends keyof TProfiles>(
-    profileId: TProfile
+    profile: TProfile
   ): Promise<TypedProfile<TProfiles[TProfile]>>;
 };
 
@@ -29,10 +30,15 @@ export function createTypedClient<TProfiles extends ProfileUseCases<any, any>>(
     implements TypedSuperfaceClient<TProfiles>
   {
     public async getProfile<TProfile extends keyof TProfiles>(
-      profileId: TProfile
+      profile: TProfile | { id: TProfile; version?: string }
     ): Promise<TypedProfile<TProfiles[TProfile]>> {
+      const { id, version } = resolveProfileId(
+        profile as string | { id: string; version?: string }
+      );
+
       const ast = await resolveProfileAst({
-        profileId: profileId as string,
+        profileId: id,
+        version,
         logger: this.logger,
         fetchInstance: this.fetchInstance,
         fileSystem: NodeFileSystem,
@@ -55,7 +61,7 @@ export function createTypedClient<TProfiles extends ProfileUseCases<any, any>>(
         NodeFileSystem,
         this.crypto,
         this.fetchInstance,
-        Object.keys(profileDefinitions[profileId]),
+        Object.keys(profileDefinitions[id]),
         this.logger
       );
     }


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
This PR adds option to pass version to `getProfile` method as part of the profileId string. Optionally, id and version can be passed as object. Passed id and version is used during profile ast resolution.

Caching of profile ast and use without any super.json will be done in separate PRs

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [x] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
