### PR TITLE
Fix for resolving accept header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Do not set `accept` header when defined in [HTTP request headers](https://spec.superface.dev/latest/map-spec.html#HTTPHeaders) - [#264](https://github.com/superfaceai/one-sdk-js/issues/264)
 
 ## [2.0.0] - 2022-08-15
 ### Added

--- a/src/core/interpreter/http/filters.test.ts
+++ b/src/core/interpreter/http/filters.test.ts
@@ -360,5 +360,22 @@ describe('HTTP Filters', () => {
         })
       );
     });
+
+    it("doesn't set accept header if already exists", async () => {
+      const result = await headersFilter({
+        parameters: {
+          url: '/test',
+          method: '',
+          baseUrl: 'https://example.com',
+          headers: {
+            aCcEpT: 'application/json',
+          },
+          accept: 'text/plain',
+          contentType: JSON_CONTENT,
+        },
+      });
+
+      expect(result.request?.headers?.accept).toBe(undefined);
+    })
   });
 });

--- a/src/core/interpreter/http/filters.ts
+++ b/src/core/interpreter/http/filters.ts
@@ -26,7 +26,7 @@ import type {
   RequestParameters,
 } from './security';
 import type { HttpResponse } from './types';
-import { createUrl, fetchRequest } from './utils';
+import { createUrl, fetchRequest, hasAcceptHeader } from './utils';
 
 /**
  * Represents input of pipe filter which works with http response
@@ -258,8 +258,12 @@ export const headersFilter: Filter = ({
   request,
   response,
 }: FilterInputOutput) => {
-  const headers: Record<string, string> = parameters.headers || {};
-  headers['accept'] = parameters.accept ?? '*/*';
+  const headers: Record<string, string> = parameters.headers ?? {};
+
+  if (!hasAcceptHeader(headers)) {
+    headers['accept'] = parameters.accept ?? '*/*';
+  }
+
   headers['user-agent'] ??= USER_AGENT;
   if (parameters.contentType === JSON_CONTENT) {
     headers['content-type'] ??= JSON_CONTENT;

--- a/src/core/interpreter/http/utils.ts
+++ b/src/core/interpreter/http/utils.ts
@@ -140,3 +140,9 @@ export async function fetchRequest(
     },
   };
 }
+
+export function hasAcceptHeader(headers: NonPrimitive): boolean {
+  return Object.keys(headers).some(
+    header => header.toLowerCase() === 'accept'
+  );
+}

--- a/src/core/interpreter/map-interpreter.ts
+++ b/src/core/interpreter/map-interpreter.ts
@@ -327,7 +327,7 @@ export class MapInterpreter<TInput extends NonPrimitive | undefined>
       this.visit(responseHandler)
     );
 
-    let accept = '';
+    let accept: string;
     if (responseHandlers.some(([, accept]) => accept === undefined)) {
       accept = '*/*';
     } else {


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->

Do not set `accept` header when defined in [HTTP request headers](https://spec.superface.dev/latest/map-spec.html#HTTPHeaders). I wanted to normalize headers and work with them, but that could lead to unexpected behavior and better will be to allow set as many headers and in any case. It will delegate need to normalize to client and server.

One thing I am not happy about, is how the logic is split in `map-interpreter` and `filters`. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #264

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [x] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
