### PR TITLE
fix: integration parameters resolution

### DIFF
--- a/src/core/profile-provider/bound-profile-provider.ts
+++ b/src/core/profile-provider/bound-profile-provider.ts
@@ -22,6 +22,7 @@ import {
   SecurityConfiguration,
 } from '../interpreter';
 import { IServiceSelector } from '../services';
+import { resolveIntegrationParameters } from './parameters';
 import { resolveSecurityConfiguration } from './security';
 
 const DEBUG_NAMESPACE_SENSITIVE = 'bound-profile-provider:sensitive';
@@ -121,9 +122,9 @@ export class BoundProfileProvider implements IBoundProfileProvider {
         usecase,
         services: this.configuration.services,
         security,
-        parameters: this.mergeParameters(
-          parameters,
-          this.configuration.parameters
+        parameters: resolveIntegrationParameters(
+          this.provider,
+          this.mergeParameters(parameters, this.configuration.parameters)
         ),
       },
       {

--- a/src/core/profile-provider/parameters.test.ts
+++ b/src/core/profile-provider/parameters.test.ts
@@ -1,0 +1,70 @@
+import { ProviderJson } from '@superfaceai/ast';
+
+import { resolveIntegrationParameters } from './parameters';
+
+describe('resolveIntegrationParameters', () => {
+  let mockProviderJson: ProviderJson;
+
+  beforeEach(() => {
+    mockProviderJson = {
+      name: 'test',
+      services: [{ id: 'test-service', baseUrl: 'service/base/url' }],
+      securitySchemes: [],
+      defaultService: 'test-service',
+      parameters: [
+        {
+          name: 'first',
+          description: 'first test value',
+        },
+        {
+          name: 'second',
+        },
+        {
+          name: 'third',
+          default: 'third-default',
+        },
+        {
+          name: 'fourth',
+          default: 'fourth-default',
+        },
+      ],
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns undefined when parameters are undefined', () => {
+    expect(resolveIntegrationParameters(mockProviderJson)).toBeUndefined();
+  });
+
+  it('prints warning when unknown parameter is used', () => {
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    mockProviderJson.parameters = undefined;
+    expect(
+      resolveIntegrationParameters(mockProviderJson, { test: 'test' })
+    ).toEqual({ test: 'test' });
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Warning: Super.json defines integration parameters but provider.json does not'
+    );
+  });
+
+  it('returns resolved parameters', () => {
+    expect(
+      resolveIntegrationParameters(mockProviderJson, {
+        first: 'plain value',
+        second: '$TEST_SECOND', // unset env value without default
+        third: '$TEST_THIRD', // unset env value with default
+        // fourth is missing - should be resolved to its default
+      })
+    ).toEqual({
+      first: 'plain value',
+      second: '$TEST_SECOND',
+      third: 'third-default',
+      fourth: 'fourth-default',
+    });
+  });
+});

--- a/src/core/profile-provider/parameters.ts
+++ b/src/core/profile-provider/parameters.ts
@@ -1,0 +1,59 @@
+import { prepareProviderParameters, ProviderJson } from '@superfaceai/ast';
+
+export function resolveIntegrationParameters(
+  providerJson: ProviderJson,
+  parameters?: Record<string, string>
+): Record<string, string> | undefined {
+  if (parameters === undefined) {
+    return undefined;
+  }
+
+  const providerJsonParameters = providerJson.parameters || [];
+  if (
+    Object.keys(parameters).length !== 0 &&
+    providerJsonParameters.length === 0
+  ) {
+    console.warn(
+      'Warning: Super.json defines integration parameters but provider.json does not'
+    );
+  }
+  const result: Record<string, string> = {};
+
+  const preparedParameters = prepareProviderParameters(
+    providerJson.name,
+    providerJsonParameters
+  );
+
+  // Resolve parameters defined in super.json
+  for (const [key, value] of Object.entries(parameters)) {
+    const providerJsonParameter = providerJsonParameters.find(
+      parameter => parameter.name === key
+    );
+    // If value name and prepared value equals we are dealing with unset env
+    if (
+      providerJsonParameter &&
+      preparedParameters[providerJsonParameter.name] === value
+    ) {
+      if (providerJsonParameter.default !== undefined) {
+        result[key] = providerJsonParameter.default;
+      }
+    }
+
+    // Use original value
+    if (!result[key]) {
+      result[key] = value;
+    }
+  }
+
+  // Resolve parameters which are missing in super.json and have default value
+  for (const parameter of providerJsonParameters) {
+    if (
+      result[parameter.name] === undefined &&
+      parameter.default !== undefined
+    ) {
+      result[parameter.name] = parameter.default;
+    }
+  }
+
+  return result;
+}

--- a/src/core/profile-provider/profile-provider.ts
+++ b/src/core/profile-provider/profile-provider.ts
@@ -5,7 +5,6 @@ import {
   isFileURIString,
   isMapFile,
   MapDocumentNode,
-  prepareProviderParameters,
   ProfileDocumentNode,
   ProviderJson,
   SecurityValues,
@@ -37,6 +36,7 @@ import {
   BoundProfileProvider,
   IBoundProfileProvider,
 } from './bound-profile-provider';
+import { resolveIntegrationParameters } from './parameters';
 import { ProfileProviderConfiguration } from './profile-provider-configuration';
 import { resolveSecurityConfiguration } from './security';
 
@@ -246,7 +246,7 @@ export class ProfileProvider {
             providerInfo.name
           ],
         security: securityConfiguration,
-        parameters: this.resolveIntegrationParameters(
+        parameters: resolveIntegrationParameters(
           providerInfo,
           this.providerConfig.parameters ??
             this.superJson?.normalized.providers[providerInfo.name]?.parameters
@@ -257,64 +257,6 @@ export class ProfileProvider {
       this.logger,
       this.events
     );
-  }
-
-  private resolveIntegrationParameters(
-    providerJson: ProviderJson,
-    superJsonParameters?: Record<string, string>
-  ): Record<string, string> | undefined {
-    if (superJsonParameters === undefined) {
-      return undefined;
-    }
-
-    const providerJsonParameters = providerJson.parameters || [];
-    if (
-      Object.keys(superJsonParameters).length !== 0 &&
-      providerJsonParameters.length === 0
-    ) {
-      console.warn(
-        'Warning: Super.json defines integration parameters but provider.json does not'
-      );
-    }
-    const result: Record<string, string> = {};
-
-    const preparedParameters = prepareProviderParameters(
-      providerJson.name,
-      providerJsonParameters
-    );
-
-    // Resolve parameters defined in super.json
-    for (const [key, value] of Object.entries(superJsonParameters)) {
-      const providerJsonParameter = providerJsonParameters.find(
-        parameter => parameter.name === key
-      );
-      // If value name and prepared value equals we are dealing with unset env
-      if (
-        providerJsonParameter &&
-        preparedParameters[providerJsonParameter.name] === value
-      ) {
-        if (providerJsonParameter.default !== undefined) {
-          result[key] = providerJsonParameter.default;
-        }
-      }
-
-      // Use original value
-      if (!result[key]) {
-        result[key] = value;
-      }
-    }
-
-    // Resolve parameters which are missing in super.json and have default value
-    for (const parameter of providerJsonParameters) {
-      if (
-        result[parameter.name] === undefined &&
-        parameter.default !== undefined
-      ) {
-        result[parameter.name] = parameter.default;
-      }
-    }
-
-    return result;
   }
 
   private async cacheProviderInfo(providerName: string): Promise<ProviderJson> {


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

This PR fixes problem with not resolving(checkong) integration parameters passed directly to perform.
Utility function for parameter resolution has been moved to separate file and is called during bind and perform. This is similar to security values resolution.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [x] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
