### PR TITLE
fix(interpreter): `/` url will not error as absolute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `multipart/form-data` supports array values to define duplicate fields
 
+### Fixed
+- An http call to `/` url returning an error about it being an absolute url
+
 ## [2.0.0] - 2022-08-15
 ### Added
 - Pass `cache` flag to SuperfaceClient constructor

--- a/src/core/interpreter/http/utils.test.ts
+++ b/src/core/interpreter/http/utils.test.ts
@@ -1,4 +1,4 @@
-import { deleteHeader, getHeader, hasHeader, setHeader } from './utils';
+import { createUrl, deleteHeader, getHeader, hasHeader, setHeader } from './utils';
 
 describe('interpreter · http · utils', () => {
   describe('getHeader', () => {
@@ -42,4 +42,27 @@ describe('interpreter · http · utils', () => {
       expect(headers).toEqual({});
     });
   })
+
+  describe('createUrl', () => {
+    it('correctly creates url for empty string', () => {
+      const mapUrl = '';
+      expect(
+        createUrl(mapUrl, { baseUrl: 'http://example.com' })
+      ).toBe('http://example.com')
+    });
+
+    it('correctly creates url for single slash', () => {
+      const mapUrl = '/';
+      expect(
+        createUrl(mapUrl, { baseUrl: 'http://example.com' })
+      ).toBe('http://example.com/')
+    });
+
+    it('returns an error for absolute url', () => {
+      const mapUrl = 'something';
+      expect(
+        () => createUrl(mapUrl, { baseUrl: 'http://example.com' })
+      ).toThrow('Expected relative url')
+    });
+  });
 });

--- a/src/core/interpreter/http/utils.ts
+++ b/src/core/interpreter/http/utils.ts
@@ -72,7 +72,7 @@ export const createUrl = (
   if (inputUrl === '') {
     return baseUrl;
   }
-  const isRelative = /^\/[^/]/.test(inputUrl);
+  const isRelative = /^\/([^/]|$)/.test(inputUrl);
   if (!isRelative) {
     throw new UnexpectedError('Expected relative url, but received absolute!');
   }


### PR DESCRIPTION
## Description
The following map was returning an error about the url not being relative, even though it is considered relative to the base url and should work.
```
http GET '/' {}
```

## Motivation and Context
Bug reported through Slack

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
