### PR TITLE
Fix for headers handling in filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Do not set `accept` header when defined in [HTTP request headers](https://spec.superface.dev/latest/map-spec.html#HTTPHeaders) - [#264](https://github.com/superfaceai/one-sdk-js/issues/264)
+- Do not set `Accept` and `Content-Type` header when defined in [HTTP request headers](https://spec.superface.dev/latest/map-spec.html#HTTPHeaders) - [#264](https://github.com/superfaceai/one-sdk-js/issues/264)
 - Replaced `isomorphic-form-data` with `form-data` package to fix `FormData` serialization - [#291](https://github.com/superfaceai/one-sdk-js/issues/291)
 - Create valid `headersInit` shape in `NodeFetch.fetch`
 

--- a/src/core/interpreter/http/filters.ts
+++ b/src/core/interpreter/http/filters.ts
@@ -26,7 +26,7 @@ import type {
   RequestParameters,
 } from './security';
 import type { HttpResponse } from './types';
-import { createUrl, fetchRequest, hasAcceptHeader } from './utils';
+import { createUrl, fetchRequest, setHeader } from './utils';
 
 /**
  * Represents input of pipe filter which works with http response
@@ -263,22 +263,20 @@ export const headersFilter: Filter = ({
 }: FilterInputOutput) => {
   const headers: Record<string, string> = parameters.headers ?? {};
 
-  if (!hasAcceptHeader(headers)) {
-    headers['accept'] = parameters.accept ?? '*/*';
-  }
+  setHeader(headers, 'user-agent', USER_AGENT);
+  setHeader(headers, 'accept', parameters.accept ?? '*/*');
 
-  headers['user-agent'] ??= USER_AGENT;
   if (parameters.contentType === JSON_CONTENT) {
-    headers['content-type'] ??= JSON_CONTENT;
+    setHeader(headers, 'content-type', JSON_CONTENT);
   } else if (parameters.contentType === URLENCODED_CONTENT) {
-    headers['content-type'] ??= URLENCODED_CONTENT;
+    setHeader(headers, 'content-type', URLENCODED_CONTENT);
   } else if (parameters.contentType === FORMDATA_CONTENT) {
     // NOTE: Do not set content-type explicitly, it will be read from FormData along with boundary
   } else if (
     parameters.contentType !== undefined &&
     BINARY_CONTENT_REGEXP.test(parameters.contentType)
   ) {
-    headers['Content-Type'] ??= parameters.contentType;
+    setHeader(headers, 'content-type', parameters.contentType);
   } else {
     if (parameters.body !== undefined) {
       const supportedTypes = [

--- a/src/core/interpreter/http/http.test.ts
+++ b/src/core/interpreter/http/http.test.ts
@@ -5,7 +5,7 @@ import { SuperCache } from '../../../lib';
 import { MockTimers } from '../../../mock';
 import { NodeCrypto, NodeFetch } from '../../../node';
 import { HttpClient } from './http';
-import { createUrl } from './utils';
+import { createUrl, getHeader } from './utils';
 
 const mockServer = getLocal();
 const timers = new MockTimers();
@@ -140,7 +140,7 @@ describe('HttpClient', () => {
             method: 'post',
             accept: 'application/json',
             baseUrl: 'http://localhost',
-            contentType: contentType,
+            contentType,
             body: Buffer.from('data') as unknown as Primitive,
           });
         });
@@ -155,7 +155,7 @@ describe('HttpClient', () => {
         it('should fetch request with correct Content-Type header', async () => {
           const requestHeaders = fetchMock.mock.calls[0][1].headers;
           expect(requestHeaders).toBeDefined();
-          expect(requestHeaders['Content-Type']).toBe(contentType);
+          expect(getHeader(requestHeaders, 'Content-Type')).toBe(contentType);
         });
       });
     }

--- a/src/core/interpreter/http/utils.test.ts
+++ b/src/core/interpreter/http/utils.test.ts
@@ -1,0 +1,45 @@
+import { deleteHeader, getHeader, hasHeader, setHeader } from './utils';
+
+describe('interpreter · http · utils', () => {
+  describe('getHeader', () => {
+    it('returns all values', () => {
+      expect(getHeader({ foo: 'bar', Foo: 'baz', FOO: ['qux', 'quz'] }, 'foo')).toEqual('bar, baz, qux, quz');
+    });
+
+    it('cleans up undefined values', () => {
+      expect(getHeader({ foo: 'bar', Foo: undefined, FOO: ['qux', 'quz'] }, 'foo')).toEqual('bar, qux, quz');
+    });
+  });
+
+  describe('hasHeader', () => {
+    it('should return true if header is present', () => {
+      expect(hasHeader({ 'Foo': 'bar' }, 'foo')).toBe(true);
+    });
+
+    it('should return false if header is not present', () => {
+      expect(hasHeader({ 'Foo': 'bar' }, 'baz')).toBe(false);
+    });
+  })
+
+  describe('setHeader', () => {
+    it('mutates passed data', () => {
+      const headers = {};
+      setHeader(headers, 'foo', 'bar');
+      expect(headers).toEqual({ foo: 'bar' });
+    });
+
+    it('does not mutate passed data if header already exists', () => {
+      const headers = { foo: 'bar' };
+      setHeader(headers, 'foo', 'baz');
+      expect(headers).toEqual({ foo: 'bar' });
+    });
+  });
+
+  describe('deleteHeader', () => {
+    it('deletes both foo and Foo headers', () => {
+      const headers = { foo: 'bar', Foo: 'baz' };
+      deleteHeader(headers, 'Foo');
+      expect(headers).toEqual({});
+    });
+  })
+});

--- a/src/core/interpreter/http/utils.ts
+++ b/src/core/interpreter/http/utils.ts
@@ -141,8 +141,47 @@ export async function fetchRequest(
   };
 }
 
-export function hasAcceptHeader(headers: NonPrimitive): boolean {
+/**
+ * Get header value. For duplicate headers all delimited by `,` are returned
+ */
+export function getHeader(headers: NonPrimitive, headerName: string): string {
+  const values = Object.entries(headers).flatMap(([key, value]) => {
+    if (key.toLowerCase() === headerName.toLowerCase()) {
+      return value;
+    }
+
+    return undefined;
+  }).filter(value => value !== undefined);
+
+  return values.join(', ');
+}
+
+/**
+ * Checks in case-insensitive way if the given header is present
+ */
+export function hasHeader(headers: NonPrimitive, headerName: string): boolean {
   return Object.keys(headers).some(
-    header => header.toLowerCase() === 'accept'
+    header => header.toLowerCase() === headerName.toLowerCase()
   );
+}
+
+export function setHeader(
+  headers: NonPrimitive,
+  headerName: string,
+  value: string
+): void {
+  if (!hasHeader(headers, headerName)) {
+    headers[headerName] = value;
+  }
+}
+
+/**
+ * Deletes header
+ */
+export function deleteHeader(headers: NonPrimitive, headerName: string): void {
+  Object.keys(headers).forEach(header => {
+    if (header.toLowerCase() === headerName.toLowerCase()) {
+      delete headers[header];
+    }
+  });
 }


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->

Added set of helper functions to work with headers in interpreter.

Best would be to switch to [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers) which isn't available for not until 18.0.0. But I wanted to avoid bigger refactoring and implementing own Headers class.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In #290 was fixed how accept header is set. This extends it to entire  `headersFilter`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [x] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
