### PR TITLE
Fix handling Buffers in `multipart/form-data`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Do not set `accept` header when defined in [HTTP request headers](https://spec.superface.dev/latest/map-spec.html#HTTPHeaders) - [#264](https://github.com/superfaceai/one-sdk-js/issues/264)
+- Replaced `isomorphic-form-data` with `form-data` package to fix `FormData` serialization - [#291](https://github.com/superfaceai/one-sdk-js/issues/291)
+
+### Added
+- `multipart/form-data` supports array values to define duplicate fields
 
 ## [2.0.0] - 2022-08-15
 ### Added

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "abort-controller": "^3.0.0",
     "cross-fetch": "^3.1.5",
     "debug": "^4.3.2",
-    "isomorphic-form-data": "^2.0.0",
+    "form-data": "^4.0.0",
     "vm2": "^3.9.7"
   }
 }

--- a/src/core/interpreter/http/filters.ts
+++ b/src/core/interpreter/http/filters.ts
@@ -1,6 +1,6 @@
 import type { ILogger } from '../../../interfaces';
 import type { MaybePromise } from '../../../lib';
-import { pipe, UnexpectedError, variablesToStrings } from '../../../lib';
+import { castToNonPrimitive, pipe, UnexpectedError, variablesToStrings } from '../../../lib';
 import { USER_AGENT } from '../../../user-agent';
 import { unsupportedContentType } from '../../errors';
 import type { FetchBody, IFetch } from './interfaces';
@@ -99,31 +99,31 @@ export const fetchFilter: (
   logger?: ILogger
 ) => FilterWithRequest =
   (fetchInstance, logger) =>
