### PR TITLE
Nulls where not expected by types

### DIFF
--- a/src/core/interpreter/map-interpreter.test.ts
+++ b/src/core/interpreter/map-interpreter.test.ts
@@ -1873,7 +1873,7 @@ describe('MapInterpreter', () => {
     expect(result.unwrap()).toStrictEqual(12);
   });
 
-  it('should return ArrayBuffer when for binary response', async () => {
+  it('should return ArrayBuffer for binary response', async () => {
     const url = '/twelve';
     const filePath = path.resolve(process.cwd(), 'fixtures', 'binary.txt');
     await mockServer.forGet(url).thenFromFile(200, filePath, { 'content-type': 'application/octet-stream' });
@@ -1900,5 +1900,48 @@ describe('MapInterpreter', () => {
     expect(result.unwrap() instanceof ArrayBuffer).toBe(true);
     expect(Buffer.from(result.unwrap() as ArrayBuffer).toString('utf8')).toBe(expected);
   });
+
+  it('should handle null when resolving variables', async () => {
+    const interpreter = new MapInterpreter(
+      {
+        usecase: 'Test',
+        security: [],
+        services: mockServicesSelector,
+        input: {}
+      },
+      { fetchInstance, config, crypto }
+    );
+    const ast = parseMapFromSource(`
+      map Test {
+        map result {
+          field = null
+        }
+      }`);
+    const result = await interpreter.perform(ast);
+
+    expect(result.unwrap()).toEqual({ field: null });
+  });
+
+  it('should handle null in input value', async () => {
+    const interpreter = new MapInterpreter(
+      {
+        usecase: 'Test',
+        security: [],
+        services: mockServicesSelector,
+        input: {
+          field: null
+        } as any
+      },
+      { fetchInstance, config, crypto }
+    );
+    const ast = parseMapFromSource(`
+      map Test {
+        map result {
+          field = input.field
+        }
+      }`);
+    const result = await interpreter.perform(ast);
+
+    expect(result.unwrap()).toEqual({ field: null });
+  });
 });
-  

--- a/src/core/interpreter/map-interpreter.ts
+++ b/src/core/interpreter/map-interpreter.ts
@@ -598,7 +598,7 @@ export class MapInterpreter<TInput extends NonPrimitive | undefined>
               this.stackTop('operation').error = outcome.result;
             }
           } else {
-            this.stackTop().result = outcome?.result ?? this.stackTop().result;
+            this.stackTop().result = outcome?.result === undefined ? this.stackTop().result : outcome.result;
           }
           this.log?.('Setting result: %O', this.stackTop());
 

--- a/src/core/interpreter/map-interpreter.ts
+++ b/src/core/interpreter/map-interpreter.ts
@@ -32,11 +32,13 @@ import type {
   ICrypto,
   ILogger,
   LogFunction,
-  MapInterpreterError} from '../../interfaces';
+  MapInterpreterError
+} from '../../interfaces';
 import {
   isBinaryData,
   isDestructible,
-  isInitializable} from '../../interfaces';
+  isInitializable
+} from '../../interfaces';
 import type { NonPrimitive, Primitive, Result, Variables } from '../../lib';
 import {
   castToVariables,
@@ -139,8 +141,7 @@ type IterationDefinition = {
 };
 
 export class MapInterpreter<TInput extends NonPrimitive | undefined>
-  implements MapAstVisitor
-{
+  implements MapAstVisitor {
   private operations: Record<string, OperationDefinitionNode | undefined> = {};
   private stack: Stack[] = [];
   private ast?: MapDocumentNode;
@@ -222,15 +223,15 @@ export class MapInterpreter<TInput extends NonPrimitive | undefined>
     node: MapASTNode
   ):
     | Promise<
-        | undefined
-        | Variables
-        | Primitive
-        | void
-        | HttpRequest
-        | OutcomeDefinition
-        | { result?: Variables; error?: MapInterpreterError }
-        | IterationDefinition
-      >
+      | undefined
+      | Variables
+      | Primitive
+      | void
+      | HttpRequest
+      | OutcomeDefinition
+      | { result?: Variables; error?: MapInterpreterError }
+      | IterationDefinition
+    >
     | Primitive
     | Variables
     | HttpResponseHandlerDefinition
@@ -775,18 +776,18 @@ export class MapInterpreter<TInput extends NonPrimitive | undefined>
     const stack =
       type === 'map'
         ? {
-            type,
-            variables: {},
-            result: undefined,
-            terminate: false,
-            context: [],
-          }
+          type,
+          variables: {},
+          result: undefined,
+          terminate: false,
+          context: [],
+        }
         : {
-            type,
-            variables: {},
-            result: undefined,
-            terminate: false,
-          };
+          type,
+          variables: {},
+          result: undefined,
+          terminate: false,
+        };
     this.stack.push(stack);
     this.log?.('New stack: %O', this.stackTop());
   }
@@ -875,7 +876,7 @@ export class MapInterpreter<TInput extends NonPrimitive | undefined>
     for (const value of Object.values(input)) {
       if (isInitializable(value)) {
         await value.initialize();
-      } else if (value !== undefined && isNonPrimitive(value)) {
+      } else if (value !== undefined && value !== null && isNonPrimitive(value)) {
         await this.initializeInput(value);
       }
     }
@@ -885,7 +886,7 @@ export class MapInterpreter<TInput extends NonPrimitive | undefined>
     for (const value of Object.values(input)) {
       if (isDestructible(value)) {
         await value.destroy();
-      } else if (value !== undefined && isNonPrimitive(value)) {
+      } else if (value !== undefined && value !== null && isNonPrimitive(value)) {
         await this.destroyInput(value);
       }
     }
@@ -894,11 +895,11 @@ export class MapInterpreter<TInput extends NonPrimitive | undefined>
   private async resolveVariables(
     input: Variables | undefined
   ): Promise<Variables | undefined> {
-    if (isBinaryData(input)) {      
+    if (isBinaryData(input)) {
       throw new UnexpectedError('BinaryData cannot be used as outcome');
     }
 
-    if (input === undefined || isPrimitive(input)) {
+    if (input === undefined || input === null || isPrimitive(input)) {
       return input;
     }
 


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->

This PR contains a fix to handling input value being `null` as well, one of the values in mapped outcome is `null`.

Types should be fixed after #295 

Station tests are passing now:
<img width="346" alt="image" src="https://user-images.githubusercontent.com/959390/208708878-56c6b098-280c-4ad5-809d-75fc65530a63.png">


Examples:
- [null in result](https://github.com/superfaceai/station/blob/main/grid/crm/contacts/maps/sendgrid.suma#L28)
- [null passed as input](https://github.com/superfaceai/station/blob/main/grid/social-media/posts/maps/linkedin.test.ts#L38)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [x] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
