### PR TITLE
Shape HeadersInit from FetchParameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Do not set `accept` header when defined in [HTTP request headers](https://spec.superface.dev/latest/map-spec.html#HTTPHeaders) - [#264](https://github.com/superfaceai/one-sdk-js/issues/264)
 - Replaced `isomorphic-form-data` with `form-data` package to fix `FormData` serialization - [#291](https://github.com/superfaceai/one-sdk-js/issues/291)
+- Create valid `headersInit` shape in `NodeFetch.fetch`
 
 ### Added
 - `multipart/form-data` supports array values to define duplicate fields

--- a/src/node/fetch/fetch.node.test.ts
+++ b/src/node/fetch/fetch.node.test.ts
@@ -15,225 +15,269 @@ const timers = new MockTimers();
 
 type ForEachCallbackFunction = (value?: string, type?: string) => void;
 
-describe('fetch', () => {
-  beforeEach(async () => {
-    await mockServer.start();
-  });
-
-  afterEach(async () => {
-    await mockServer.stop();
-    jest.resetAllMocks();
-    jest.resetModules();
-  });
-
-  describe('timeout', () => {
-    it('timeouts on network timeout', async () => {
-      // we want to use actuall fetch implementation
-      mocked(fetch).mockImplementation(jest.requireActual('cross-fetch').fetch);
-
-      await mockServer.forGet('/test').thenTimeout();
-      const realTimers = new NodeTimers();
-      const nodeFetch = new NodeFetch(realTimers);
-
-      await expect(
-        nodeFetch.fetch(`${mockServer.url}/test`, { method: 'GET', timeout: 2000 })
-      ).rejects.toEqual(new NetworkFetchError('timeout'));
-    });
-
-    it('rejects on rejected connection', async () => {
-      // we want to use actuall fetch implementation
-      mocked(fetch).mockImplementation(jest.requireActual('cross-fetch').fetch);
-
-      await mockServer.forGet('/test').thenCloseConnection();
-      const nodeFetch = new NodeFetch(timers);
-
-      await expect(
-        nodeFetch.fetch(`${mockServer.url}/test`, { method: 'GET', timeout: 2000 })
-      ).rejects.toEqual(new NetworkFetchError('reject'));
-    });
-
-    it('rethrows error if it is string', async () => {
-      mocked(fetch).mockRejectedValue('something-bad');
-
-      const fetchInstance = new NodeFetch(timers);
-
-      await expect(
-        fetchInstance.fetch(`${mockServer.url}/test`, {
-          method: 'GET',
-          timeout: 2000,
-        })
-      ).rejects.toEqual('something-bad');
-    });
-
-    it('rethrows error if it does not contain type property', async () => {
-      // We are mocking node-fetch
-      mocked(fetch).mockRejectedValue({ some: 'something-bad' });
-
-      const fetchInstance = new NodeFetch(timers);
-
-      await expect(
-        fetchInstance.fetch(`${mockServer.url}/test`, {
-          method: 'GET',
-          timeout: 2000,
-        })
-      ).rejects.toEqual({ some: 'something-bad' });
-    });
-
-    it('throws request abort if error does not get recognized', async () => {
-      // We are mocking node-fetch
-      mocked(fetch).mockRejectedValue({ type: 'something-bad' });
-
-      const fetchInstance = new NodeFetch(timers);
-
-      await expect(
-        fetchInstance.fetch(`${mockServer.url}/test`, {
-          method: 'GET',
-          timeout: 2000,
-        })
-      ).rejects.toEqual(new RequestFetchError('abort'));
-    });
-
-    it('throws on dns ENOTFOUND', async () => {
-      // We are mocking node-fetch
-      mocked(fetch).mockRejectedValue({
-        type: 'system',
-        code: 'ENOTFOUND',
-        errno: '',
-      });
-
-      const fetchInstance = new NodeFetch(timers);
-
-      await expect(
-        fetchInstance.fetch(`${mockServer.url}/test`, {
-          method: 'GET',
-          timeout: 2000,
-        })
-      ).rejects.toEqual(new NetworkFetchError('dns'));
-    });
-
-    it('throws on dns EAI_AGAIN', async () => {
-      // We are mocking node-fetch
-      mocked(fetch).mockRejectedValue({
-        type: 'system',
-        code: 'EAI_AGAIN',
-        errno: '',
-      });
-
-      const fetchInstance = new NodeFetch(timers);
-
-      await expect(
-        fetchInstance.fetch(`${mockServer.url}/test`, {
-          method: 'GET',
-          timeout: 2000,
-        })
-      ).rejects.toEqual(new NetworkFetchError('dns'));
-    });
-  });
-
-  describe('when application/json content type received', () => {
-    let responseJsonMock: jest.Mock;
-    let result: any;
-
+describe('NodeFetch', () => {
+  describe('fetch', () => {
     beforeEach(async () => {
-      responseJsonMock = jest.fn().mockResolvedValue({
-        foo: 'bar',
+      await mockServer.start();
+    });
+
+    afterEach(async () => {
+      await mockServer.stop();
+      jest.resetAllMocks();
+      jest.resetModules();
+    });
+
+    describe('timeout', () => {
+      it('timeouts on network timeout', async () => {
+        // we want to use actuall fetch implementation
+        mocked(fetch).mockImplementation(jest.requireActual('cross-fetch').fetch);
+
+        await mockServer.forGet('/test').thenTimeout();
+        const realTimers = new NodeTimers();
+        const nodeFetch = new NodeFetch(realTimers);
+
+        await expect(
+          nodeFetch.fetch(`${mockServer.url}/test`, { method: 'GET', timeout: 2000 })
+        ).rejects.toEqual(new NetworkFetchError('timeout'));
       });
 
-      mocked(fetch).mockResolvedValue({
-        headers: {
-          forEach: jest.fn((callbackfn: ForEachCallbackFunction) => {
-            callbackfn('application/json', 'content-type');
-          }),
-        },
-        json: responseJsonMock,
-      } as any);
+      it('rejects on rejected connection', async () => {
+        // we want to use actuall fetch implementation
+        mocked(fetch).mockImplementation(jest.requireActual('cross-fetch').fetch);
 
+        await mockServer.forGet('/test').thenCloseConnection();
+        const nodeFetch = new NodeFetch(timers);
 
-      const fetchInstance = new NodeFetch(timers);
+        await expect(
+          nodeFetch.fetch(`${mockServer.url}/test`, { method: 'GET', timeout: 2000 })
+        ).rejects.toEqual(new NetworkFetchError('reject'));
+      });
 
-      result = await fetchInstance.fetch(`${mockServer.url}/test`, {
-        method: 'GET',
+      it('rethrows error if it is string', async () => {
+        mocked(fetch).mockRejectedValue('something-bad');
+
+        const fetchInstance = new NodeFetch(timers);
+
+        await expect(
+          fetchInstance.fetch(`${mockServer.url}/test`, {
+            method: 'GET',
+            timeout: 2000,
+          })
+        ).rejects.toEqual('something-bad');
+      });
+
+      it('rethrows error if it does not contain type property', async () => {
+        // We are mocking node-fetch
+        mocked(fetch).mockRejectedValue({ some: 'something-bad' });
+
+        const fetchInstance = new NodeFetch(timers);
+
+        await expect(
+          fetchInstance.fetch(`${mockServer.url}/test`, {
+            method: 'GET',
+            timeout: 2000,
+          })
+        ).rejects.toEqual({ some: 'something-bad' });
+      });
+
+      it('throws request abort if error does not get recognized', async () => {
+        // We are mocking node-fetch
+        mocked(fetch).mockRejectedValue({ type: 'something-bad' });
+
+        const fetchInstance = new NodeFetch(timers);
+
+        await expect(
+          fetchInstance.fetch(`${mockServer.url}/test`, {
+            method: 'GET',
+            timeout: 2000,
+          })
+        ).rejects.toEqual(new RequestFetchError('abort'));
+      });
+
+      it('throws on dns ENOTFOUND', async () => {
+        // We are mocking node-fetch
+        mocked(fetch).mockRejectedValue({
+          type: 'system',
+          code: 'ENOTFOUND',
+          errno: '',
+        });
+
+        const fetchInstance = new NodeFetch(timers);
+
+        await expect(
+          fetchInstance.fetch(`${mockServer.url}/test`, {
+            method: 'GET',
+            timeout: 2000,
+          })
+        ).rejects.toEqual(new NetworkFetchError('dns'));
+      });
+
+      it('throws on dns EAI_AGAIN', async () => {
+        // We are mocking node-fetch
+        mocked(fetch).mockRejectedValue({
+          type: 'system',
+          code: 'EAI_AGAIN',
+          errno: '',
+        });
+
+        const fetchInstance = new NodeFetch(timers);
+
+        await expect(
+          fetchInstance.fetch(`${mockServer.url}/test`, {
+            method: 'GET',
+            timeout: 2000,
+          })
+        ).rejects.toEqual(new NetworkFetchError('dns'));
       });
     });
 
-    it('should call json', async () => {
-      expect(responseJsonMock).toBeCalled();
-    });
+    describe('when application/json content type received', () => {
+      let responseJsonMock: jest.Mock;
+      let result: any;
 
-    it('should return json object in body', async () => {
-      expect(result.body).toBeInstanceOf(Object);
-      expect(result.body).toStrictEqual({
-        foo: 'bar',
+      beforeEach(async () => {
+        responseJsonMock = jest.fn().mockResolvedValue({
+          foo: 'bar',
+        });
+
+        mocked(fetch).mockResolvedValue({
+          headers: {
+            forEach: jest.fn((callbackfn: ForEachCallbackFunction) => {
+              callbackfn('application/json', 'content-type');
+            }),
+          },
+          json: responseJsonMock,
+        } as any);
+
+
+        const fetchInstance = new NodeFetch(timers);
+
+        result = await fetchInstance.fetch(`${mockServer.url}/test`, {
+          method: 'GET',
+        });
+      });
+
+      it('should call json', async () => {
+        expect(responseJsonMock).toBeCalled();
+      });
+
+      it('should return json object in body', async () => {
+        expect(result.body).toBeInstanceOf(Object);
+        expect(result.body).toStrictEqual({
+          foo: 'bar',
+        });
       });
     });
-  });
 
-  describe('when text/plain content type received', () => {
-    let responseTextMock: jest.Mock;
-    let result: any;
+    describe('when text/plain content type received', () => {
+      let responseTextMock: jest.Mock;
+      let result: any;
 
-    beforeEach(async () => {
-      responseTextMock = jest.fn().mockResolvedValue('foobar');
+      beforeEach(async () => {
+        responseTextMock = jest.fn().mockResolvedValue('foobar');
 
-      mocked(fetch).mockResolvedValue({
-        headers: {
-          forEach: jest.fn((callbackfn: ForEachCallbackFunction) => {
-            callbackfn('text/plain', 'content-type');
-          }),
-        },
-        text: responseTextMock,
-      } as any);
+        mocked(fetch).mockResolvedValue({
+          headers: {
+            forEach: jest.fn((callbackfn: ForEachCallbackFunction) => {
+              callbackfn('text/plain', 'content-type');
+            }),
+          },
+          text: responseTextMock,
+        } as any);
 
 
-      const fetchInstance = new NodeFetch(timers);
+        const fetchInstance = new NodeFetch(timers);
 
-      result = await fetchInstance.fetch(`${mockServer.url}/test`, {
-        method: 'GET',
+        result = await fetchInstance.fetch(`${mockServer.url}/test`, {
+          method: 'GET',
+        });
+      });
+
+      it('should call text', async () => {
+        expect(responseTextMock).toBeCalled();
+      });
+
+      it('should return plain text in body', async () => {
+        expect(result.body).toBe('foobar');
       });
     });
 
-    it('should call text', async () => {
-      expect(responseTextMock).toBeCalled();
+    describe('when binary content type received', () => {
+      const binaryContentTypes = [
+        'application/octet-stream',
+        'audio/mp3',
+        'audio/wav',
+        'audio/wav;rate=8000',
+        'video/mp4',
+        'image/jpeg',
+      ];
+
+      for (const contentType of binaryContentTypes) {
+        describe(`${contentType}`, () => {
+          let responseArrayBufferMock: jest.Mock;
+          let result: any;
+
+          beforeEach(async () => {
+            responseArrayBufferMock = jest
+              .fn()
+              .mockResolvedValue(Buffer.from('foobar'));
+
+            mocked(fetch).mockResolvedValue({
+              headers: {
+                forEach: jest.fn((callbackfn: ForEachCallbackFunction) => {
+                  callbackfn(contentType, 'content-type');
+                }),
+              },
+              arrayBuffer: responseArrayBufferMock,
+            } as any);
+
+            const fetchInstance = new NodeFetch(timers);
+
+            result = await fetchInstance.fetch(`${mockServer.url}/test`, {
+              method: 'GET',
+            });
+          });
+
+          it('should call arrayBuffer', async () => {
+            expect(responseArrayBufferMock).toBeCalled();
+          });
+
+          it('should return instance of Buffer in body', async () => {
+            expect(result.body).toBeInstanceOf(Buffer);
+          });
+        });
+      }
     });
 
-    it('should return plain text in body', async () => {
-      expect(result.body).toBe('foobar');
-    });
-  });
+    describe('when application/octet-stream content type accepted', () => {
+      let responseArrayBufferMock: jest.Mock;
 
-  describe('when binary content type received', () => {
-    const binaryContentTypes = [
-      'application/octet-stream',
-      'audio/mp3',
-      'audio/wav',
-      'audio/wav;rate=8000',
-      'video/mp4',
-      'image/jpeg',
-    ];
+      beforeEach(async () => {
+        responseArrayBufferMock = jest
+          .fn()
+          .mockResolvedValue(Buffer.from('foobar'));
 
-    for (const contentType of binaryContentTypes) {
-      describe(`${contentType}`, () => {
-        let responseArrayBufferMock: jest.Mock;
+        mocked(fetch).mockResolvedValue({
+          headers: {
+            forEach: jest.fn((callbackfn: ForEachCallbackFunction) => {
+              callbackfn(undefined, undefined);
+            }),
+          },
+          arrayBuffer: responseArrayBufferMock,
+        } as any);
+      });
+
+      describe('when accept header contains string value', () => {
         let result: any;
 
         beforeEach(async () => {
-          responseArrayBufferMock = jest
-            .fn()
-            .mockResolvedValue(Buffer.from('foobar'));
-
-          mocked(fetch).mockResolvedValue({
-            headers: {
-              forEach: jest.fn((callbackfn: ForEachCallbackFunction) => {
-                callbackfn(contentType, 'content-type');
-              }),
-            },
-            arrayBuffer: responseArrayBufferMock,
-          } as any);
-
           const fetchInstance = new NodeFetch(timers);
 
           result = await fetchInstance.fetch(`${mockServer.url}/test`, {
             method: 'GET',
+            headers: {
+              accept: 'application/octet-stream',
+            },
           });
         });
 
@@ -245,137 +289,118 @@ describe('fetch', () => {
           expect(result.body).toBeInstanceOf(Buffer);
         });
       });
+
+      describe('when accept header contains array of string values', () => {
+        let result: any;
+
+        beforeEach(async () => {
+          const fetchInstance = new NodeFetch(timers);
+
+          result = await fetchInstance.fetch(`${mockServer.url}/test`, {
+            method: 'GET',
+            headers: {
+              accept: ['application/octet-stream'],
+            },
+          });
+        });
+
+        it('should call arrayBuffer', async () => {
+          expect(responseArrayBufferMock).toBeCalled();
+        });
+
+        it('should return instance of Buffer in body', async () => {
+          expect(result.body).toBeInstanceOf(Buffer);
+        });
+      });
+    });
+
+    describe('when request body contains binary data', () => {
+      it('should call cross-fetch with Buffer in body', async () => {
+        mocked(fetch).mockResolvedValue({
+          headers: {
+            forEach: jest.fn((callbackfn: ForEachCallbackFunction) => {
+              callbackfn(undefined, undefined);
+            }),
+          },
+          text: jest.fn(),
+        } as any);
+
+        const fetchInstance = new NodeFetch(timers);
+
+        await fetchInstance.fetch(`${mockServer.url}/test`, {
+          method: 'POST',
+          body: { _type: 'binary', data: Buffer.from('data') },
+        });
+
+        expect((fetch as jest.Mock).mock.calls[0][1].body).toBeInstanceOf(Buffer);
+      });
+    });
+
+    describe('when request body is multipart/form-data', () => {
+      let fetchInstance: NodeFetch;
+
+      beforeEach(() => {
+        fetchInstance = new NodeFetch(timers);
+
+        mocked(fetch).mockResolvedValue({
+          headers: {
+            forEach: jest.fn((callbackfn: ForEachCallbackFunction) => {
+              callbackfn(undefined, undefined);
+            }),
+          },
+          text: jest.fn(),
+        } as any);
+      });
+
+      describe('field value is a Buffer', () => {
+        it('passes FormData instance as body', async () => {
+          await fetchInstance.fetch(`${mockServer.url}/test`, {
+            method: 'POST',
+            body: { _type: 'formdata', data: { bufferField: Buffer.from('data') } },
+          });
+
+          expect(mocked(fetch).mock.calls[0][1]?.body).toBeInstanceOf(FormData);
+        });
+      });
+
+      describe('field value is an Array', () => {
+        it('expands array to duplicate fields in FormData', async () => {
+          await fetchInstance.fetch(`${mockServer.url}/test`, {
+            method: 'POST',
+            body: { _type: 'formdata', data: { arrayField: [1, 2] } },
+          });
+
+          // form-data library doesn't have getAll, so need to get buffer,
+          // create string and regex for number of entries
+          expect(
+            (mocked(fetch).mock.calls[0][1]?.body as unknown as FormData)
+              .getBuffer().toString().match(/arrayField/g)?.length,
+          ).toBe(2)
+        });
+      });
+    });
+  });
+
+  describe('prepareHeadersInit', () => {
+    let nodeFetch: NodeFetch;
+
+    type OverrideNodeFetch = {
+      prepareHeadersInit: (data: any) => any | undefined
     }
-  });
-
-  describe('when application/octet-stream content type accepted', () => {
-    let responseArrayBufferMock: jest.Mock;
-
-    beforeEach(async () => {
-      responseArrayBufferMock = jest
-        .fn()
-        .mockResolvedValue(Buffer.from('foobar'));
-
-      mocked(fetch).mockResolvedValue({
-        headers: {
-          forEach: jest.fn((callbackfn: ForEachCallbackFunction) => {
-            callbackfn(undefined, undefined);
-          }),
-        },
-        arrayBuffer: responseArrayBufferMock,
-      } as any);
-    });
-
-    describe('when accept header contains string value', () => {
-      let result: any;
-
-      beforeEach(async () => {
-        const fetchInstance = new NodeFetch(timers);
-
-        result = await fetchInstance.fetch(`${mockServer.url}/test`, {
-          method: 'GET',
-          headers: {
-            accept: 'application/octet-stream',
-          },
-        });
-      });
-
-      it('should call arrayBuffer', async () => {
-        expect(responseArrayBufferMock).toBeCalled();
-      });
-
-      it('should return instance of Buffer in body', async () => {
-        expect(result.body).toBeInstanceOf(Buffer);
-      });
-    });
-
-    describe('when accept header contains array of string values', () => {
-      let result: any;
-
-      beforeEach(async () => {
-        const fetchInstance = new NodeFetch(timers);
-
-        result = await fetchInstance.fetch(`${mockServer.url}/test`, {
-          method: 'GET',
-          headers: {
-            accept: ['application/octet-stream'],
-          },
-        });
-      });
-
-      it('should call arrayBuffer', async () => {
-        expect(responseArrayBufferMock).toBeCalled();
-      });
-
-      it('should return instance of Buffer in body', async () => {
-        expect(result.body).toBeInstanceOf(Buffer);
-      });
-    });
-  });
-
-  describe('when request body contains binary data', () => {
-    it('should call cross-fetch with Buffer in body', async () => {
-      mocked(fetch).mockResolvedValue({
-        headers: {
-          forEach: jest.fn((callbackfn: ForEachCallbackFunction) => {
-            callbackfn(undefined, undefined);
-          }),
-        },
-        text: jest.fn(),
-      } as any);
-
-      const fetchInstance = new NodeFetch(timers);
-
-      await fetchInstance.fetch(`${mockServer.url}/test`, {
-        method: 'POST',
-        body: { _type: 'binary', data: Buffer.from('data') },
-      });
-
-      expect((fetch as jest.Mock).mock.calls[0][1].body).toBeInstanceOf(Buffer);
-    });
-  });
-
-  describe('when request body is multipart/form-data', () => {
-    let fetchInstance: NodeFetch;
 
     beforeEach(() => {
-      fetchInstance = new NodeFetch(timers);
-
-      mocked(fetch).mockResolvedValue({
-        headers: {
-          forEach: jest.fn((callbackfn: ForEachCallbackFunction) => {
-            callbackfn(undefined, undefined);
-          }),
-        },
-        text: jest.fn(),
-      } as any);
+      nodeFetch = new NodeFetch(timers);
     });
 
-    describe('field value is a Buffer', () => {
-      it('passes FormData instance as body', async () => {
-        await fetchInstance.fetch(`${mockServer.url}/test`, {
-          method: 'POST',
-          body: { _type: 'formdata', data: { bufferField: Buffer.from('data') } },
-        });
-
-        expect(mocked(fetch).mock.calls[0][1]?.body).toBeInstanceOf(FormData);
-      });
+    it('returns empty array if data are undefined', () => {
+      expect((nodeFetch as any as OverrideNodeFetch).prepareHeadersInit(undefined)).toEqual([]);
     });
 
-    describe('field value is an Array', () => {
-      it('expands array to duplicate fields in FormData', async () => {
-        await fetchInstance.fetch(`${mockServer.url}/test`, {
-          method: 'POST',
-          body: { _type: 'formdata', data: { arrayField: [1, 2] } },
-        });
-
-        // form-data library doesn't have getAll, so need to get buffer,
-        // create string and regex for number of entries
-        expect(
-          (mocked(fetch).mock.calls[0][1]?.body as unknown as FormData)
-            .getBuffer().toString().match(/arrayField/g)?.length,
-        ).toBe(2)
-      });
+    it('returns array of tuples if header value is array', () => {
+      expect(
+        (nodeFetch as any as OverrideNodeFetch)
+          .prepareHeadersInit({ header: ['val1', 'val2'] })
+      ).toEqual([['header', 'val1'], ['header', 'val2']]);
     });
   });
 });

--- a/src/node/fetch/fetch.node.ts
+++ b/src/node/fetch/fetch.node.ts
@@ -43,12 +43,7 @@ export class NodeFetch implements IFetch, Interceptable, AuthCache {
     url: string,
     parameters: FetchParameters
   ): Promise<FetchResponse> {
-    const headersInit = parameters.headers
-      ? Object.entries(parameters.headers).map(([key, value]) => [
-        key,
-        ...(Array.isArray(value) ? value : [value]),
-      ])
-      : undefined;
+    const headersInit = this.prepareHeadersInit(parameters.headers);
 
     const request: RequestInit = {
       headers: new Headers(headersInit),
@@ -238,5 +233,23 @@ export class NodeFetch implements IFetch, Interceptable, AuthCache {
     }
 
     return false;
+  }
+
+  private prepareHeadersInit(data: FetchParameters['headers'] | undefined): HeadersInit {
+    if (data === undefined) {
+      return [];
+    }
+
+    const headers: [string, string][] = [];
+
+    Object.entries(data).forEach(([key, value]) => {
+      if (Array.isArray(value)) {
+        value.forEach((val) => headers.push([key, val]));
+      } else {
+        headers.push([key, value]);
+      }
+    });
+
+    return headers;
   }
 }


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->

Added function to format Record to array of tuples which is expected in `HeadersInit` and support duplicate headers.

The original test is indented, so it looks long. So, check it with [hidden whitespaces](https://github.com/superfaceai/one-sdk-js/pull/293/files?diff=split&w=1).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

TypeScript compiler was complaining about the shape of `headersInit` data.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [x] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