-  async ({ parameters, request }: FilterInputWithRequest) => {
-    return {
-      parameters,
-      request,
-      response: await fetchRequest(fetchInstance, request, logger),
+    async ({ parameters, request }: FilterInputWithRequest) => {
+      return {
+        parameters,
+        request,
+        response: await fetchRequest(fetchInstance, request, logger),
+      };
     };
-  };
 
 export const authenticateFilter: (handler?: ISecurityHandler) => Filter =
   handler =>
-  async ({ parameters, request, response }: FilterInputOutput) => {
-    if (handler !== undefined) {
+    async ({ parameters, request, response }: FilterInputOutput) => {
+      if (handler !== undefined) {
+        return {
+          parameters: await handler.authenticate(parameters),
+          request,
+          response,
+        };
+      }
+
       return {
-        parameters: await handler.authenticate(parameters),
+        parameters,
         request,
         response,
       };
-    }
-
-    return {
-      parameters,
-      request,
-      response,
     };
-  };
 
 // This is handling the cases when we are authenticated but eg. digest credentials expired or OAuth access token is no longer valid
 export const handleResponseFilter: (
@@ -132,18 +132,18 @@ export const handleResponseFilter: (
   handler?: ISecurityHandler
 ) => FilterWithResponse =
   (fetchInstance, logger, handler) =>
-  async ({ parameters, request, response }: FilterInputWithResponse) => {
-    if (handler?.handleResponse !== undefined) {
-      // We get new parameters (with updated auth, also updated cache)
-      const authRequest = await handler.handleResponse(response, parameters);
-      // We retry the request
-      if (authRequest !== undefined) {
-        response = await fetchRequest(fetchInstance, authRequest, logger);
+    async ({ parameters, request, response }: FilterInputWithResponse) => {
+      if (handler?.handleResponse !== undefined) {
+        // We get new parameters (with updated auth, also updated cache)
+        const authRequest = await handler.handleResponse(response, parameters);
+        // We retry the request
+        if (authRequest !== undefined) {
+          response = await fetchRequest(fetchInstance, authRequest, logger);
+        }
       }
-    }
 
-    return { parameters, request, response };
-  };
+      return { parameters, request, response };
+    };
 
 export const urlFilter: Filter = ({
   parameters,
@@ -178,7 +178,10 @@ export const bodyFilter: Filter = ({
     } else if (parameters.contentType === URLENCODED_CONTENT) {
       finalBody = urlSearchParamsBody(variablesToStrings(parameters.body));
     } else if (parameters.contentType === FORMDATA_CONTENT) {
-      finalBody = formDataBody(variablesToStrings(parameters.body));
+      const body = castToNonPrimitive(parameters.body);
+      if (body) {
+        finalBody = formDataBody(body);
+      }
     } else if (
       parameters.contentType !== undefined &&
       BINARY_CONTENT_REGEXP.test(parameters.contentType)

--- a/src/core/interpreter/http/interfaces.ts
+++ b/src/core/interpreter/http/interfaces.ts
@@ -1,5 +1,5 @@
 type StringBody = { _type: 'string'; data: string };
-type FormDataBody = { _type: 'formdata'; data: Record<string, string> };
+type FormDataBody = { _type: 'formdata'; data: Record<string, unknown> };
 type BinaryBody = { _type: 'binary'; data: Buffer };
 type URLSearchParamsBody = {
   _type: 'urlsearchparams';
@@ -9,7 +9,7 @@ export const stringBody = (data: string): StringBody => ({
   _type: 'string',
   data,
 });
-export const formDataBody = (data: Record<string, string>): FormDataBody => ({
+export const formDataBody = (data: Record<string, unknown>): FormDataBody => ({
   _type: 'formdata',
   data,
 });

--- a/src/node/fetch/fetch.node.test.ts
+++ b/src/node/fetch/fetch.node.test.ts
@@ -1,3 +1,4 @@
+import FormData from 'form-data';
 import { getLocal } from 'mockttp';
 import { mocked } from 'ts-jest/utils';
 
@@ -376,5 +377,36 @@ describe('fetch', () => {
 
       expect((fetch as jest.Mock).mock.calls[0][1].body).toBeInstanceOf(Buffer);
     });
+  });
+
+  describe('when request body is multipart/form-data', () => {
+    describe('field value is a Buffer', () => {
+      it('passes FormData instance as body', async () => {
+        const { NodeFetch } = await import('./fetch.node');
+
+        const { fetch } = await import('cross-fetch');
+        jest.mock('cross-fetch');
+
+        mocked(fetch).mockResolvedValue({
+          headers: {
+            forEach: jest.fn((callbackfn: ForEachCallbackFunction) => {
+              callbackfn(undefined, undefined);
+            }),
+          },
+          text: jest.fn(),
+        } as any);
+
+        const fetchInstance = new NodeFetch(timers);
+
+        await fetchInstance.fetch(`${mockServer.url}/test`, {
+          method: 'POST',
+          body: { _type: 'formdata', data: { bufferField: Buffer.from('data') } },
+        });
+
+        expect(mocked(fetch).mock.calls[0][1]?.body).toBeInstanceOf(FormData);
+      });
+    });
+
+    describe('field value is an Array', () => { });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1453,7 +1453,7 @@ colorette@^1.2.2:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
-combined-stream@^1.0.6, combined-stream@^1.0.8:
+combined-stream@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -2220,19 +2220,19 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469"
   integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
 
-form-data@^2.3.2:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
-  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.6"
-    mime-types "^2.1.12"
-
 form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
   integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -2714,13 +2714,6 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
-
-isomorphic-form-data@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/isomorphic-form-data/-/isomorphic-form-data-2.0.0.tgz#9f6adf1c4c61ae3aefd8f110ab60fb9b143d6cec"
-  integrity sha512-TYgVnXWeESVmQSg4GLVbalmQ+B4NPi/H4eWxqALKj63KsUrcu301YDjBqaOw3h+cbak7Na4Xyps3BiptHtxTfg==
-  dependencies:
-    form-data "^2.3.2"
 
 isomorphic-ws@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->

This PR fixes handling Buffers in `multipart/form-data`. It also adds support to duplicate fields by allowing define array as value.

Switched from `isomorphic-form-data` to `form-data`, which handles buffers correctly.

Also, I had to fix `fetch.node.test.ts` where the mocking wasn't working as expected. https://github.com/superfaceai/one-sdk-js/pull/292/commits/6c193a8ed0fd65779475c4830c8e426d01749b9b

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #291 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [x] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
