### PR TITLE
feat: get provider for profile error

### DIFF
--- a/src/core/errors/errors.helpers.ts
+++ b/src/core/errors/errors.helpers.ts
@@ -12,6 +12,19 @@ export function ensureErrorSubclass(error: unknown): Error {
   return new Error(JSON.stringify(error));
 }
 
+export function superJsonNotDefinedError(
+  callerName: string
+): SDKExecutionError {
+  return new SDKExecutionError(
+    `Super.json must be defined to call "${callerName}"`,
+    [],
+    [
+      'Define "superJson" property in SuperfaceClient constructor',
+      'Add super.json config file',
+    ]
+  );
+}
+
 export function superJsonNotFoundError(
   path: string,
   error?: Error

--- a/src/core/errors/errors.helpers.ts
+++ b/src/core/errors/errors.helpers.ts
@@ -20,7 +20,7 @@ export function superJsonNotDefinedError(
     [],
     [
       'Define "superJson" property in SuperfaceClient constructor',
-      'Add super.json config file',
+      'Add super.json config file with @superfaceai/cli package',
     ]
   );
 }

--- a/src/mock/client.ts
+++ b/src/mock/client.ts
@@ -29,6 +29,7 @@ import {
   resolveSecurityValues,
   SecurityConfiguration,
   ServiceSelector,
+  superJsonNotDefinedError,
 } from '../core';
 import { SuperCache } from '../lib/cache';
 import { NodeCrypto, NodeFetch, NodeFileSystem, NodeLogger } from '../node';
@@ -198,6 +199,10 @@ export class MockClient implements ISuperfaceClient {
   }
 
   public async getProviderForProfile(profileId: string): Promise<Provider> {
+    if (this.superJson === undefined) {
+      throw superJsonNotDefinedError('getProviderForProfile');
+    }
+
     return resolveProvider({
       superJson: this.superJson,
       profileId,

--- a/src/node/client/client.test.ts
+++ b/src/node/client/client.test.ts
@@ -5,6 +5,7 @@ import {
   ProfileConfiguration,
   ProviderConfiguration,
   resolveProfileAst,
+  superJsonNotDefinedError,
 } from '../../core';
 import { MockClient, mockProfileDocumentNode } from '../../mock';
 import { SuperJson } from '../../schema-tools';
@@ -186,33 +187,59 @@ describe('superface client', () => {
         );
       });
     });
-  });
 
-  describe('when using without super json', () => {
-    it('returns Provider instance', async () => {
-      const client = new MockClient();
-      const provider = await client.getProvider('test-provider');
+    describe('when using without super json', () => {
+      it('returns Provider instance', async () => {
+        const client = new MockClient();
+        const provider = await client.getProvider('test-provider');
 
-      expect(provider.configuration).toEqual(
-        new ProviderConfiguration('test-provider', [])
-      );
-    });
-
-    it('returns Provider instance with custom security values and parameters', async () => {
-      const client = new MockClient();
-
-      const provider = await client.getProvider('test-provider', {
-        security: mockSecurityValues,
-        parameters: mockParameters,
+        expect(provider.configuration).toEqual(
+          new ProviderConfiguration('test-provider', [])
+        );
       });
 
-      expect(provider.configuration).toEqual(
-        new ProviderConfiguration(
-          'test-provider',
-          mockSecurityValues,
-          mockParameters
-        )
-      );
+      it('returns Provider instance with custom security values and parameters', async () => {
+        const client = new MockClient();
+
+        const provider = await client.getProvider('test-provider', {
+          security: mockSecurityValues,
+          parameters: mockParameters,
+        });
+
+        expect(provider.configuration).toEqual(
+          new ProviderConfiguration(
+            'test-provider',
+            mockSecurityValues,
+            mockParameters
+          )
+        );
+      });
+    });
+  });
+
+  describe('getProviderForProfile', () => {
+    describe('when using with super json', () => {
+      it('returns Provider instance', async () => {
+        const client = new MockClient(mockSuperJson);
+        const provider = await client.getProviderForProfile('test-profile');
+
+        expect(provider.configuration).toEqual(
+          new ProviderConfiguration(
+            'test-provider',
+            mockSecurityValues,
+            mockParameters
+          )
+        );
+      });
+    });
+
+    describe('when using without super json', () => {
+      it('throws error', async () => {
+        const client = new MockClient();
+        await expect(
+          client.getProviderForProfile('test-profile')
+        ).rejects.toEqual(superJsonNotDefinedError('getProviderForProfile'));
+      });
     });
   });
 });

--- a/src/node/client/client.ts
+++ b/src/node/client/client.ts
@@ -26,6 +26,7 @@ import {
   registerHooks as registerFailoverHooks,
   resolveProvider,
   resolveSecurityValues,
+  superJsonNotDefinedError,
 } from '../../core';
 import { SuperCache } from '../../lib';
 import { SuperJson } from '../../schema-tools';
@@ -212,9 +213,12 @@ export abstract class SuperfaceClientBase {
     });
   }
 
-  // TDOD: do we need this?
   /** Returns a provider configuration for when no provider is passed to untyped `.perform`. */
   public async getProviderForProfile(profileId: string): Promise<Provider> {
+    if (this.superJson === undefined) {
+      throw superJsonNotDefinedError('getProviderForProfile');
+    }
+
     return resolveProvider({
       superJson: this.superJson,
       profileId,


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

This PR adds throwing of error when `getProviderForProfile` is called on client without SuperJson

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [x] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
