### PR TITLE
Metrics reporting without super.json

### DIFF
--- a/src/core/events/reporter/reporter.test.ts
+++ b/src/core/events/reporter/reporter.test.ts
@@ -749,4 +749,31 @@ describe('MetricReporter', () => {
 
     systemTimeMock.mockRestore();
   }, 10000);
+
+  describe('without super.json', () => {
+    it('should report without configuration and hash', async () => {
+      const client = new MockClient(undefined, {
+        configOverride: {
+          disableReporting: false,
+          superfaceApiUrl: mockServer.url,
+        },
+      });
+
+      client.metricReporter?.reportEvent({
+        eventType: 'SDKInit',
+        occurredAt: new Date(),
+      });
+
+      while (await eventEndpoint.isPending()) {
+        await new Promise(setImmediate);
+      }
+
+      const requests = await eventEndpoint.getSeenRequests();
+      expect(requests).toHaveLength(1);
+      expect(await requests[0].body.getJson()).toMatchObject({
+        event_type: 'SDKInit',
+        data: {},
+      });
+    });
+  });
 });

--- a/src/core/events/reporter/reporter.ts
+++ b/src/core/events/reporter/reporter.ts
@@ -17,14 +17,14 @@ const DEBUG_NAMESPACE = 'metric-reporter';
 
 type EventBase = {
   event_type: 'SDKInit' | 'Metrics' | 'ProviderChange';
-  configuration_hash: string;
+  configuration_hash: string | undefined;
   occurred_at: string;
 };
 
 type SDKInitEvent = EventBase & {
   event_type: 'SDKInit';
   data: {
-    configuration: AnonymizedSuperJsonDocument;
+    configuration: AnonymizedSuperJsonDocument | undefined;
   };
 };
 
@@ -179,15 +179,15 @@ export class MetricReporter {
   private startTime: number | undefined;
   private readonly sdkToken: string | undefined;
   private performMetrics: Omit<PerformMetricsInput, 'eventType'>[] = [];
-  private configHash: string;
-  private anonymizedSuperJson: AnonymizedSuperJsonDocument;
+  private configHash: string | undefined;
+  private anonymizedSuperJson: AnonymizedSuperJsonDocument | undefined;
   private readonly log: LogFunction | undefined;
 
   constructor(
-    superJson: SuperJson,
     private readonly config: IConfig,
     private readonly timers: ITimers,
     private readonly fetchInstance: IFetch,
+    superJson?: SuperJson,
     logger?: ILogger
   ) {
     if (config.metricDebounceTimeMax < config.metricDebounceTimeMin) {
@@ -196,9 +196,12 @@ export class MetricReporter {
       );
     }
     this.sdkToken = config.sdkAuthToken;
-    this.configHash = superJson.configHash;
-    this.anonymizedSuperJson = superJson.anonymized;
     this.log = logger?.log(DEBUG_NAMESPACE);
+
+    if (superJson) {
+      this.configHash = superJson.configHash;
+      this.anonymizedSuperJson = superJson.anonymized;
+    }
   }
 
   public reportEvent(event: EventInput): void {

--- a/src/mock/client.ts
+++ b/src/mock/client.ts
@@ -84,15 +84,12 @@ export class MockClient implements ISuperfaceClient {
     this.events = new Events(this.timers, this.logger);
     registerHooks(this.events, this.timers, this.logger);
 
-    if (
-      this.config.disableReporting === false &&
-      this.superJson !== undefined
-    ) {
+    if (this.config.disableReporting === false) {
       this.metricReporter = new MetricReporter(
-        this.superJson,
         this.config,
         this.timers,
         new NodeFetch(this.timers),
+        this.superJson,
         this.logger
       );
       hookMetrics(this.events, this.metricReporter);

--- a/src/node/client/client.test.ts
+++ b/src/node/client/client.test.ts
@@ -2,12 +2,14 @@ import { SecurityValues } from '@superfaceai/ast';
 import { mocked } from 'ts-jest/utils';
 
 import {
+  MetricReporter,
   ProfileConfiguration,
   ProviderConfiguration,
   resolveProfileAst,
 } from '../../core';
 import { MockClient, mockProfileDocumentNode } from '../../mock';
 import { SuperJson } from '../../schema-tools';
+import { SuperfaceClient } from './client';
 
 const mockSecurityValues: SecurityValues[] = [
   {
@@ -83,6 +85,7 @@ afterEach(() => {
 jest.mock('../../core/registry');
 jest.mock('../../core/profile/resolve-profile-ast');
 jest.mock('../../core/events/failure/event-adapter');
+jest.mock('../../core/events/reporter');
 
 describe('superface client', () => {
   describe('getProfile', () => {
@@ -213,6 +216,24 @@ describe('superface client', () => {
           mockParameters
         )
       );
+    });
+
+    it('skips SDKInit reporting', async () => {
+      new SuperfaceClient({ superJson: undefined });
+
+      // Metric Reporter is setted up
+      expect(MetricReporter).toHaveBeenCalled();
+
+      // SDKInit event is not reported
+      expect(
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        MetricReporter.prototype.reportEvent
+      ).not.toHaveBeenCalledWith([
+        {
+          eventType: 'SDKInit',
+          occurredAt: expect.any(Date),
+        },
+      ]);
     });
   });
 });


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->

Setting up metrics reporting without super.json and changing super.json to be uptional for MetricReporter instance.

Client will skip `SDKInit` event reporting if super.json is not present.

This requires changes in backend services, which are done in https://github.com/superfaceai/brain/pull/434

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We want reporting of performs even without super.json.
But SDKInit doesn't need to be send as it doesn't have any value.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [x] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
