### PR TITLE
Allow setting binary data metadata

### DIFF
--- a/src/core/interpreter/sandbox/stdlib.ts
+++ b/src/core/interpreter/sandbox/stdlib.ts
@@ -16,7 +16,7 @@ const STDLIB_UNSTABLE = (debugLog?: LogFunction) => ({
     log(formatter: string, ...args: unknown[]): void {
       return debugLog?.(formatter, ...args);
     },
-  },
+  }
 });
 
 const STDLIB = (debugLog?: LogFunction) =>

--- a/src/node/filesystem/binary.node.test.ts
+++ b/src/node/filesystem/binary.node.test.ts
@@ -166,7 +166,7 @@ describe('Node Binary', () => {
     let fileContainer: FileContainer;
 
     beforeEach(async () => {
-      fileContainer = new FileContainer(fixturePath, { filename: 'testfile.txt', mimetype: 'text/plain' });
+      fileContainer = new FileContainer(fixturePath);
       await fileContainer.initialize();
     });
 
@@ -183,9 +183,12 @@ describe('Node Binary', () => {
       await expect(fileContainer.initialize()).rejects.toThrow(NotFoundError);
     });
 
-    it('sets name from file if not passed as option', () => {
-      const fileContainer = new FileContainer(fixturePath);
+    it('sets name as basename of path', () => {
       expect(fileContainer.name).toBe('binary.txt');
+    });
+
+    it('sets size', () => {
+      expect(fileContainer.size).toBe(955);
     });
 
     it('closes handle and resets data container', async () => {
@@ -228,6 +231,17 @@ describe('Node Binary', () => {
         expect(binaryData).toBeInstanceOf(BinaryData);
       });
 
+      it('sets meta from options', () => {
+        binaryData = BinaryData.fromPath(fixturePath, { name: 'filename.txt', mimetype: 'text/plain' });
+        expect(binaryData.name).toBe('filename.txt');
+        expect(binaryData.mimetype).toBe('text/plain');
+      });
+
+      it('uses name from file container if not passed as option', () => {
+        binaryData = BinaryData.fromPath(fixturePath);
+        expect(binaryData.name).toBe('binary.txt');
+      })
+
       it('throws an error if trying to read a file that is not initialized', async () => {
         binaryData = BinaryData.fromPath(fixturePath);
         await expect(binaryData.read(10)).rejects.toBeInstanceOf(UnexpectedError);
@@ -238,6 +252,22 @@ describe('Node Binary', () => {
       it('returns BinaryData instance', () => {
         binaryData = BinaryData.fromStream(new MockStream());
         expect(binaryData).toBeInstanceOf(BinaryData);
+      });
+    });
+
+    describe('setting metadata', () => {
+      beforeEach(() => {
+        binaryData = BinaryData.fromStream(new MockStream());
+      });
+
+      it('allows to set name', () => {
+        binaryData.name = 'test.txt';
+        expect(binaryData.name).toBe('test.txt');
+      });
+
+      it('allows to set mimetype', () => {
+        binaryData.mimetype = 'text/plain';
+        expect(binaryData.mimetype).toBe('text/plain');
       });
     });
 

--- a/src/node/filesystem/index.ts
+++ b/src/node/filesystem/index.ts
@@ -1,2 +1,3 @@
 export * from './filesystem.node';
 export { BinaryData } from './binary.node';
+export type { BinaryDataOptions } from './binary.node';


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->

- adds `name` and `mimetype` to `fromStream` factory function
- adds setters on `BinaryData` for `name` and `mimetype`

### Example use in map

```
map Example {
  // need to do comlink variable assign to be able to use Script expression
  tmp = (input.file.name = input.filename)
  tmp = (input.file.mimetype = input.mimetype)
  
  http POST "/" {
    request "multipart/form-data" {
      body = {
        file: input.file
      }
    }
  
    response 200 {
      map result body
    }
  }
}
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Comlink author may need to set mimetype or name from within the map.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [x] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
