### PR TITLE
fix: pass correct version to cache helper

### DIFF
--- a/src/core/profile/resolve-profile-ast.ts
+++ b/src/core/profile/resolve-profile-ast.ts
@@ -127,19 +127,22 @@ export async function resolveProfileAst({
     void error;
   }
 
-  logFunction?.('Fetching profile file from registry');
+  logFunction?.('Trying to load profile file from cache');
 
   // Fallback to cache/remote
   const cachedAst = await tryToLoadCachedAst({
     profileId,
-    version,
+    version: resolvedVersion,
     fileSystem,
     config,
     log: logFunction,
   });
   if (cachedAst !== undefined) {
+    logFunction?.('Loading profile file from cache successful');
+
     return cachedAst;
   }
+  logFunction?.('Fetching profile file from registry');
 
   const ast = await fetchProfileAst(
     `${profileId}@${resolvedVersion}`,


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

This PR fixes problem with passing incorrect version to caching helper.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [x] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
