### PR TITLE
Shared: Introduce `None`  type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## Changed
+- Handle `None` (js `null` and `undefined`) - [#314](https://github.com/superfaceai/one-sdk-js/pull/314)
+- [Required field](https://superface.ai/docs/comlink/profile#sec-Required-field) validation uses `Object.hasOwn` to check field presence - [#318](https://github.com/superfaceai/one-sdk-js/pull/318)
+- Header and query parameters must be `string` or `string[]` - [#324](https://github.com/superfaceai/one-sdk-js/pull/324)
+- If profile doesn't have input defined, input isn't added to interpreter stack (input can't be access from Comlink Map) - [#323](https://github.com/superfaceai/one-sdk-js/pull/323)
+
 ### Fixed
-- Trailing comments in comlink script expressions broke sandbox evaluation
+- Trailing comments in comlink script expressions broke sandbox evaluation - [#327](https://github.com/superfaceai/one-sdk-js/pull/327)
 
 ## [2.2.0] - 2023-01-02
 ### Added

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "watch": "yarn build --watch"
   },
   "devDependencies": {
-    "@superfaceai/parser": "^1.2.0",
+    "@superfaceai/parser": "^2.1.0",
     "@types/debug": "^4.1.7",
     "@types/jest": "^27.0.1",
     "@types/node": "^18.11.18",
@@ -72,7 +72,7 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@superfaceai/ast": "1.2.0",
+    "@superfaceai/ast": "1.3.0",
     "abort-controller": "^3.0.0",
     "debug": "^4.3.2",
     "form-data": "^4.0.0",

--- a/src/core/errors/errors.helpers.ts
+++ b/src/core/errors/errors.helpers.ts
@@ -351,26 +351,26 @@ export function invalidBackoffEntryError(kind: string): SDKExecutionError {
   );
 }
 
-export function missingPathReplacementError(
-  missing: string[],
+export function invalidPathReplacementError(
+  invalid: string[],
   url: string,
   all: string[],
   available: string[]
 ): SDKExecutionError {
   return new SDKExecutionError(
-    `Missing values for URL path replacement: ${missing.join(', ')}`,
+    `Missing or mistyped values for URL path replacement: ${invalid.join(', ')}`,
     [
       `Trying to replace path keys for url: ${url}`,
       all.length > 0
         ? `Found these path keys: ${all.join(', ')}`
         : 'Found no path keys',
       available.length > 0
-        ? `But only found these potential variables: ${available.join(', ')}`
-        : 'But found no potential variables',
+        ? `But only found these string variables: ${available.join(', ')}`
+        : 'But found no string variables',
     ],
     [
-      'Make sure the url path variable refers to an available variable',
-      'Consider introducing a new variable with the correct name and desired value',
+      'Make sure the url path variable refers to an available string variable',
+      'Consider introducing a new variable with the correct name and desired string value',
     ]
   );
 }
@@ -485,6 +485,22 @@ export function profileIdsDoNotMatchError(
     ],
     ['Pass profile id that matches to profile id in map or provide correct map']
   );
+}
+
+export function invalidHTTPMapValueType(
+  kind: 'header' | 'query parameter',
+  key: string,
+  type: string
+): SDKExecutionError {
+  return new SDKExecutionError(
+    `Invalid HTTP ${kind} value type: ${key}`,
+    [
+      `Value is of type ${type} but string was expected`
+    ],
+    [
+      'Stringify value before passing it to the HTTP request'
+    ]
+  )
 }
 
 export function digestHeaderNotFound(

--- a/src/core/errors/errors.helpers.ts
+++ b/src/core/errors/errors.helpers.ts
@@ -365,12 +365,12 @@ export function invalidPathReplacementError(
         ? `Found these path keys: ${all.join(', ')}`
         : 'Found no path keys',
       available.length > 0
-        ? `But only found these string variables: ${available.join(', ')}`
-        : 'But found no string variables',
+        ? `But only found these variables with supported types: ${available.join(', ')}`
+        : 'But found no variables with supported types',
     ],
     [
-      'Make sure the url path variable refers to an available string variable',
-      'Consider introducing a new variable with the correct name and desired string value',
+      'Make sure the url path variable refers to an available string, number or boolean variable',
+      'Consider introducing a new variable with the correct name and desired value',
     ]
   );
 }

--- a/src/core/errors/errors.helpers.ts
+++ b/src/core/errors/errors.helpers.ts
@@ -358,14 +358,18 @@ export function invalidPathReplacementError(
   available: string[]
 ): SDKExecutionError {
   return new SDKExecutionError(
-    `Missing or mistyped values for URL path replacement: ${invalid.join(', ')}`,
+    `Missing or mistyped values for URL path replacement: ${invalid.join(
+      ', '
+    )}`,
     [
       `Trying to replace path keys for url: ${url}`,
       all.length > 0
         ? `Found these path keys: ${all.join(', ')}`
         : 'Found no path keys',
       available.length > 0
-        ? `But only found these variables with supported types: ${available.join(', ')}`
+        ? `But only found these variables with supported types: ${available.join(
+            ', '
+          )}`
         : 'But found no variables with supported types',
     ],
     [
@@ -494,13 +498,9 @@ export function invalidHTTPMapValueType(
 ): SDKExecutionError {
   return new SDKExecutionError(
     `Invalid HTTP ${kind} value type: ${key}`,
-    [
-      `Value is of type ${type} but string was expected`
-    ],
-    [
-      'Stringify value before passing it to the HTTP request'
-    ]
-  )
+    [`Value is of type ${type} but string was expected`],
+    ['Stringify value before passing it to the HTTP request']
+  );
 }
 
 export function digestHeaderNotFound(

--- a/src/core/interpreter/http/filters.ts
+++ b/src/core/interpreter/http/filters.ts
@@ -229,7 +229,7 @@ export const queryParametersFilter: Filter = ({
 }: FilterInputOutput) => {
   const queryParameters = {
     ...request?.queryParameters,
-    ...variablesToStrings(parameters.queryParameters ?? {}),
+    ...(parameters.queryParameters ?? {})
   };
 
   return {
@@ -264,7 +264,7 @@ export const headersFilter: Filter = ({
   request,
   response,
 }: FilterInputOutput) => {
-  const headers: Record<string, string> = parameters.headers ?? {};
+  const headers: Record<string, string | string[]> = parameters.headers ?? {};
 
   setHeader(headers, 'user-agent', USER_AGENT);
   setHeader(headers, 'accept', parameters.accept ?? '*/*');
@@ -360,7 +360,7 @@ export function isCompleteHttpRequest(
 
     if (
       !Object.values(input.queryParameters).every(
-        value => typeof value === 'string'
+        value => typeof value === 'string' || Array.isArray(value)
       )
     ) {
       return false;

--- a/src/core/interpreter/http/filters.ts
+++ b/src/core/interpreter/http/filters.ts
@@ -105,31 +105,31 @@ export const fetchFilter: (
   logger?: ILogger
 ) => FilterWithRequest =
   (fetchInstance, logger) =>
-  async ({ parameters, request }: FilterInputWithRequest) => {
-    return {
-      parameters,
-      request,
-      response: await fetchRequest(fetchInstance, request, logger),
+    async ({ parameters, request }: FilterInputWithRequest) => {
+      return {
+        parameters,
+        request,
+        response: await fetchRequest(fetchInstance, request, logger),
+      };
     };
-  };
 
 export const authenticateFilter: (handler?: ISecurityHandler) => Filter =
   handler =>
-  async ({ parameters, request, response }: FilterInputOutput) => {
-    if (handler !== undefined) {
+    async ({ parameters, request, response }: FilterInputOutput) => {
+      if (handler !== undefined) {
+        return {
+          parameters: await handler.authenticate(parameters),
+          request,
+          response,
+        };
+      }
+
       return {
-        parameters: await handler.authenticate(parameters),
+        parameters,
         request,
         response,
       };
-    }
-
-    return {
-      parameters,
-      request,
-      response,
     };
-  };
 
 // This is handling the cases when we are authenticated but eg. digest credentials expired or OAuth access token is no longer valid
 export const handleResponseFilter: (
@@ -138,18 +138,18 @@ export const handleResponseFilter: (
   handler?: ISecurityHandler
 ) => FilterWithResponse =
   (fetchInstance, logger, handler) =>
-  async ({ parameters, request, response }: FilterInputWithResponse) => {
-    if (handler?.handleResponse !== undefined) {
-      // We get new parameters (with updated auth, also updated cache)
-      const authRequest = await handler.handleResponse(response, parameters);
-      // We retry the request
-      if (authRequest !== undefined) {
-        response = await fetchRequest(fetchInstance, authRequest, logger);
+    async ({ parameters, request, response }: FilterInputWithResponse) => {
+      if (handler?.handleResponse !== undefined) {
+        // We get new parameters (with updated auth, also updated cache)
+        const authRequest = await handler.handleResponse(response, parameters);
+        // We retry the request
+        if (authRequest !== undefined) {
+          response = await fetchRequest(fetchInstance, authRequest, logger);
+        }
       }
-    }
 
-    return { parameters, request, response };
-  };
+      return { parameters, request, response };
+    };
 
 export const urlFilter: Filter = ({
   parameters,
@@ -182,12 +182,9 @@ export const bodyFilter: Filter = ({
     if (parameters.contentType === JSON_CONTENT) {
       finalBody = stringBody(JSON.stringify(parameters.body));
     } else if (parameters.contentType === URLENCODED_CONTENT) {
-      finalBody = urlSearchParamsBody(variablesToStrings(parameters.body));
+      finalBody = urlSearchParamsBody(variablesToStrings(castToNonPrimitive(parameters.body)));
     } else if (parameters.contentType === FORMDATA_CONTENT) {
-      const body = castToNonPrimitive(parameters.body);
-      if (body) {
-        finalBody = formDataBody(body);
-      }
+      finalBody = formDataBody(castToNonPrimitive(parameters.body));
     } else if (
       parameters.contentType !== undefined &&
       BINARY_CONTENT_REGEXP.test(parameters.contentType)
@@ -232,7 +229,7 @@ export const queryParametersFilter: Filter = ({
 }: FilterInputOutput) => {
   const queryParameters = {
     ...request?.queryParameters,
-    ...variablesToStrings(parameters.queryParameters),
+    ...variablesToStrings(parameters.queryParameters ?? {}),
   };
 
   return {

--- a/src/core/interpreter/http/filters.ts
+++ b/src/core/interpreter/http/filters.ts
@@ -105,31 +105,31 @@ export const fetchFilter: (
   logger?: ILogger
 ) => FilterWithRequest =
   (fetchInstance, logger) =>
-    async ({ parameters, request }: FilterInputWithRequest) => {
-      return {
-        parameters,
-        request,
-        response: await fetchRequest(fetchInstance, request, logger),
-      };
+  async ({ parameters, request }: FilterInputWithRequest) => {
+    return {
+      parameters,
+      request,
+      response: await fetchRequest(fetchInstance, request, logger),
     };
+  };
 
 export const authenticateFilter: (handler?: ISecurityHandler) => Filter =
   handler =>
-    async ({ parameters, request, response }: FilterInputOutput) => {
-      if (handler !== undefined) {
-        return {
-          parameters: await handler.authenticate(parameters),
-          request,
-          response,
-        };
-      }
-
+  async ({ parameters, request, response }: FilterInputOutput) => {
+    if (handler !== undefined) {
       return {
-        parameters,
+        parameters: await handler.authenticate(parameters),
         request,
         response,
       };
+    }
+
+    return {
+      parameters,
+      request,
+      response,
     };
+  };
 
 // This is handling the cases when we are authenticated but eg. digest credentials expired or OAuth access token is no longer valid
 export const handleResponseFilter: (
@@ -138,18 +138,18 @@ export const handleResponseFilter: (
   handler?: ISecurityHandler
 ) => FilterWithResponse =
   (fetchInstance, logger, handler) =>
-    async ({ parameters, request, response }: FilterInputWithResponse) => {
-      if (handler?.handleResponse !== undefined) {
-        // We get new parameters (with updated auth, also updated cache)
-        const authRequest = await handler.handleResponse(response, parameters);
-        // We retry the request
-        if (authRequest !== undefined) {
-          response = await fetchRequest(fetchInstance, authRequest, logger);
-        }
+  async ({ parameters, request, response }: FilterInputWithResponse) => {
+    if (handler?.handleResponse !== undefined) {
+      // We get new parameters (with updated auth, also updated cache)
+      const authRequest = await handler.handleResponse(response, parameters);
+      // We retry the request
+      if (authRequest !== undefined) {
+        response = await fetchRequest(fetchInstance, authRequest, logger);
       }
+    }
 
-      return { parameters, request, response };
-    };
+    return { parameters, request, response };
+  };
 
 export const urlFilter: Filter = ({
   parameters,
@@ -182,7 +182,9 @@ export const bodyFilter: Filter = ({
     if (parameters.contentType === JSON_CONTENT) {
       finalBody = stringBody(JSON.stringify(parameters.body));
     } else if (parameters.contentType === URLENCODED_CONTENT) {
-      finalBody = urlSearchParamsBody(variablesToStrings(castToNonPrimitive(parameters.body)));
+      finalBody = urlSearchParamsBody(
+        variablesToStrings(castToNonPrimitive(parameters.body))
+      );
     } else if (parameters.contentType === FORMDATA_CONTENT) {
       finalBody = formDataBody(castToNonPrimitive(parameters.body));
     } else if (
@@ -229,7 +231,7 @@ export const queryParametersFilter: Filter = ({
 }: FilterInputOutput) => {
   const queryParameters = {
     ...request?.queryParameters,
-    ...(parameters.queryParameters ?? {})
+    ...(parameters.queryParameters ?? {}),
   };
 
   return {

--- a/src/core/interpreter/http/filters.ts
+++ b/src/core/interpreter/http/filters.ts
@@ -9,7 +9,7 @@ import {
 } from '../../../lib';
 import { USER_AGENT } from '../../../user-agent';
 import { unsupportedContentType } from '../../errors';
-import type { FetchBody, IFetch } from './interfaces';
+import type { FetchBody, HttpMultiMap, IFetch } from './interfaces';
 import {
   BINARY_CONTENT_REGEXP,
   BINARY_CONTENT_TYPES,
@@ -264,7 +264,7 @@ export const headersFilter: Filter = ({
   request,
   response,
 }: FilterInputOutput) => {
-  const headers: Record<string, string | string[]> = parameters.headers ?? {};
+  const headers: HttpMultiMap = parameters.headers ?? {};
 
   setHeader(headers, 'user-agent', USER_AGENT);
   setHeader(headers, 'accept', parameters.accept ?? '*/*');

--- a/src/core/interpreter/http/http.ts
+++ b/src/core/interpreter/http/http.ts
@@ -39,7 +39,7 @@ export class HttpClient {
     url: string,
     parameters: {
       method: string;
-      headers?: Variables;
+      headers?: NonPrimitive;
       queryParameters?: NonPrimitive;
       body?: Variables;
       contentType?: string;

--- a/src/core/interpreter/http/http.ts
+++ b/src/core/interpreter/http/http.ts
@@ -5,7 +5,10 @@ import type { ICrypto, ILogger } from '../../../interfaces';
 import type { NonPrimitive, Variables } from '../../../lib';
 import { UnexpectedError } from '../../../lib';
 import { pipe } from '../../../lib/pipe/pipe';
-import { invalidHTTPMapValueType, missingSecurityValuesError } from '../../errors';
+import {
+  invalidHTTPMapValueType,
+  missingSecurityValuesError,
+} from '../../errors';
 import {
   authenticateFilter,
   fetchFilter,
@@ -34,7 +37,7 @@ export class HttpClient {
     private fetchInstance: IFetch & AuthCache,
     private readonly crypto: ICrypto,
     private readonly logger?: ILogger
-  ) { }
+  ) {}
 
   public async request(
     url: string,
@@ -55,13 +58,19 @@ export class HttpClient {
     const requestParameters: RequestParameters = {
       url,
       ...parameters,
-      queryParameters: variablesToHttpMap(parameters.queryParameters ?? {}).match(
+      queryParameters: variablesToHttpMap(
+        parameters.queryParameters ?? {}
+      ).match(
         v => v,
-        ([key, value]) => { throw invalidHTTPMapValueType('header', key, typeof value); }
+        ([key, value]) => {
+          throw invalidHTTPMapValueType('header', key, typeof value);
+        }
       ),
       headers: variablesToHttpMap(parameters.headers ?? {}).match(
         v => v,
-        ([key, value]) => { throw invalidHTTPMapValueType('query parameter', key, typeof value); }
+        ([key, value]) => {
+          throw invalidHTTPMapValueType('query parameter', key, typeof value);
+        }
       ),
     };
 

--- a/src/core/interpreter/http/http.ts
+++ b/src/core/interpreter/http/http.ts
@@ -3,9 +3,9 @@ import { HttpScheme, SecurityType } from '@superfaceai/ast';
 
 import type { ICrypto, ILogger } from '../../../interfaces';
 import type { NonPrimitive, Variables } from '../../../lib';
-import { UnexpectedError, variablesToStrings } from '../../../lib';
+import { UnexpectedError } from '../../../lib';
 import { pipe } from '../../../lib/pipe/pipe';
-import { missingSecurityValuesError } from '../../errors';
+import { invalidHTTPMapValueType, missingSecurityValuesError } from '../../errors';
 import {
   authenticateFilter,
   fetchFilter,
@@ -23,6 +23,7 @@ import type {
 } from './security';
 import { ApiKeyHandler, DigestHandler, HttpHandler } from './security';
 import type { HttpResponse } from './types';
+import { variablesToHttpMap } from './utils';
 
 export enum NetworkErrors {
   TIMEOUT_ERROR = 'TIMEOUT_ERROR',
@@ -54,7 +55,14 @@ export class HttpClient {
     const requestParameters: RequestParameters = {
       url,
       ...parameters,
-      headers: variablesToStrings(parameters.headers ?? {}),
+      queryParameters: variablesToHttpMap(parameters.queryParameters ?? {}).match(
+        v => v,
+        ([key, value]) => { throw invalidHTTPMapValueType('header', key, typeof value); }
+      ),
+      headers: variablesToHttpMap(parameters.headers ?? {}).match(
+        v => v,
+        ([key, value]) => { throw invalidHTTPMapValueType('query parameter', key, typeof value); }
+      ),
     };
 
     const handler = createSecurityHandler(

--- a/src/core/interpreter/http/http.ts
+++ b/src/core/interpreter/http/http.ts
@@ -63,13 +63,13 @@ export class HttpClient {
       ).match(
         v => v,
         ([key, value]) => {
-          throw invalidHTTPMapValueType('header', key, typeof value);
+          throw invalidHTTPMapValueType('query parameter', key, typeof value);
         }
       ),
       headers: variablesToHttpMap(parameters.headers ?? {}).match(
         v => v,
         ([key, value]) => {
-          throw invalidHTTPMapValueType('query parameter', key, typeof value);
+          throw invalidHTTPMapValueType('header', key, typeof value);
         }
       ),
     };

--- a/src/core/interpreter/http/http.ts
+++ b/src/core/interpreter/http/http.ts
@@ -33,7 +33,7 @@ export class HttpClient {
     private fetchInstance: IFetch & AuthCache,
     private readonly crypto: ICrypto,
     private readonly logger?: ILogger
-  ) {}
+  ) { }
 
   public async request(
     url: string,
@@ -54,7 +54,7 @@ export class HttpClient {
     const requestParameters: RequestParameters = {
       url,
       ...parameters,
-      headers: variablesToStrings(parameters?.headers),
+      headers: variablesToStrings(parameters.headers ?? {}),
     };
 
     const handler = createSecurityHandler(

--- a/src/core/interpreter/http/interfaces.ts
+++ b/src/core/interpreter/http/interfaces.ts
@@ -55,7 +55,7 @@ export type FetchParameters = {
 export type FetchResponse = {
   status: number;
   statusText: string;
-  headers: Record<string, string>;
+  headers: HttpMultiMap;
   body?: unknown;
 };
 

--- a/src/core/interpreter/http/interfaces.ts
+++ b/src/core/interpreter/http/interfaces.ts
@@ -46,7 +46,7 @@ export type FetchParameters = {
   headers?: Record<string, string | string[]>;
   method: string;
   body?: FetchBody;
-  queryParameters?: Record<string, string>;
+  queryParameters?: Record<string, string | string[]>;
   timeout?: number;
 };
 

--- a/src/core/interpreter/http/interfaces.ts
+++ b/src/core/interpreter/http/interfaces.ts
@@ -42,11 +42,13 @@ export type FetchBody =
   | URLSearchParamsBody
   | BinaryBody;
 
+export type HttpMultiMap = Record<string, string | string[]>;
+
 export type FetchParameters = {
-  headers?: Record<string, string | string[]>;
+  headers?: HttpMultiMap;
   method: string;
   body?: FetchBody;
-  queryParameters?: Record<string, string | string[]>;
+  queryParameters?: HttpMultiMap;
   timeout?: number;
 };
 

--- a/src/core/interpreter/http/security/api-key/api-key.ts
+++ b/src/core/interpreter/http/security/api-key/api-key.ts
@@ -5,8 +5,8 @@ import type {
 import { ApiKeyPlacement } from '@superfaceai/ast';
 
 import type { ILogger, LogFunction } from '../../../../../interfaces';
-import { isBinaryData } from '../../../../../interfaces';
 import type { Variables } from '../../../../../lib';
+import { isPrimitive } from '../../../../../lib';
 import { apiKeyInBodyError } from '../../../../errors';
 import type {
   AuthenticateRequestAsync,
@@ -32,7 +32,7 @@ export class ApiKeyHandler implements ISecurityHandler {
     parameters: RequestParameters
   ) => {
     let body: Variables | undefined = parameters.body;
-    const headers: Record<string, string> = parameters.headers ?? {};
+    const headers: Record<string, string | string[]> = parameters.headers ?? {};
     const pathParameters = parameters.pathParameters ?? {};
     const queryParameters = parameters.queryParameters ?? {};
 
@@ -80,12 +80,7 @@ function applyApiKeyAuthInBody(
   apikey: string,
   visitedReferenceTokens: string[] = []
 ): Variables {
-  if (
-    typeof requestBody !== 'object' ||
-    Array.isArray(requestBody) ||
-    Buffer.isBuffer(requestBody) ||
-    isBinaryData(requestBody)
-  ) {
+  if (isPrimitive(requestBody)) {
     const valueLocation = visitedReferenceTokens.length
       ? `value at /${visitedReferenceTokens.join('/')}`
       : 'body';

--- a/src/core/interpreter/http/security/api-key/api-key.ts
+++ b/src/core/interpreter/http/security/api-key/api-key.ts
@@ -8,6 +8,7 @@ import type { ILogger, LogFunction } from '../../../../../interfaces';
 import type { Variables } from '../../../../../lib';
 import { isPrimitive } from '../../../../../lib';
 import { apiKeyInBodyError } from '../../../../errors';
+import type { HttpMultiMap } from '../../interfaces';
 import type {
   AuthenticateRequestAsync,
   ISecurityHandler,
@@ -32,7 +33,7 @@ export class ApiKeyHandler implements ISecurityHandler {
     parameters: RequestParameters
   ) => {
     let body: Variables | undefined = parameters.body;
-    const headers: Record<string, string | string[]> = parameters.headers ?? {};
+    const headers: HttpMultiMap = parameters.headers ?? {};
     const pathParameters = parameters.pathParameters ?? {};
     const queryParameters = parameters.queryParameters ?? {};
 

--- a/src/core/interpreter/http/security/digest/digest.ts
+++ b/src/core/interpreter/http/security/digest/digest.ts
@@ -96,7 +96,7 @@ export class DigestHandler implements ISecurityHandler {
   public authenticate: AuthenticateRequestAsync = async (
     parameters: RequestParameters
   ) => {
-    const headers: Record<string, string> = parameters.headers || {};
+    const headers: Record<string, string | string[]> = parameters.headers ?? {};
 
     const credentials = await this.fetchInstance.digest.getCached(
       hashDigestConfiguration(this.configuration, this.crypto),

--- a/src/core/interpreter/http/security/digest/digest.ts
+++ b/src/core/interpreter/http/security/digest/digest.ts
@@ -16,7 +16,7 @@ import {
   prepareRequestFilter,
   withRequest,
 } from '../../filters';
-import type { IFetch } from '../../interfaces';
+import type { HttpMultiMap, IFetch } from '../../interfaces';
 import type { HttpResponse } from '../../types';
 import type {
   AuthCache,
@@ -96,7 +96,7 @@ export class DigestHandler implements ISecurityHandler {
   public authenticate: AuthenticateRequestAsync = async (
     parameters: RequestParameters
   ) => {
-    const headers: Record<string, string | string[]> = parameters.headers ?? {};
+    const headers: HttpMultiMap = parameters.headers ?? {};
 
     const credentials = await this.fetchInstance.digest.getCached(
       hashDigestConfiguration(this.configuration, this.crypto),

--- a/src/core/interpreter/http/security/digest/digest.ts
+++ b/src/core/interpreter/http/security/digest/digest.ts
@@ -117,8 +117,14 @@ export class DigestHandler implements ISecurityHandler {
           throw new Error('Response is undefined');
         }
 
-        const challengeHeader = getHeaderMulti(response.headers, this.challengeHeader);
-        if (response.statusCode !== this.statusCode || challengeHeader === undefined) {
+        const challengeHeader = getHeaderMulti(
+          response.headers,
+          this.challengeHeader
+        );
+        if (
+          response.statusCode !== this.statusCode ||
+          challengeHeader === undefined
+        ) {
           throw digestHeaderNotFound(
             this.challengeHeader,
             Object.keys(response.headers)
@@ -152,7 +158,10 @@ export class DigestHandler implements ISecurityHandler {
     resourceRequestParameters: RequestParameters
   ) => {
     if (response.statusCode === this.statusCode) {
-      const challengeHeader = getHeaderMulti(response.headers, this.challengeHeader);
+      const challengeHeader = getHeaderMulti(
+        response.headers,
+        this.challengeHeader
+      );
 
       if (challengeHeader === undefined) {
         throw digestHeaderNotFound(

--- a/src/core/interpreter/http/security/digest/digest.ts
+++ b/src/core/interpreter/http/security/digest/digest.ts
@@ -18,6 +18,7 @@ import {
 } from '../../filters';
 import type { HttpMultiMap, IFetch } from '../../interfaces';
 import type { HttpResponse } from '../../types';
+import { getHeaderMulti } from '../../utils';
 import type {
   AuthCache,
   AuthenticateRequestAsync,
@@ -116,10 +117,8 @@ export class DigestHandler implements ISecurityHandler {
           throw new Error('Response is undefined');
         }
 
-        if (
-          response.statusCode !== this.statusCode ||
-          !response.headers[this.challengeHeader]
-        ) {
+        const challengeHeader = getHeaderMulti(response.headers, this.challengeHeader);
+        if (response.statusCode !== this.statusCode || challengeHeader === undefined) {
           throw digestHeaderNotFound(
             this.challengeHeader,
             Object.keys(response.headers)
@@ -131,7 +130,7 @@ export class DigestHandler implements ISecurityHandler {
           // We need actual resolved url
           response.debug.request.url,
           parameters.method,
-          this.extractDigestValues(response.headers[this.challengeHeader])
+          this.extractDigestValues(challengeHeader)
         );
 
         return credentials;
@@ -153,7 +152,9 @@ export class DigestHandler implements ISecurityHandler {
     resourceRequestParameters: RequestParameters
   ) => {
     if (response.statusCode === this.statusCode) {
-      if (!response.headers[this.challengeHeader]) {
+      const challengeHeader = getHeaderMulti(response.headers, this.challengeHeader);
+
+      if (challengeHeader === undefined) {
         throw digestHeaderNotFound(
           this.challengeHeader,
           Object.keys(response.headers)
@@ -173,7 +174,7 @@ export class DigestHandler implements ISecurityHandler {
             // We need actual resolved url
             response.debug.request.url,
             resourceRequestParameters.method,
-            this.extractDigestValues(response.headers[this.challengeHeader])
+            this.extractDigestValues(challengeHeader)
           );
         }
       );
@@ -273,10 +274,17 @@ export class DigestHandler implements ISecurityHandler {
       .join(',');
   }
 
-  private extractDigestValues(header: string): DigestAuthValues {
+  private extractDigestValues(headerValues: string[]): DigestAuthValues {
     this.logSensitive?.(
-      `Extracting digest authentication values from: ${header}`
+      `Extracting digest authentication values from: ${headerValues.join(', ')}`
     );
+
+    if (headerValues.length != 1) {
+      // TODO: the RFC does seem to allow multiple challenges:
+      // https://www.rfc-editor.org/rfc/rfc2617#section-1.2
+      // here we just pick the first one
+    }
+    const header = headerValues[0];
 
     const scheme = header.split(/\s/)[0];
     if (!scheme) {

--- a/src/core/interpreter/http/security/http/http.ts
+++ b/src/core/interpreter/http/security/http/http.ts
@@ -2,6 +2,7 @@ import type { SecurityType } from '@superfaceai/ast';
 import { HttpScheme } from '@superfaceai/ast';
 
 import type { ILogger, LogFunction } from '../../../../../interfaces';
+import type { HttpMultiMap } from '../../interfaces';
 import type {
   AuthenticateRequestAsync,
   ISecurityHandler,
@@ -27,7 +28,7 @@ export class HttpHandler implements ISecurityHandler {
   public authenticate: AuthenticateRequestAsync = async (
     parameters: RequestParameters
   ) => {
-    const headers: Record<string, string | string[]> = parameters.headers ?? {};
+    const headers: HttpMultiMap = parameters.headers ?? {};
 
     switch (this.configuration.scheme) {
       case HttpScheme.BASIC:

--- a/src/core/interpreter/http/security/http/http.ts
+++ b/src/core/interpreter/http/security/http/http.ts
@@ -27,7 +27,7 @@ export class HttpHandler implements ISecurityHandler {
   public authenticate: AuthenticateRequestAsync = async (
     parameters: RequestParameters
   ) => {
-    const headers: Record<string, string> = parameters.headers || {};
+    const headers: Record<string, string | string[]> = parameters.headers ?? {};
 
     switch (this.configuration.scheme) {
       case HttpScheme.BASIC:

--- a/src/core/interpreter/http/security/interfaces.ts
+++ b/src/core/interpreter/http/security/interfaces.ts
@@ -59,8 +59,8 @@ export type SecurityConfiguration =
 export type RequestParameters = {
   url: string;
   method: string;
-  headers?: Record<string, string>;
-  queryParameters?: NonPrimitive;
+  headers?: Record<string, string | string[]>;
+  queryParameters?: Record<string, string | string[]>;
   body?: Variables;
   contentType?: string;
   accept?: string;

--- a/src/core/interpreter/http/security/interfaces.ts
+++ b/src/core/interpreter/http/security/interfaces.ts
@@ -11,7 +11,7 @@ import type {
 } from '@superfaceai/ast';
 
 import type { NonPrimitive, SuperCache, Variables } from '../../../../lib';
-import type { FetchParameters } from '../interfaces';
+import type { FetchParameters, HttpMultiMap } from '../interfaces';
 import type { HttpResponse } from '../types';
 
 export const DEFAULT_AUTHORIZATION_HEADER_NAME = 'Authorization';
@@ -59,8 +59,8 @@ export type SecurityConfiguration =
 export type RequestParameters = {
   url: string;
   method: string;
-  headers?: Record<string, string | string[]>;
-  queryParameters?: Record<string, string | string[]>;
+  headers?: HttpMultiMap;
+  queryParameters?: HttpMultiMap;
   body?: Variables;
   contentType?: string;
   accept?: string;

--- a/src/core/interpreter/http/types.ts
+++ b/src/core/interpreter/http/types.ts
@@ -1,10 +1,12 @@
+import type { HttpMultiMap } from './interfaces';
+
 export interface HttpResponse {
   statusCode: number;
   body: unknown;
-  headers: Record<string, string>;
+  headers: HttpMultiMap;
   debug: {
     request: {
-      headers: Record<string, string>;
+      headers: HttpMultiMap;
       url: string;
       body: unknown;
     };

--- a/src/core/interpreter/http/utils.test.ts
+++ b/src/core/interpreter/http/utils.test.ts
@@ -74,5 +74,37 @@ describe('interpreter · http · utils', () => {
         createUrl(mapUrl, { baseUrl: 'http://example.com' })
       ).toThrow('Expected relative url');
     });
+
+    it('replaces integration parameters in baseURL', () => {
+      expect(
+        createUrl('/baz', {
+          baseUrl: 'http://example.com/{FOO}/{BAR}',
+          integrationParameters: {
+            FOO: 'foo', BAR: 'bar'
+          }
+        })
+      ).toBe('http://example.com/foo/bar/baz');
+    });
+
+    it('replaces path parameters in inputUrl', () => {
+      expect(
+        createUrl('/{FOO}/{BAR.BAZ}', {
+          baseUrl: 'http://example.com',
+          pathParameters: {
+            FOO: 'foo', BAR: { BAZ: 'baz' }
+          }
+        })
+      ).toBe('http://example.com/foo/baz');
+    });
+
+    it('throws missing key error if path parameter for inputUrl is missing', () => {
+      expect(
+        () => createUrl(
+          '/{FOO}/{BAR}',
+          {
+            baseUrl: 'http://example.com',
+            pathParameters: { FOO: 'foo' }
+          })).toThrow('Missing values for URL path replacement: BAR')
+    });
   });
 });

--- a/src/core/interpreter/http/utils.test.ts
+++ b/src/core/interpreter/http/utils.test.ts
@@ -104,7 +104,19 @@ describe('interpreter · http · utils', () => {
           {
             baseUrl: 'http://example.com',
             pathParameters: { FOO: 'foo' }
-          })).toThrow('Missing values for URL path replacement: BAR')
+          })
+      ).toThrow('Missing or mistyped values for URL path replacement: BAR')
+    });
+
+    it('throws mistyped key error if path parameter for inputUrl is not string', () => {
+      expect(
+        () => createUrl(
+          '/{FOO}/{BAR}',
+          {
+            baseUrl: 'http://example.com',
+            pathParameters: { FOO: 'foo', BAR: [1, 2, 3] }
+          })
+      ).toThrow('Missing or mistyped values for URL path replacement: BAR')
     });
   });
 });

--- a/src/core/interpreter/http/utils.test.ts
+++ b/src/core/interpreter/http/utils.test.ts
@@ -1,3 +1,6 @@
+import { err, ok } from '../../../lib';
+import { getHeaderMulti, variablesToHttpMap } from '..';
+import type { HttpMultiMap } from './interfaces';
 import {
   createUrl,
   deleteHeader,
@@ -117,6 +120,36 @@ describe('interpreter · http · utils', () => {
             pathParameters: { FOO: 'foo', BAR: [1, 2, 3] }
           })
       ).toThrow('Missing or mistyped values for URL path replacement: BAR')
+    });
+  });
+
+  describe('variablesToHttpMap', () => {
+    it.each([
+      [{}, ok({})],
+      [{ foo: 'string', bar: ['s1', 's2'] }, ok({ foo: 'string', bar: ['s1', 's2'] })],
+      [{ foo: undefined, bar: ['s1', null, undefined, 's2'], baz: null }, ok({ bar: ['s1', 's2'] })],
+      [{ foo: 1, bar: [true, false] }, ok({ foo: '1', bar: ['true', 'false'] })],
+      [{ foo: Buffer.from([]) }, err(['foo', Buffer.from([])])],
+      [{ foo: ['s1', {}] }, err(['foo', {}])],
+      [{ foo: ['s1', []] }, err(['foo', []])],
+    ])('correctly handles "%s"', (value, expected) => {
+      const result = variablesToHttpMap(value);
+      expect(result).toStrictEqual(expected);
+    });
+  });
+
+  describe('getHeaderMulti', () => {
+    const map: HttpMultiMap = {
+      foo: 'string',
+      bar: ['a', 'b']
+    };
+    
+    it.each([
+      ['none', undefined],
+      ['foo', ['string']],
+      ['bar', ['a', 'b']]
+    ])('correctly handles "%s"', (key, expected) => {
+      expect(getHeaderMulti(map, key)).toStrictEqual(expected);
     });
   });
 });

--- a/src/core/interpreter/http/utils.test.ts
+++ b/src/core/interpreter/http/utils.test.ts
@@ -83,8 +83,9 @@ describe('interpreter · http · utils', () => {
         createUrl('/baz', {
           baseUrl: 'http://example.com/{FOO}/{BAR}',
           integrationParameters: {
-            FOO: 'foo', BAR: 'bar'
-          }
+            FOO: 'foo',
+            BAR: 'bar',
+          },
         })
       ).toBe('http://example.com/foo/bar/baz');
     });
@@ -94,41 +95,47 @@ describe('interpreter · http · utils', () => {
         createUrl('/{FOO}/{BAR.BAZ}', {
           baseUrl: 'http://example.com',
           pathParameters: {
-            FOO: 'foo', BAR: { BAZ: 'baz' }
-          }
+            FOO: 'foo',
+            BAR: { BAZ: 'baz' },
+          },
         })
       ).toBe('http://example.com/foo/baz');
     });
 
     it('throws missing key error if path parameter for inputUrl is missing', () => {
-      expect(
-        () => createUrl(
-          '/{FOO}/{BAR}',
-          {
-            baseUrl: 'http://example.com',
-            pathParameters: { FOO: 'foo' }
-          })
-      ).toThrow('Missing or mistyped values for URL path replacement: BAR')
+      expect(() =>
+        createUrl('/{FOO}/{BAR}', {
+          baseUrl: 'http://example.com',
+          pathParameters: { FOO: 'foo' },
+        })
+      ).toThrow('Missing or mistyped values for URL path replacement: BAR');
     });
 
     it('throws mistyped key error if path parameter for inputUrl is not string', () => {
-      expect(
-        () => createUrl(
-          '/{FOO}/{BAR}',
-          {
-            baseUrl: 'http://example.com',
-            pathParameters: { FOO: 'foo', BAR: [1, 2, 3] }
-          })
-      ).toThrow('Missing or mistyped values for URL path replacement: BAR')
+      expect(() =>
+        createUrl('/{FOO}/{BAR}', {
+          baseUrl: 'http://example.com',
+          pathParameters: { FOO: 'foo', BAR: [1, 2, 3] },
+        })
+      ).toThrow('Missing or mistyped values for URL path replacement: BAR');
     });
   });
 
   describe('variablesToHttpMap', () => {
     it.each([
       [{}, ok({})],
-      [{ foo: 'string', bar: ['s1', 's2'] }, ok({ foo: 'string', bar: ['s1', 's2'] })],
-      [{ foo: undefined, bar: ['s1', null, undefined, 's2'], baz: null }, ok({ bar: ['s1', 's2'] })],
-      [{ foo: 1, bar: [true, false] }, ok({ foo: '1', bar: ['true', 'false'] })],
+      [
+        { foo: 'string', bar: ['s1', 's2'] },
+        ok({ foo: 'string', bar: ['s1', 's2'] }),
+      ],
+      [
+        { foo: undefined, bar: ['s1', null, undefined, 's2'], baz: null },
+        ok({ bar: ['s1', 's2'] }),
+      ],
+      [
+        { foo: 1, bar: [true, false] },
+        ok({ foo: '1', bar: ['true', 'false'] }),
+      ],
       [{ foo: Buffer.from([]) }, err(['foo', Buffer.from([])])],
       [{ foo: ['s1', {}] }, err(['foo', {}])],
       [{ foo: ['s1', []] }, err(['foo', []])],
@@ -141,13 +148,13 @@ describe('interpreter · http · utils', () => {
   describe('getHeaderMulti', () => {
     const map: HttpMultiMap = {
       foo: 'string',
-      bar: ['a', 'b']
+      bar: ['a', 'b'],
     };
-    
+
     it.each([
       ['none', undefined],
       ['foo', ['string']],
-      ['bar', ['a', 'b']]
+      ['bar', ['a', 'b']],
     ])('correctly handles "%s"', (key, expected) => {
       expect(getHeaderMulti(map, key)).toStrictEqual(expected);
     });

--- a/src/core/interpreter/http/utils.ts
+++ b/src/core/interpreter/http/utils.ts
@@ -1,8 +1,5 @@
 import type { ILogger, LogFunction } from '../../../interfaces';
-import type {
-  NonPrimitive,
-  Result
-} from '../../../lib';
+import type { NonPrimitive, Result } from '../../../lib';
 import {
   err,
   indexRecord,
@@ -31,7 +28,9 @@ function tryToHttpString(variable: unknown): string | undefined {
   return undefined;
 }
 
-export function variablesToHttpMap(variables: NonPrimitive): Result<HttpMultiMap, [key: string, value: unknown]> {
+export function variablesToHttpMap(
+  variables: NonPrimitive
+): Result<HttpMultiMap, [key: string, value: unknown]> {
   const result: HttpMultiMap = {};
 
   for (const [key, value] of Object.entries(variables)) {
@@ -95,9 +94,7 @@ function replaceParameters(url: string, parameters: NonPrimitive) {
 
     let value: string | undefined;
     try {
-      value = tryToHttpString(
-        indexRecord(parameters, key.split('.'))
-      );
+      value = tryToHttpString(indexRecord(parameters, key.split('.')));
     } catch (_e) {
       value = undefined;
     }
@@ -115,7 +112,10 @@ function replaceParameters(url: string, parameters: NonPrimitive) {
   result += url.slice(lastIndex);
 
   if (invalidKeys.length > 0) {
-    const available = recursiveKeyList(parameters ?? {}, value => tryToHttpString(value) !== undefined);
+    const available = recursiveKeyList(
+      parameters ?? {},
+      value => tryToHttpString(value) !== undefined
+    );
 
     throw invalidPathReplacementError(invalidKeys, url, allKeys, available);
   }
@@ -149,10 +149,7 @@ export const createUrl = (
   return baseUrl.replace(/\/+$/, '') + url;
 };
 
-function logHeaders(
-  log: LogFunction,
-  headers: HttpMultiMap
-) {
+function logHeaders(log: LogFunction, headers: HttpMultiMap) {
   Object.entries(headers).forEach(([headerName, value]) => {
     let valueArray = value;
     if (!Array.isArray(value)) {
@@ -164,12 +161,12 @@ function logHeaders(
     }
   });
 }
-function logRequest(
-  log: LogFunction,
-  request: HttpRequest
-) {
+function logRequest(log: LogFunction, request: HttpRequest) {
   let url = request.url;
-  if (request.queryParameters !== undefined && Object.keys(request.queryParameters).length > 0) {
+  if (
+    request.queryParameters !== undefined &&
+    Object.keys(request.queryParameters).length > 0
+  ) {
     const searchParams = new URLSearchParams(request.queryParameters);
     url = `${url}?${searchParams.toString()}`;
   }
@@ -181,10 +178,7 @@ function logRequest(
     log('\n\t%O', request.body);
   }
 }
-function logResponse(
-  log: LogFunction,
-  response: FetchResponse
-) {
+function logResponse(log: LogFunction, response: FetchResponse) {
   log(`\tHTTP/1.1 ${response.status} ${response.statusText}`);
   logHeaders(log, response.headers);
   log('\n\t%j\n', response.body);
@@ -273,7 +267,10 @@ export function deleteHeader(headers: NonPrimitive, headerName: string): void {
 }
 
 /** Returns case-insensitive header value(s) from multimap. */
-export function getHeaderMulti(map: HttpMultiMap, headerKey: string): string[] | undefined {
+export function getHeaderMulti(
+  map: HttpMultiMap,
+  headerKey: string
+): string[] | undefined {
   for (const [key, value] of Object.entries(map)) {
     if (key.toLowerCase() === headerKey.toLowerCase()) {
       if (!Array.isArray(value)) {

--- a/src/core/interpreter/http/utils.ts
+++ b/src/core/interpreter/http/utils.ts
@@ -1,7 +1,7 @@
 import type { ILogger } from '../../../interfaces';
 import type { NonPrimitive } from '../../../lib';
 import {
-  getValue,
+  indexRecord,
   recursiveKeyList,
   UnexpectedError,
   variableToString,
@@ -33,7 +33,13 @@ function replaceParameters(url: string, parameters: NonPrimitive) {
 
     const end = start + match[0].length;
     const key = match[1].trim();
-    const value = getValue(parameters, key.split('.'));
+
+    let value;
+    try {
+      value = indexRecord(parameters, key.split('.'));
+    } catch (_e) {
+      value = undefined;
+    }
 
     allKeys.push(key);
     if (value === undefined) {

--- a/src/core/interpreter/map-interpreter.errors.test.ts
+++ b/src/core/interpreter/map-interpreter.errors.test.ts
@@ -327,7 +327,6 @@ AST Path: definitions[0].statements[0].assignments[0].value`
 
       const ast = parseMapFromSource(`
         map Test {
-          page = input.page
           http GET "/{missing}/{alsoMissing}" {
             request {
               headers {
@@ -345,7 +344,7 @@ AST Path: definitions[0].statements[0].assignments[0].value`
       expect(() => {
         result.unwrap();
       }).toThrow(
-        'Missing values for URL path replacement: missing, alsoMissing'
+        'Missing or mistyped values for URL path replacement: missing, alsoMissing'
       );
     });
 
@@ -545,7 +544,7 @@ AST Path: definitions[0].statements[0].assignments[0].value`
       );
       const result = await interpreter.perform(ast);
       expect(result.isErr() && result.error.toString()).toMatch(
-        'Missing values for URL path replacement: path'
+        'Missing or mistyped values for URL path replacement: path'
       );
     });
   });

--- a/src/core/interpreter/map-interpreter.errors.ts
+++ b/src/core/interpreter/map-interpreter.errors.ts
@@ -109,7 +109,7 @@ export class HTTPError extends MapInterpreterErrorBase implements IHTTPError {
     },
     public response?: {
       body?: unknown;
-      headers?: Record<string, string>;
+      headers?: HttpMultiMap;
     }
   ) {
     super('HTTPError', message, metadata);

--- a/src/core/interpreter/map-interpreter.errors.ts
+++ b/src/core/interpreter/map-interpreter.errors.ts
@@ -9,6 +9,7 @@ import type {
   IMappedHTTPError,
 } from '../../interfaces';
 import { ErrorBase } from '../../lib';
+import type { HttpMultiMap } from './http';
 
 export class MapInterpreterErrorBase extends ErrorBase {
   private path?: string[];
@@ -103,7 +104,7 @@ export class HTTPError extends MapInterpreterErrorBase implements IHTTPError {
     public statusCode?: number,
     public request?: {
       body?: unknown;
-      headers?: Record<string, string>;
+      headers?: HttpMultiMap;
       url?: string;
     },
     public response?: {

--- a/src/core/interpreter/map-interpreter.test.ts
+++ b/src/core/interpreter/map-interpreter.test.ts
@@ -1557,8 +1557,6 @@ describe('MapInterpreter', () => {
           return {
             statusCode: 201,
             headers: {
-              // TODO: an array here gets joined by `, ` instead of sent as multiple header lines
-              // not sure if we can force mockttp to not join it
               test: req.headers['someheader']
             },
             json: { bodyOk: true, headerOk: true },
@@ -1598,7 +1596,7 @@ describe('MapInterpreter', () => {
       expect(result.unwrap()).toEqual({
         headerOk: true,
         bodyOk: true,
-        headerTest: expected
+        headerTest: expected,
       });
     });
 

--- a/src/core/interpreter/map-interpreter.test.ts
+++ b/src/core/interpreter/map-interpreter.test.ts
@@ -1447,20 +1447,24 @@ describe('MapInterpreter', () => {
     it.each([
       ['param', 'param'],
       [2, '2'],
-      [true, 'true']
-    ])('should call an API with path parameter "%s"', async (value, expected) => {
-      const url = '/twelve';
-      await mockServer.forGet(`${url}/${expected}`).thenJson(200, { data: 144 });
-      const interpreter = new MapInterpreter(
-        {
-          usecase: 'Test',
-          input: { page: value },
-          security: [],
-          services: mockServicesSelector,
-        },
-        interpreterDependencies
-      );
-      const ast = parseMapFromSource(`
+      [true, 'true'],
+    ])(
+      'should call an API with path parameter "%s"',
+      async (value, expected) => {
+        const url = '/twelve';
+        await mockServer
+          .forGet(`${url}/${expected}`)
+          .thenJson(200, { data: 144 });
+        const interpreter = new MapInterpreter(
+          {
+            usecase: 'Test',
+            input: { page: value },
+            security: [],
+            services: mockServicesSelector,
+          },
+          interpreterDependencies
+        );
+        const ast = parseMapFromSource(`
       map Test {
         page = input.page
         http GET "${url}/{page}" {
@@ -1475,10 +1479,11 @@ describe('MapInterpreter', () => {
           }
         }
       }`);
-      const result = await interpreter.perform(ast);
+        const result = await interpreter.perform(ast);
 
-      expect(result.unwrap()).toEqual(144);
-    });
+        expect(result.unwrap()).toEqual(144);
+      }
+    );
 
     it('should be able to use input in path parameters', async () => {
       const url = '/twelve';
@@ -1546,31 +1551,33 @@ describe('MapInterpreter', () => {
       ['2', '2'],
       ['false', 'false'],
       // ['[1, true, "hi"]', ['1', 'true', 'hi']], // FIXME: blocked by node-fetch update to 3 and node.js implicit header joining https://nodejs.org/api/http.html#messageheaders
-    ])('should send a POST request with header "%s" and receive it back', async (value, expected) => {
-      const url = '/checkBody';
-      await mockServer
-        .forPost(url)
-        .withJsonBody({ anArray: [1, 2, 3] })
-        .thenCallback(req => {
-          expect(req.headers['someheader']).toStrictEqual(expected);
+    ])(
+      'should send a POST request with header "%s" and receive it back',
+      async (value, expected) => {
+        const url = '/checkBody';
+        await mockServer
+          .forPost(url)
+          .withJsonBody({ anArray: [1, 2, 3] })
+          .thenCallback(req => {
+            expect(req.headers['someheader']).toStrictEqual(expected);
 
-          return {
-            statusCode: 201,
-            headers: {
-              test: req.headers['someheader']
-            },
-            json: { bodyOk: true, headerOk: true },
-          };
-        });
-      const interpreter = new MapInterpreter(
-        {
-          usecase: 'Test',
-          security: [],
-          services: mockServicesSelector,
-        },
-        interpreterDependencies
-      );
-      const ast = parseMapFromSource(`
+            return {
+              statusCode: 201,
+              headers: {
+                test: req.headers['someheader'],
+              },
+              json: { bodyOk: true, headerOk: true },
+            };
+          });
+        const interpreter = new MapInterpreter(
+          {
+            usecase: 'Test',
+            security: [],
+            services: mockServicesSelector,
+          },
+          interpreterDependencies
+        );
+        const ast = parseMapFromSource(`
       map Test {
         http POST "${url}" {
           request {
@@ -1591,35 +1598,38 @@ describe('MapInterpreter', () => {
           }
         }
       }`);
-      const result = await interpreter.perform(ast);
+        const result = await interpreter.perform(ast);
 
-      expect(result.unwrap()).toEqual({
-        headerOk: true,
-        bodyOk: true,
-        headerTest: expected,
-      });
-    });
+        expect(result.unwrap()).toEqual({
+          headerOk: true,
+          bodyOk: true,
+          headerTest: expected,
+        });
+      }
+    );
 
     it.each([
       ['2', '2'],
       [2, '2'],
-      [true, 'true']
-    ])('should call an API with query parameter "%s"', async (value, expected) => {
-      const url = '/twelve';
-      await mockServer
-        .forGet(url)
-        .withQuery({ page: expected })
-        .thenJson(200, { data: 144 });
-      const interpreter = new MapInterpreter(
-        {
-          usecase: 'Test',
-          input: { page: value },
-          security: [],
-          services: mockServicesSelector,
-        },
-        interpreterDependencies
-      );
-      const ast = parseMapFromSource(`
+      [true, 'true'],
+    ])(
+      'should call an API with query parameter "%s"',
+      async (value, expected) => {
+        const url = '/twelve';
+        await mockServer
+          .forGet(url)
+          .withQuery({ page: expected })
+          .thenJson(200, { data: 144 });
+        const interpreter = new MapInterpreter(
+          {
+            usecase: 'Test',
+            input: { page: value },
+            security: [],
+            services: mockServicesSelector,
+          },
+          interpreterDependencies
+        );
+        const ast = parseMapFromSource(`
       map Test {
         http GET "${url}" {
           request {
@@ -1636,10 +1646,11 @@ describe('MapInterpreter', () => {
           }
         }
       }`);
-      const result = await interpreter.perform(ast);
+        const result = await interpreter.perform(ast);
 
-      expect(result.unwrap()).toEqual(144);
-    });
+        expect(result.unwrap()).toEqual(144);
+      }
+    );
 
     it('should strip trailing slash from baseUrl', async () => {
       await mockServer.forGet('/thirteen').thenJson(200, { data: 12 });
@@ -1805,7 +1816,10 @@ describe('MapInterpreter', () => {
             [
               { id: 'one', baseUrl: `${mockServicesSelector.getUrl()!}/one` },
               { id: 'two', baseUrl: `${mockServicesSelector.getUrl()!}/two` },
-              { id: 'three', baseUrl: `${mockServicesSelector.getUrl()!}/three` },
+              {
+                id: 'three',
+                baseUrl: `${mockServicesSelector.getUrl()!}/three`,
+              },
             ],
             'one'
           ),
@@ -1911,11 +1925,16 @@ describe('MapInterpreter', () => {
 
     it('should send file in its entirety as FormData with passed mimetype and filename', async () => {
       const filePath = path.resolve(process.cwd(), 'fixtures', 'binary.txt');
-      const file = BinaryData.fromPath(filePath, { name: 'test.txt', mimetype: 'text/plain' });
+      const file = BinaryData.fromPath(filePath, {
+        name: 'test.txt',
+        mimetype: 'text/plain',
+      });
 
       await mockServer.forPost('/test').thenCallback(async req => {
         const data = await req.body.getText();
-        expect(data).toContain('Content-Disposition: form-data; name="file"; filename="test.txt"');
+        expect(data).toContain(
+          'Content-Disposition: form-data; name="file"; filename="test.txt"'
+        );
         expect(data).toContain('Content-Type: text/plain');
 
         return { status: 200, json: { ok: true } };
@@ -1965,7 +1984,9 @@ describe('MapInterpreter', () => {
       await mockServer.forPost('/test').thenCallback(async req => {
         const data = await req.body.getText();
 
-        expect(data).toContain('Content-Disposition: form-data; name="file"; filename="mapset.txt"');
+        expect(data).toContain(
+          'Content-Disposition: form-data; name="file"; filename="mapset.txt"'
+        );
         expect(data).toContain('Content-Type: vnd.test/mapset');
 
         return { status: 200, json: { ok: true } };
@@ -1998,7 +2019,7 @@ describe('MapInterpreter', () => {
           input: {
             file,
             filename: 'mapset.txt',
-            mimetype: 'vnd.test/mapset'
+            mimetype: 'vnd.test/mapset',
           },
         },
         interpreterDependencies
@@ -2017,7 +2038,9 @@ describe('MapInterpreter', () => {
     it('should return ArrayBuffer for binary response', async () => {
       const url = '/twelve';
       const filePath = path.resolve(process.cwd(), 'fixtures', 'binary.txt');
-      await mockServer.forGet(url).thenFromFile(200, filePath, { 'content-type': 'application/octet-stream' });
+      await mockServer.forGet(url).thenFromFile(200, filePath, {
+        'content-type': 'application/octet-stream',
+      });
 
       const interpreter = new MapInterpreter(
         {
@@ -2039,7 +2062,9 @@ describe('MapInterpreter', () => {
       const expected = (await readFile(filePath)).toString('utf8');
 
       expect(result.unwrap() instanceof ArrayBuffer).toBe(true);
-      expect(Buffer.from(result.unwrap() as ArrayBuffer).toString('utf8')).toBe(expected);
+      expect(Buffer.from(result.unwrap() as ArrayBuffer).toString('utf8')).toBe(
+        expected
+      );
     });
   });
 
@@ -2050,7 +2075,7 @@ describe('MapInterpreter', () => {
       [undefined, err(expect.any(JessieError))],
       // no special handling of nested None
       [{ foo: null }, ok({ foo: null })],
-      [{ foo: undefined }, ok({ foo: undefined })]
+      [{ foo: undefined }, ok({ foo: undefined })],
     ])('should handle input "%s"', async (value, expected) => {
       const ast = parseMapFromSource(`
         map Test {
@@ -2063,7 +2088,7 @@ describe('MapInterpreter', () => {
           security: [],
           services: ServiceSelector.withDefaultUrl(''),
           input: value as any,
-          parameters: {}
+          parameters: {},
         },
         interpreterDependencies
       );
@@ -2078,7 +2103,7 @@ describe('MapInterpreter', () => {
       [undefined, err(expect.any(JessieError))],
       // not touched
       [{ foo: null }, ok({ foo: null })],
-      [{ foo: undefined }, ok({ foo: undefined })]
+      [{ foo: undefined }, ok({ foo: undefined })],
     ])('should handle parameters "%s"', async (value, expected) => {
       const ast = parseMapFromSource(`
         map Test {
@@ -2091,7 +2116,7 @@ describe('MapInterpreter', () => {
           security: [],
           services: ServiceSelector.withDefaultUrl(''),
           input: undefined,
-          parameters: value as any
+          parameters: value as any,
         },
         interpreterDependencies
       );
@@ -2119,7 +2144,7 @@ describe('MapInterpreter', () => {
           security: [],
           services: ServiceSelector.withDefaultUrl(''),
           input: undefined,
-          parameters: {}
+          parameters: {},
         },
         interpreterDependencies
       );
@@ -2133,12 +2158,14 @@ describe('MapInterpreter', () => {
       ['undefined', err(expect.any(SDKExecutionError))],
       ['{ foo: null }', err(expect.any(SDKExecutionError))],
       ['{ foo: undefined }', err(expect.any(SDKExecutionError))],
-    ])('should handle stringifying HTTP url with "%s"', async (value, expected) => {
-      await mockServer.forAnyRequest().thenCallback(async req => {
-        return { status: 200, json: { data: req.path } };
-      });
+    ])(
+      'should handle stringifying HTTP url with "%s"',
+      async (value, expected) => {
+        await mockServer.forAnyRequest().thenCallback(async req => {
+          return { status: 200, json: { data: req.path } };
+        });
 
-      const ast = parseMapFromSource(`
+        const ast = parseMapFromSource(`
         map Test {
           val = ${value}
           http GET "/test/{val}" {
@@ -2148,27 +2175,28 @@ describe('MapInterpreter', () => {
           }
         }`);
 
-      const interpreter = new MapInterpreter(
-        {
-          usecase: 'Test',
-          security: [],
-          services: ServiceSelector.withDefaultUrl(mockServer.url),
-          input: undefined,
-          parameters: {}
-        },
-        interpreterDependencies
-      );
+        const interpreter = new MapInterpreter(
+          {
+            usecase: 'Test',
+            security: [],
+            services: ServiceSelector.withDefaultUrl(mockServer.url),
+            input: undefined,
+            parameters: {},
+          },
+          interpreterDependencies
+        );
 
-      const result = await interpreter.perform(ast);
-      expect(result).toStrictEqual(expected);
-    });
+        const result = await interpreter.perform(ast);
+        expect(result).toStrictEqual(expected);
+      }
+    );
 
     it.each([
       // content-type is JSON by default
       [null, null],
       [undefined, undefined],
       [{ foo: null }, { foo: null }],
-      [{ foo: undefined }, {}]
+      [{ foo: undefined }, {}],
     ])('should handle HTTP body "%s"', async (value, expected) => {
       await mockServer.forPost('/test').thenCallback(async req => {
         return { status: 200, json: { data: await req.body.getJson() } };
@@ -2193,7 +2221,7 @@ describe('MapInterpreter', () => {
           security: [],
           services: ServiceSelector.withDefaultUrl(mockServer.url),
           input: { foo: value as any },
-          parameters: {}
+          parameters: {},
         },
         interpreterDependencies
       );
@@ -2211,10 +2239,15 @@ describe('MapInterpreter', () => {
       [{ foo: undefined }, err(expect.any(SDKExecutionError))],
       // array filtered
       [[null, 'value', undefined], ok([true, 'value'])],
-      [[null, 'value', undefined, 'value2'], ok([true, ['value', 'value2']])]
+      [[null, 'value', undefined, 'value2'], ok([true, ['value', 'value2']])],
     ])('should handle HTTP header "%s"', async (value, expected) => {
       await mockServer.forGet('/test').thenCallback(async req => {
-        return { status: 200, json: { data: ['test-header' in req.headers, req.headers['test-header']] } };
+        return {
+          status: 200,
+          json: {
+            data: ['test-header' in req.headers, req.headers['test-header']],
+          },
+        };
       });
 
       const ast = parseMapFromSource(`
@@ -2238,7 +2271,7 @@ describe('MapInterpreter', () => {
           security: [],
           services: ServiceSelector.withDefaultUrl(mockServer.url),
           input: { foo: value as any },
-          parameters: {}
+          parameters: {},
         },
         interpreterDependencies
       );
@@ -2256,10 +2289,12 @@ describe('MapInterpreter', () => {
       [{ foo: undefined }, err(expect.any(SDKExecutionError))],
       // array filtered
       [[null, 'value', undefined], ok([true, 'value'])],
-      [[null, 'value', undefined, 'value2'], ok([true, ['value', 'value2']])]
+      [[null, 'value', undefined, 'value2'], ok([true, ['value', 'value2']])],
     ])('should handle HTTP query parameter "%s"', async (value, expected) => {
       await mockServer.forGet('/test').thenCallback(async req => {
-        let query: string | string[] = new URL(req.url).searchParams.getAll('test-query');
+        let query: string | string[] = new URL(req.url).searchParams.getAll(
+          'test-query'
+        );
         const present = query.length !== 0;
         if (query.length === 1) {
           query = query[0];
@@ -2289,7 +2324,7 @@ describe('MapInterpreter', () => {
           security: [],
           services: ServiceSelector.withDefaultUrl(mockServer.url),
           input: { foo: value as any },
-          parameters: {}
+          parameters: {},
         },
         interpreterDependencies
       );

--- a/src/core/interpreter/map-interpreter.test.ts
+++ b/src/core/interpreter/map-interpreter.test.ts
@@ -1545,7 +1545,7 @@ describe('MapInterpreter', () => {
       ['"hello"', 'hello'],
       ['2', '2'],
       ['false', 'false'],
-      ['[1, true, "hi"]', ['1', 'true', 'hi']]
+      // ['[1, true, "hi"]', ['1', 'true', 'hi']], // FIXME: blocked by node-fetch update to 3 and node.js implicit header joining https://nodejs.org/api/http.html#messageheaders
     ])('should send a POST request with header "%s" and receive it back', async (value, expected) => {
       const url = '/checkBody';
       await mockServer

--- a/src/core/interpreter/map-interpreter.ts
+++ b/src/core/interpreter/map-interpreter.ts
@@ -48,7 +48,7 @@ import {
   mergeVariables,
   ok,
   SDKExecutionError,
-  UnexpectedError
+  UnexpectedError,
 } from '../../lib';
 import type { IServiceSelector } from '../services';
 import type { MapInterpreterExternalHandler } from './external-handler';
@@ -167,7 +167,7 @@ abstract class NodeVisitor<N extends MapASTNode, V = undefined>
     protected stack: NonPrimitive,
     protected readonly childIdentifier: string,
     protected readonly log: LogFunction | undefined
-  ) { }
+  ) {}
 
   protected prepareResultDone(
     value?: V,
@@ -320,7 +320,7 @@ class MapDefinitionVisitor extends NodeVisitor<MapDefinitionNode> {
     return this.prepareResultDone(undefined);
   }
 
-  public override[Symbol.toStringTag](): string {
+  public override [Symbol.toStringTag](): string {
     return 'MapDefinitionVisitor';
   }
 }
@@ -343,7 +343,7 @@ class OperationDefinitionVisitor extends NodeVisitor<OperationDefinitionNode> {
     return this.prepareResultDone(undefined);
   }
 
-  public override[Symbol.toStringTag](): string {
+  public override [Symbol.toStringTag](): string {
     return 'OperationDefinitionVisitor';
   }
 }
@@ -391,7 +391,7 @@ class SetStatementVisitor extends NodeVisitor<SetStatementNode> {
     return this.prepareResultDone(undefined);
   }
 
-  public override[Symbol.toStringTag](): string {
+  public override [Symbol.toStringTag](): string {
     return 'SetStatementVisitor';
   }
 }
@@ -408,7 +408,7 @@ class ConditionAtomVisitor extends NodeVisitor<ConditionAtomNode, boolean> {
     return this.prepareResultDone(Boolean(result.value));
   }
 
-  public override[Symbol.toStringTag](): string {
+  public override [Symbol.toStringTag](): string {
     return 'ConditionAtomVisitor';
   }
 }
@@ -449,7 +449,7 @@ class AssignmentVisitor extends NodeVisitor<AssignmentNode, NonPrimitive> {
     return this.prepareResultDone(object);
   }
 
-  public override[Symbol.toStringTag](): string {
+  public override [Symbol.toStringTag](): string {
     return 'AssignmentVisitor';
   }
 }
@@ -463,7 +463,7 @@ class PrimitiveLiteralVisitor extends NodeVisitor<
     return this.prepareResultDone(this.node.value);
   }
 
-  public override[Symbol.toStringTag](): string {
+  public override [Symbol.toStringTag](): string {
     return 'PrimitiveLiteralVisitor';
   }
 }
@@ -490,7 +490,7 @@ class ObjectLiteralVisitor extends NodeVisitor<
     return this.prepareResultDone(object);
   }
 
-  public override[Symbol.toStringTag](): string {
+  public override [Symbol.toStringTag](): string {
     return 'ObjectLiteralVisitor';
   }
 }
@@ -525,7 +525,7 @@ class JessieExpressionVisitor extends NodeVisitor<
           ...fromEntriesOptional(
             ['input', this.inputParameters],
             ['parameters', this.integrationParameters]
-          )
+          ),
         }
       );
 
@@ -540,7 +540,7 @@ class JessieExpressionVisitor extends NodeVisitor<
     }
   }
 
-  public override[Symbol.toStringTag](): string {
+  public override [Symbol.toStringTag](): string {
     return 'JessieExpressionVisitor';
   }
 }
@@ -578,7 +578,7 @@ class IterationAtomVisitor extends NodeVisitor<
     return this.prepareResultDone(result.value);
   }
 
-  public override[Symbol.toStringTag](): string {
+  public override [Symbol.toStringTag](): string {
     return 'IterationAtomVisitor';
   }
 }
@@ -697,7 +697,7 @@ class CallVisitor extends NodeVisitor<
     }
   }
 
-  public override[Symbol.toStringTag](): string {
+  public override [Symbol.toStringTag](): string {
     return 'CallVisitor';
   }
 }
@@ -778,7 +778,7 @@ class HttpCallStatementVisitor extends NodeVisitor<HttpCallStatementNode> {
             ...fromEntriesOptional(
               ['input', this.inputParameters],
               ['parameters', this.integrationParameters]
-            )
+            ),
           },
           body: request?.body,
           securityRequirements: request?.security,
@@ -867,7 +867,7 @@ class HttpCallStatementVisitor extends NodeVisitor<HttpCallStatementNode> {
     return this.prepareResultDone(undefined);
   }
 
-  public override[Symbol.toStringTag](): string {
+  public override [Symbol.toStringTag](): string {
     return 'HttpCallStatementVisitor';
   }
 }
@@ -923,7 +923,7 @@ class HttpRequestVisitor extends NodeVisitor<HttpRequestNode, HttpRequest> {
     });
   }
 
-  public override[Symbol.toStringTag](): string {
+  public override [Symbol.toStringTag](): string {
     return 'HttpRequestVisitor';
   }
 }
@@ -1009,7 +1009,7 @@ class HttpResponseHandlerVisitor extends NodeVisitor<
     return this.prepareResultDone(true);
   }
 
-  public override[Symbol.toStringTag](): string {
+  public override [Symbol.toStringTag](): string {
     return 'HttpResponseHandlerVisitor';
   }
 }
@@ -1064,7 +1064,7 @@ class OutcomeStatementVisitor extends NodeVisitor<OutcomeStatementNode> {
     return this.prepareResultDone(undefined, this.node.terminateFlow);
   }
 
-  public override[Symbol.toStringTag](): string {
+  public override [Symbol.toStringTag](): string {
     return 'OutcomeStatementVisitor';
   }
 }
@@ -1365,7 +1365,10 @@ export class MapInterpreter<TInput extends NonPrimitive | undefined> {
       }
     }
 
-    const result = await MapInterpreter.handleFinalOutcome(lastResult?.outcome?.value, ast);
+    const result = await MapInterpreter.handleFinalOutcome(
+      lastResult?.outcome?.value,
+      ast
+    );
     if (result.isOk() && !isNone(this.parameters.input)) {
       await MapInterpreter.destroyInput(this.parameters.input);
     }

--- a/src/core/interpreter/profile-parameter-validator.test.ts
+++ b/src/core/interpreter/profile-parameter-validator.test.ts
@@ -477,7 +477,7 @@ describe('ProfileParameterValidator', () => {
       });
 
       it.each([undefined, null, 'value'])('returns ok for foo being %p', (value) => {
-        expect(parameterValidator.validate({ foo: value }, 'result', 'Test').isErr()).toBeTruthy();
+        expect(parameterValidator.validate({ foo: value }, 'result', 'Test').isOk()).toBeTruthy();
       });
 
       it('returns error for foo not being set', () => {

--- a/src/core/interpreter/profile-parameter-validator.test.ts
+++ b/src/core/interpreter/profile-parameter-validator.test.ts
@@ -407,7 +407,7 @@ describe('ProfileParameterValidator', () => {
 
       it('returns error for invalid value in bar', () => {
         expect(parameterValidator.validate({ bar: { foo: true } }, 'result', 'Test').isErr()).toBeTruthy();
-        expect(parameterValidator.validate({ bar: { foo: 'value', bar: 'value' } }, 'result', 'Test').isErr()).toBeTruthy();
+        expect(parameterValidator.validate({ bar: { foo: 1, bar: 1 } }, 'result', 'Test').isErr()).toBeTruthy();
       });
 
       it('returns error for invalid value in baz', () => {

--- a/src/core/interpreter/profile-parameter-validator.test.ts
+++ b/src/core/interpreter/profile-parameter-validator.test.ts
@@ -3,7 +3,12 @@ import { parseProfile, Source } from '@superfaceai/parser';
 import type { ProfileParameterError } from '../../interfaces';
 import type { Result, UnexpectedError } from '../../lib';
 import { ProfileParameterValidator } from './profile-parameter-validator';
-import { InputValidationError, isInputValidationError, isResultValidationError, ResultValidationError } from './profile-parameter-validator.errors';
+import {
+  InputValidationError,
+  isInputValidationError,
+  isResultValidationError,
+  ResultValidationError,
+} from './profile-parameter-validator.errors';
 
 const parseProfileFromSource = (source: string) =>
   parseProfile(
@@ -20,21 +25,21 @@ const checkErrorKind = (result: Result<unknown, unknown>) =>
   (isInputValidationError(result.error)
     ? result.error.errors?.map(error => error.kind)
     : isResultValidationError(result.error) &&
-    result.error.errors?.map(error => error.kind));
+      result.error.errors?.map(error => error.kind));
 
 const checkErrorPath = (result: Result<unknown, unknown>) =>
   result.isErr() &&
   (isInputValidationError(result.error)
     ? result.error.errors?.map(error => error.context?.path)
     : isResultValidationError(result.error) &&
-    result.error.errors?.map(error => error.context?.path));
+      result.error.errors?.map(error => error.context?.path));
 
 const checkErrorContext = (result: Result<unknown, unknown>) =>
   result.isErr() &&
   (isInputValidationError(result.error)
     ? result.error.errors?.map(error => error.context)
     : isResultValidationError(result.error) &&
-    result.error.errors?.map(error => error.context));
+      result.error.errors?.map(error => error.context));
 
 describe('ProfileParameterValidator', () => {
   let parameterValidator: ProfileParameterValidator;
@@ -56,15 +61,29 @@ describe('ProfileParameterValidator', () => {
       });
 
       it('returns ok for valid values', () => {
-        expect(parameterValidator.validate({ foo: true, }, 'result', 'Test').isOk()).toBeTruthy();
-        expect(parameterValidator.validate({ bar: 1 }, 'result', 'Test').isOk()).toBeTruthy();
-        expect(parameterValidator.validate({ baz: 'value' }, 'result', 'Test').isOk()).toBeTruthy();
+        expect(
+          parameterValidator.validate({ foo: true }, 'result', 'Test').isOk()
+        ).toBeTruthy();
+        expect(
+          parameterValidator.validate({ bar: 1 }, 'result', 'Test').isOk()
+        ).toBeTruthy();
+        expect(
+          parameterValidator.validate({ baz: 'value' }, 'result', 'Test').isOk()
+        ).toBeTruthy();
       });
 
       it('returns error for invalid values', () => {
-        expect(parameterValidator.validate({ foo: 1 }, 'result', 'Test').isErr()).toBeTruthy();
-        expect(parameterValidator.validate({ bar: 'value' }, 'result', 'Test').isErr()).toBeTruthy();
-        expect(parameterValidator.validate({ baz: true }, 'result', 'Test').isErr()).toBeTruthy();
+        expect(
+          parameterValidator.validate({ foo: 1 }, 'result', 'Test').isErr()
+        ).toBeTruthy();
+        expect(
+          parameterValidator
+            .validate({ bar: 'value' }, 'result', 'Test')
+            .isErr()
+        ).toBeTruthy();
+        expect(
+          parameterValidator.validate({ baz: true }, 'result', 'Test').isErr()
+        ).toBeTruthy();
       });
     });
 
@@ -80,13 +99,21 @@ describe('ProfileParameterValidator', () => {
       });
 
       it('returns ok for valid values', () => {
-        expect(parameterValidator.validate('OK', 'result', 'Test').isOk()).toBeTruthy();
-        expect(parameterValidator.validate('WARNING', 'result', 'Test').isOk()).toBeTruthy();
-        expect(parameterValidator.validate('ERR', 'result', 'Test').isOk()).toBeTruthy();
+        expect(
+          parameterValidator.validate('OK', 'result', 'Test').isOk()
+        ).toBeTruthy();
+        expect(
+          parameterValidator.validate('WARNING', 'result', 'Test').isOk()
+        ).toBeTruthy();
+        expect(
+          parameterValidator.validate('ERR', 'result', 'Test').isOk()
+        ).toBeTruthy();
       });
 
       it('returns error for invalid values', () => {
-        expect(parameterValidator.validate('INVALID', 'result', 'Test').isErr()).toBeTruthy();
+        expect(
+          parameterValidator.validate('INVALID', 'result', 'Test').isErr()
+        ).toBeTruthy();
       });
     });
 
@@ -109,38 +136,77 @@ describe('ProfileParameterValidator', () => {
       });
 
       it('returns ok for valid values', () => {
-        expect(parameterValidator.validate(
-          {
-            field: {
-              foo: true,
-              bar: 1,
-              baz: 'value',
-              waf: 'OK'
-            }
-          }, 'result', 'Test').isOk()).toBeTruthy();
+        expect(
+          parameterValidator
+            .validate(
+              {
+                field: {
+                  foo: true,
+                  bar: 1,
+                  baz: 'value',
+                  waf: 'OK',
+                },
+              },
+              'result',
+              'Test'
+            )
+            .isOk()
+        ).toBeTruthy();
       });
 
       it('returns error for invalid values', () => {
-        expect(parameterValidator.validate({
-          field: {
-            foo: 1
-          }
-        }, 'result', 'Test').isErr()).toBeTruthy();
-        expect(parameterValidator.validate({
-          field: {
-            bar: 'value'
-          }
-        }, 'result', 'Test').isErr()).toBeTruthy();
-        expect(parameterValidator.validate({
-          field: {
-            baz: true
-          }
-        }, 'result', 'Test').isErr()).toBeTruthy();
-        expect(parameterValidator.validate({
-          field: {
-            waf: 'INVALID'
-          }
-        }, 'result', 'Test').isErr()).toBeTruthy();
+        expect(
+          parameterValidator
+            .validate(
+              {
+                field: {
+                  foo: 1,
+                },
+              },
+              'result',
+              'Test'
+            )
+            .isErr()
+        ).toBeTruthy();
+        expect(
+          parameterValidator
+            .validate(
+              {
+                field: {
+                  bar: 'value',
+                },
+              },
+              'result',
+              'Test'
+            )
+            .isErr()
+        ).toBeTruthy();
+        expect(
+          parameterValidator
+            .validate(
+              {
+                field: {
+                  baz: true,
+                },
+              },
+              'result',
+              'Test'
+            )
+            .isErr()
+        ).toBeTruthy();
+        expect(
+          parameterValidator
+            .validate(
+              {
+                field: {
+                  waf: 'INVALID',
+                },
+              },
+              'result',
+              'Test'
+            )
+            .isErr()
+        ).toBeTruthy();
       });
     });
 
@@ -165,48 +231,87 @@ describe('ProfileParameterValidator', () => {
       });
 
       it('returns ok for valid values', () => {
-        expect(parameterValidator.validate(
-          {
-            field: {
-              nestedField: {
-                foo: true,
-                bar: 1,
-                baz: 'value',
-                waf: 'OK'
-              }
-            }
-          }, 'result', 'Test').isOk()).toBeTruthy();
+        expect(
+          parameterValidator
+            .validate(
+              {
+                field: {
+                  nestedField: {
+                    foo: true,
+                    bar: 1,
+                    baz: 'value',
+                    waf: 'OK',
+                  },
+                },
+              },
+              'result',
+              'Test'
+            )
+            .isOk()
+        ).toBeTruthy();
       });
 
       it('returns error for invalid values', () => {
-        expect(parameterValidator.validate({
-          field: {
-            nestedField: {
-              foo: 1
-            }
-          }
-        }, 'result', 'Test').isErr()).toBeTruthy();
-        expect(parameterValidator.validate({
-          field: {
-            nestedField: {
-              bar: 'value'
-            }
-          }
-        }, 'result', 'Test').isErr()).toBeTruthy();
-        expect(parameterValidator.validate({
-          field: {
-            nestedField: {
-              baz: true
-            }
-          }
-        }, 'result', 'Test').isErr()).toBeTruthy();
-        expect(parameterValidator.validate({
-          field: {
-            nestedField: {
-              waf: 'INVALID'
-            }
-          }
-        }, 'result', 'Test').isErr()).toBeTruthy();
+        expect(
+          parameterValidator
+            .validate(
+              {
+                field: {
+                  nestedField: {
+                    foo: 1,
+                  },
+                },
+              },
+              'result',
+              'Test'
+            )
+            .isErr()
+        ).toBeTruthy();
+        expect(
+          parameterValidator
+            .validate(
+              {
+                field: {
+                  nestedField: {
+                    bar: 'value',
+                  },
+                },
+              },
+              'result',
+              'Test'
+            )
+            .isErr()
+        ).toBeTruthy();
+        expect(
+          parameterValidator
+            .validate(
+              {
+                field: {
+                  nestedField: {
+                    baz: true,
+                  },
+                },
+              },
+              'result',
+              'Test'
+            )
+            .isErr()
+        ).toBeTruthy();
+        expect(
+          parameterValidator
+            .validate(
+              {
+                field: {
+                  nestedField: {
+                    waf: 'INVALID',
+                  },
+                },
+              },
+              'result',
+              'Test'
+            )
+            .isErr()
+        ).toBeTruthy();
       });
     });
 
@@ -230,25 +335,57 @@ describe('ProfileParameterValidator', () => {
       });
 
       it('returns ok for valid values', () => {
-        expect(parameterValidator.validate({
-          foo: ['value'],
-          bar: [{ field: 'value' }],
-          baz: [{ field: 'value' }],
-        }, 'result', 'Test').isOk()).toBeTruthy();
+        expect(
+          parameterValidator
+            .validate(
+              {
+                foo: ['value'],
+                bar: [{ field: 'value' }],
+                baz: [{ field: 'value' }],
+              },
+              'result',
+              'Test'
+            )
+            .isOk()
+        ).toBeTruthy();
       });
 
       it('returns error for invalid values', () => {
-        expect(parameterValidator.validate({
-          foo: [1, true, { field: 'value' }]
-        }, 'result', 'Test').isErr()).toBeTruthy();
+        expect(
+          parameterValidator
+            .validate(
+              {
+                foo: [1, true, { field: 'value' }],
+              },
+              'result',
+              'Test'
+            )
+            .isErr()
+        ).toBeTruthy();
 
-        expect(parameterValidator.validate({
-          bar: [1, true, 'value']
-        }, 'result', 'Test').isErr()).toBeTruthy();
+        expect(
+          parameterValidator
+            .validate(
+              {
+                bar: [1, true, 'value'],
+              },
+              'result',
+              'Test'
+            )
+            .isErr()
+        ).toBeTruthy();
 
-        expect(parameterValidator.validate({
-          baz: [1, true, 'value']
-        }, 'result', 'Test').isErr()).toBeTruthy();
+        expect(
+          parameterValidator
+            .validate(
+              {
+                baz: [1, true, 'value'],
+              },
+              'result',
+              'Test'
+            )
+            .isErr()
+        ).toBeTruthy();
       });
     });
 
@@ -268,11 +405,15 @@ describe('ProfileParameterValidator', () => {
       });
 
       it('returns ok for valid values', () => {
-        expect(parameterValidator.validate({ foo: 'value', }, 'result', 'Test').isOk()).toBeTruthy();
+        expect(
+          parameterValidator.validate({ foo: 'value' }, 'result', 'Test').isOk()
+        ).toBeTruthy();
       });
 
       it('returns error for invalid values', () => {
-        expect(parameterValidator.validate({ foo: 1 }, 'result', 'Test').isErr()).toBeTruthy();
+        expect(
+          parameterValidator.validate({ foo: 1 }, 'result', 'Test').isErr()
+        ).toBeTruthy();
       });
     });
 
@@ -292,11 +433,15 @@ describe('ProfileParameterValidator', () => {
       });
 
       it('returns ok for valid values', () => {
-        expect(parameterValidator.validate({ foo: 'value', }, 'result', 'Test').isOk()).toBeTruthy();
+        expect(
+          parameterValidator.validate({ foo: 'value' }, 'result', 'Test').isOk()
+        ).toBeTruthy();
       });
 
       it('returns error for invalid values', () => {
-        expect(parameterValidator.validate({ foo: 1 }, 'result', 'Test').isErr()).toBeTruthy();
+        expect(
+          parameterValidator.validate({ foo: 1 }, 'result', 'Test').isErr()
+        ).toBeTruthy();
       });
     });
 
@@ -317,11 +462,15 @@ describe('ProfileParameterValidator', () => {
       });
 
       it('returns ok for valid values', () => {
-        expect(parameterValidator.validate({ foo: 'value', }, 'result', 'Test').isOk()).toBeTruthy();
+        expect(
+          parameterValidator.validate({ foo: 'value' }, 'result', 'Test').isOk()
+        ).toBeTruthy();
       });
 
       it('returns error for invalid values', () => {
-        expect(parameterValidator.validate({ foo: 1 }, 'result', 'Test').isErr()).toBeTruthy();
+        expect(
+          parameterValidator.validate({ foo: 1 }, 'result', 'Test').isErr()
+        ).toBeTruthy();
       });
     });
 
@@ -342,11 +491,15 @@ describe('ProfileParameterValidator', () => {
       });
 
       it('returns ok for valid values', () => {
-        expect(parameterValidator.validate({ foo: 'value', }, 'result', 'Test').isOk()).toBeTruthy();
+        expect(
+          parameterValidator.validate({ foo: 'value' }, 'result', 'Test').isOk()
+        ).toBeTruthy();
       });
 
       it('returns error for invalid values', () => {
-        expect(parameterValidator.validate({ foo: 1 }, 'result', 'Test').isErr()).toBeTruthy();
+        expect(
+          parameterValidator.validate({ foo: 1 }, 'result', 'Test').isErr()
+        ).toBeTruthy();
       });
     });
 
@@ -375,43 +528,83 @@ describe('ProfileParameterValidator', () => {
       });
 
       it('returns ok for valid primitives in foo', () => {
-        expect(parameterValidator.validate({ foo: true, }, 'result', 'Test').isOk()).toBeTruthy();
-        expect(parameterValidator.validate({ foo: 1, }, 'result', 'Test').isOk()).toBeTruthy();
-        expect(parameterValidator.validate({ foo: 'value', }, 'result', 'Test').isOk()).toBeTruthy();
+        expect(
+          parameterValidator.validate({ foo: true }, 'result', 'Test').isOk()
+        ).toBeTruthy();
+        expect(
+          parameterValidator.validate({ foo: 1 }, 'result', 'Test').isOk()
+        ).toBeTruthy();
+        expect(
+          parameterValidator.validate({ foo: 'value' }, 'result', 'Test').isOk()
+        ).toBeTruthy();
       });
 
       it('returns ok for valid object in bar', () => {
-        expect(parameterValidator.validate({ bar: { foo: 'value' } }, 'result', 'Test').isOk()).toBeTruthy();
-        expect(parameterValidator.validate({ bar: { foo: 1, bar: 'value' } }, 'result', 'Test').isOk()).toBeTruthy();
+        expect(
+          parameterValidator
+            .validate({ bar: { foo: 'value' } }, 'result', 'Test')
+            .isOk()
+        ).toBeTruthy();
+        expect(
+          parameterValidator
+            .validate({ bar: { foo: 1, bar: 'value' } }, 'result', 'Test')
+            .isOk()
+        ).toBeTruthy();
       });
 
       it('returns ok for boolean in baz', () => {
-        expect(parameterValidator.validate({ baz: true }, 'result', 'Test').isOk()).toBeTruthy();
+        expect(
+          parameterValidator.validate({ baz: true }, 'result', 'Test').isOk()
+        ).toBeTruthy();
       });
 
       it('returns ok for valid list in baz', () => {
-        expect(parameterValidator.validate({ baz: ['value'] }, 'result', 'Test').isOk()).toBeTruthy();
+        expect(
+          parameterValidator
+            .validate({ baz: ['value'] }, 'result', 'Test')
+            .isOk()
+        ).toBeTruthy();
       });
 
       it('returns ok for valid object in baz', () => {
-        expect(parameterValidator.validate({ baz: { foo: 'value' } }, 'result', 'Test').isOk()).toBeTruthy();
+        expect(
+          parameterValidator
+            .validate({ baz: { foo: 'value' } }, 'result', 'Test')
+            .isOk()
+        ).toBeTruthy();
       });
 
       it('returns ok for valid enum value in baz', () => {
-        expect(parameterValidator.validate({ baz: 'OK' }, 'result', 'Test').isOk()).toBeTruthy();
+        expect(
+          parameterValidator.validate({ baz: 'OK' }, 'result', 'Test').isOk()
+        ).toBeTruthy();
       });
 
       it('returns error for invalid value in foo', () => {
-        expect(parameterValidator.validate({ foo: { foo: 'value' } }, 'result', 'Test').isErr()).toBeTruthy();
+        expect(
+          parameterValidator
+            .validate({ foo: { foo: 'value' } }, 'result', 'Test')
+            .isErr()
+        ).toBeTruthy();
       });
 
       it('returns error for invalid value in bar', () => {
-        expect(parameterValidator.validate({ bar: { foo: true } }, 'result', 'Test').isErr()).toBeTruthy();
-        expect(parameterValidator.validate({ bar: { foo: 1, bar: 1 } }, 'result', 'Test').isErr()).toBeTruthy();
+        expect(
+          parameterValidator
+            .validate({ bar: { foo: true } }, 'result', 'Test')
+            .isErr()
+        ).toBeTruthy();
+        expect(
+          parameterValidator
+            .validate({ bar: { foo: 1, bar: 1 } }, 'result', 'Test')
+            .isErr()
+        ).toBeTruthy();
       });
 
       it('returns error for invalid value in baz', () => {
-        expect(parameterValidator.validate({ bar: 1 }, 'result', 'Test').isErr()).toBeTruthy();
+        expect(
+          parameterValidator.validate({ bar: 1 }, 'result', 'Test').isErr()
+        ).toBeTruthy();
       });
     });
 
@@ -429,10 +622,20 @@ describe('ProfileParameterValidator', () => {
       });
 
       it('returns ok for any value', () => {
-        expect(parameterValidator.validate({ foo: true, }, 'result', 'Test').isOk()).toBeTruthy();
-        expect(parameterValidator.validate({ foo: 1, }, 'result', 'Test').isOk()).toBeTruthy();
-        expect(parameterValidator.validate({ foo: 'value', }, 'result', 'Test').isOk()).toBeTruthy();
-        expect(parameterValidator.validate({ foo: Buffer.alloc(0), }, 'result', 'Test').isOk()).toBeTruthy();
+        expect(
+          parameterValidator.validate({ foo: true }, 'result', 'Test').isOk()
+        ).toBeTruthy();
+        expect(
+          parameterValidator.validate({ foo: 1 }, 'result', 'Test').isOk()
+        ).toBeTruthy();
+        expect(
+          parameterValidator.validate({ foo: 'value' }, 'result', 'Test').isOk()
+        ).toBeTruthy();
+        expect(
+          parameterValidator
+            .validate({ foo: Buffer.alloc(0) }, 'result', 'Test')
+            .isOk()
+        ).toBeTruthy();
       });
     });
 
@@ -451,15 +654,24 @@ describe('ProfileParameterValidator', () => {
       });
 
       it('returns ok for foo and bar not being set', () => {
-        expect(parameterValidator.validate({}, 'result', 'Test').isOk()).toBeTruthy();
+        expect(
+          parameterValidator.validate({}, 'result', 'Test').isOk()
+        ).toBeTruthy();
       });
 
-      it.each([undefined, null, 'value'])('returns ok for bar not set and foo = %p', (value) => {
-        expect(parameterValidator.validate({ foo: value }, 'result', 'Test').isOk()).toBeTruthy();
-      });
+      it.each([undefined, null, 'value'])(
+        'returns ok for bar not set and foo = %p',
+        value => {
+          expect(
+            parameterValidator.validate({ foo: value }, 'result', 'Test').isOk()
+          ).toBeTruthy();
+        }
+      );
 
       it('returns ok for foo not set and bar = value', () => {
-        expect(parameterValidator.validate({ foo: 'value' }, 'result', 'Test').isOk()).toBeTruthy();
+        expect(
+          parameterValidator.validate({ foo: 'value' }, 'result', 'Test').isOk()
+        ).toBeTruthy();
       });
     });
 
@@ -476,12 +688,19 @@ describe('ProfileParameterValidator', () => {
         parameterValidator = new ProfileParameterValidator(ast);
       });
 
-      it.each([undefined, null, 'value'])('returns ok for foo being %p', (value) => {
-        expect(parameterValidator.validate({ foo: value }, 'result', 'Test').isOk()).toBeTruthy();
-      });
+      it.each([undefined, null, 'value'])(
+        'returns ok for foo being %p',
+        value => {
+          expect(
+            parameterValidator.validate({ foo: value }, 'result', 'Test').isOk()
+          ).toBeTruthy();
+        }
+      );
 
       it('returns error for foo not being set', () => {
-        expect(parameterValidator.validate({}, 'result', 'Test').isErr()).toBeTruthy();
+        expect(
+          parameterValidator.validate({}, 'result', 'Test').isErr()
+        ).toBeTruthy();
       });
     });
 
@@ -504,13 +723,27 @@ describe('ProfileParameterValidator', () => {
         parameterValidator = new ProfileParameterValidator(ast);
       });
 
-      it.each(['foo', 'bar', 'baz', 'waf'])('returns ok for %s being null', (fieldName) => {
-        expect(parameterValidator.validate({ [fieldName]: null }, 'result', 'Test').isOk()).toBeTruthy();
-      });
+      it.each(['foo', 'bar', 'baz', 'waf'])(
+        'returns ok for %s being null',
+        fieldName => {
+          expect(
+            parameterValidator
+              .validate({ [fieldName]: null }, 'result', 'Test')
+              .isOk()
+          ).toBeTruthy();
+        }
+      );
 
-      it.each(['foo', 'bar', 'baz', 'waf'])('returns ok for %s being undefined', (fieldName) => {
-        expect(parameterValidator.validate({ [fieldName]: undefined }, 'result', 'Test').isOk()).toBeTruthy();
-      });
+      it.each(['foo', 'bar', 'baz', 'waf'])(
+        'returns ok for %s being undefined',
+        fieldName => {
+          expect(
+            parameterValidator
+              .validate({ [fieldName]: undefined }, 'result', 'Test')
+              .isOk()
+          ).toBeTruthy();
+        }
+      );
     });
 
     describe('required value', () => {
@@ -532,17 +765,38 @@ describe('ProfileParameterValidator', () => {
         parameterValidator = new ProfileParameterValidator(ast);
       });
 
-      it.each(['foo', 'bar', 'baz', 'waf'])('returns error for %s = undefined', (fieldName) => {
-        expect(parameterValidator.validate({ [fieldName]: undefined }, 'result', 'Test').isErr()).toBeTruthy();
-      });
+      it.each(['foo', 'bar', 'baz', 'waf'])(
+        'returns error for %s = undefined',
+        fieldName => {
+          expect(
+            parameterValidator
+              .validate({ [fieldName]: undefined }, 'result', 'Test')
+              .isErr()
+          ).toBeTruthy();
+        }
+      );
 
-      it.each(['foo', 'bar', 'baz', 'waf'])('returns error for %s = null', (fieldName) => {
-        expect(parameterValidator.validate({ [fieldName]: null }, 'result', 'Test').isErr()).toBeTruthy();
-      });
+      it.each(['foo', 'bar', 'baz', 'waf'])(
+        'returns error for %s = null',
+        fieldName => {
+          expect(
+            parameterValidator
+              .validate({ [fieldName]: null }, 'result', 'Test')
+              .isErr()
+          ).toBeTruthy();
+        }
+      );
 
-      it.each([undefined, null])('returns error for %p in bar\'s value', (value) => {
-        expect(parameterValidator.validate({ bar: [value] }, 'result', 'Test').isErr()).toBeTruthy();
-      });
+      it.each([undefined, null])(
+        "returns error for %p in bar's value",
+        value => {
+          expect(
+            parameterValidator
+              .validate({ bar: [value] }, 'result', 'Test')
+              .isErr()
+          ).toBeTruthy();
+        }
+      );
     });
 
     describe('extraneous fields', () => {
@@ -559,15 +813,25 @@ describe('ProfileParameterValidator', () => {
       });
 
       it('returns ok for set extra field', () => {
-        expect(parameterValidator.validate({ foo: 'value', bar: 1 }, 'result', 'Test').isOk()).toBeTruthy();
+        expect(
+          parameterValidator
+            .validate({ foo: 'value', bar: 1 }, 'result', 'Test')
+            .isOk()
+        ).toBeTruthy();
       });
 
       it('returns error for invalid foo type', () => {
-        expect(parameterValidator.validate({ foo: 1, bar: 1 }, 'result', 'Test').isErr()).toBeTruthy();
+        expect(
+          parameterValidator
+            .validate({ foo: 1, bar: 1 }, 'result', 'Test')
+            .isErr()
+        ).toBeTruthy();
       });
 
       it('returns error for missing foo', () => {
-        expect(parameterValidator.validate({ bar: 1 }, 'result', 'Test').isErr()).toBeTruthy();
+        expect(
+          parameterValidator.validate({ bar: 1 }, 'result', 'Test').isErr()
+        ).toBeTruthy();
       });
     });
 
@@ -593,14 +857,22 @@ describe('ProfileParameterValidator', () => {
       });
 
       it('returns ok for valid input data', () => {
-        expect(parameterValidator.validate({
-          foo: {
-            foo: 'value',
-            bar: 'OK',
-            baz: ['value'],
-            waf: null,
-          }
-        }, 'input', 'Test').isOk()).toBeTruthy();
+        expect(
+          parameterValidator
+            .validate(
+              {
+                foo: {
+                  foo: 'value',
+                  bar: 'OK',
+                  baz: ['value'],
+                  waf: null,
+                },
+              },
+              'input',
+              'Test'
+            )
+            .isOk()
+        ).toBeTruthy();
       });
     });
 
@@ -616,12 +888,19 @@ describe('ProfileParameterValidator', () => {
           parameterValidator = new ProfileParameterValidator(ast);
         });
 
-        it.each([null, undefined, 'value'])('returns ok for %p as result', (value) => {
-          expect(parameterValidator.validate(value, 'result', 'Test').isOk()).toBeTruthy();
-        });
+        it.each([null, undefined, 'value'])(
+          'returns ok for %p as result',
+          value => {
+            expect(
+              parameterValidator.validate(value, 'result', 'Test').isOk()
+            ).toBeTruthy();
+          }
+        );
 
-        it.each([1, true, {}])('returns error for `%p` as result', (value) => {
-          expect(parameterValidator.validate(value, 'result', 'Test').isErr()).toBeTruthy();
+        it.each([1, true, {}])('returns error for `%p` as result', value => {
+          expect(
+            parameterValidator.validate(value, 'result', 'Test').isErr()
+          ).toBeTruthy();
         });
       });
 
@@ -636,9 +915,14 @@ describe('ProfileParameterValidator', () => {
           parameterValidator = new ProfileParameterValidator(ast);
         });
 
-        it.each(['OK', undefined, null])('returns ok for %p as result', (value) => {
-          expect(parameterValidator.validate(value, 'result', 'Test').isOk()).toBeTruthy();
-        });
+        it.each(['OK', undefined, null])(
+          'returns ok for %p as result',
+          value => {
+            expect(
+              parameterValidator.validate(value, 'result', 'Test').isOk()
+            ).toBeTruthy();
+          }
+        );
       });
 
       describe('list', () => {
@@ -652,9 +936,14 @@ describe('ProfileParameterValidator', () => {
           parameterValidator = new ProfileParameterValidator(ast);
         });
 
-        it.each([undefined, null, [], ['value']])('returns ok for `%p` as result', (value) => {
-          expect(parameterValidator.validate(value, 'result', 'Test').isOk()).toBeTruthy();
-        });
+        it.each([undefined, null, [], ['value']])(
+          'returns ok for `%p` as result',
+          value => {
+            expect(
+              parameterValidator.validate(value, 'result', 'Test').isOk()
+            ).toBeTruthy();
+          }
+        );
       });
 
       describe('object', () => {
@@ -670,9 +959,14 @@ describe('ProfileParameterValidator', () => {
           parameterValidator = new ProfileParameterValidator(ast);
         });
 
-        it.each([undefined, null, {}, { foo: 'value' }])('returns ok for `%p` as result', (value) => {
-          expect(parameterValidator.validate(value, 'result', 'Test').isOk()).toBeTruthy();
-        });
+        it.each([undefined, null, {}, { foo: 'value' }])(
+          'returns ok for `%p` as result',
+          value => {
+            expect(
+              parameterValidator.validate(value, 'result', 'Test').isOk()
+            ).toBeTruthy();
+          }
+        );
       });
 
       describe('required value', () => {
@@ -686,8 +980,10 @@ describe('ProfileParameterValidator', () => {
           parameterValidator = new ProfileParameterValidator(ast);
         });
 
-        it.each([undefined, null])('returns error for %p as result', (value) => {
-          expect(parameterValidator.validate(value, 'result', 'Test').isErr()).toBeTruthy();
+        it.each([undefined, null])('returns error for %p as result', value => {
+          expect(
+            parameterValidator.validate(value, 'result', 'Test').isErr()
+          ).toBeTruthy();
         });
       });
     });
@@ -710,34 +1006,26 @@ describe('ProfileParameterValidator', () => {
       });
 
       it('returns InputValidationError instance', () => {
-        const result = parameterValidator.validate(
-          {},
-          'input',
-          'Test'
-        );
+        const result = parameterValidator.validate({}, 'input', 'Test');
 
-        expect(result.isErr() && result.error).toBeInstanceOf(InputValidationError);
+        expect(result.isErr() && result.error).toBeInstanceOf(
+          InputValidationError
+        );
       });
 
       it('returns ResultValidationError instance', () => {
-        const result = parameterValidator.validate(
-          {},
-          'result',
-          'Test'
-        );
+        const result = parameterValidator.validate({}, 'result', 'Test');
 
-        expect(result.isErr() && result.error).toBeInstanceOf(ResultValidationError);
+        expect(result.isErr() && result.error).toBeInstanceOf(
+          ResultValidationError
+        );
       });
 
       describe('for wrong type', () => {
         let result: Result<undefined, ProfileParameterError | UnexpectedError>;
 
         beforeEach(() => {
-          result = parameterValidator.validate(
-            { foo: 1 },
-            'input',
-            'Test'
-          );
+          result = parameterValidator.validate({ foo: 1 }, 'input', 'Test');
         });
 
         it("returns errorKind = 'wrongType'", () => {
@@ -749,9 +1037,13 @@ describe('ProfileParameterValidator', () => {
         });
 
         it('returns context', () => {
-          expect(checkErrorContext(result)).toMatchObject([{ expected: 'string' }]);
-          expect(checkErrorContext(result)).toMatchObject([{ actual: 'number' }]);
-        })
+          expect(checkErrorContext(result)).toMatchObject([
+            { expected: 'string' },
+          ]);
+          expect(checkErrorContext(result)).toMatchObject([
+            { actual: 'number' },
+          ]);
+        });
       });
     });
   });

--- a/src/core/interpreter/profile-parameter-validator.test.ts
+++ b/src/core/interpreter/profile-parameter-validator.test.ts
@@ -436,7 +436,7 @@ describe('ProfileParameterValidator', () => {
       });
     });
 
-    describe('optional fields', () => {
+    describe('optional field', () => {
       const ast = parseProfileFromSource(`
         usecase Test {
           result {
@@ -450,16 +450,20 @@ describe('ProfileParameterValidator', () => {
         parameterValidator = new ProfileParameterValidator(ast);
       });
 
-      it('returns ok for foo not being passed', () => {
+      it('returns ok for foo and bar not being set', () => {
         expect(parameterValidator.validate({}, 'result', 'Test').isOk()).toBeTruthy();
       });
 
-      it('returns ok for foo being undefined', () => {
-        expect(parameterValidator.validate({ foo: undefined }, 'result', 'Test').isOk()).toBeTruthy();
+      it.each([undefined, null, 'value'])('returns ok for bar not set and foo = %p', (value) => {
+        expect(parameterValidator.validate({ foo: value }, 'result', 'Test').isOk()).toBeTruthy();
+      });
+
+      it('returns ok for foo not set and bar = value', () => {
+        expect(parameterValidator.validate({ foo: 'value' }, 'result', 'Test').isOk()).toBeTruthy();
       });
     });
 
-    describe('required fields', () => {
+    describe('required field', () => {
       const ast = parseProfileFromSource(`
         usecase Test {
           result {
@@ -472,16 +476,16 @@ describe('ProfileParameterValidator', () => {
         parameterValidator = new ProfileParameterValidator(ast);
       });
 
+      it.each([undefined, null, 'value'])('returns ok for foo being %p', (value) => {
+        expect(parameterValidator.validate({ foo: value }, 'result', 'Test').isErr()).toBeTruthy();
+      });
+
       it('returns error for foo not being passed', () => {
         expect(parameterValidator.validate({}, 'result', 'Test').isErr()).toBeTruthy();
       });
-
-      it('returns error for foo being undefined', () => {
-        expect(parameterValidator.validate({ foo: undefined }, 'result', 'Test').isErr()).toBeTruthy();
-      });
     });
 
-    describe('nullable fields', () => {
+    describe('optional value', () => {
       const ast = parseProfileFromSource(`
         usecase Test {
           result {
@@ -503,9 +507,13 @@ describe('ProfileParameterValidator', () => {
       it.each(['foo', 'bar', 'baz', 'waf'])('returns ok for %s being null', (fieldName) => {
         expect(parameterValidator.validate({ [fieldName]: null }, 'result', 'Test').isOk()).toBeTruthy();
       });
+
+      it.each(['foo', 'bar', 'baz', 'waf'])('returns ok for %s being undefined', (fieldName) => {
+        expect(parameterValidator.validate({ [fieldName]: undefined }, 'result', 'Test').isOk()).toBeTruthy();
+      });
     });
 
-    describe('non-nullable fields', () => {
+    describe('required value', () => {
       const ast = parseProfileFromSource(`
         usecase Test {
           result {
@@ -524,13 +532,17 @@ describe('ProfileParameterValidator', () => {
         parameterValidator = new ProfileParameterValidator(ast);
       });
 
-      it.each(['foo', 'bar', 'baz', 'waf'])('returns error for %s being null', (fieldName) => {
+      it.each(['foo', 'bar', 'baz', 'waf'])('returns error for %s = undefined', (fieldName) => {
+        expect(parameterValidator.validate({ [fieldName]: undefined }, 'result', 'Test').isErr()).toBeTruthy();
+      });
+
+      it.each(['foo', 'bar', 'baz', 'waf'])('returns error for %s = null', (fieldName) => {
         expect(parameterValidator.validate({ [fieldName]: null }, 'result', 'Test').isErr()).toBeTruthy();
       });
 
-      it('returns error for null in list', () => {
-        expect(parameterValidator.validate({ bar: [null] }, 'result', 'Test').isErr()).toBeTruthy();
-      })
+      it.each([undefined, null])('returns error for %p in bar\'s value', (value) => {
+        expect(parameterValidator.validate({ bar: [value] }, 'result', 'Test').isErr()).toBeTruthy();
+      });
     });
 
     describe('extraneous fields', () => {

--- a/src/core/interpreter/profile-parameter-validator.test.ts
+++ b/src/core/interpreter/profile-parameter-validator.test.ts
@@ -40,32 +40,6 @@ describe('ProfileParameterValidator', () => {
   let parameterValidator: ProfileParameterValidator;
 
   describe('.validate()', () => {
-    /*
-    - primitives: boolean, number, string ✓
-    - enum ✓
-    - object ✓
-    - nested object ✓
-    - list ✓
-    - named fields ✓
-    - named models ✓
-    - named model with named fields ✓
-    - alias ✓
-    - union ✓
-    - untyped fields
-    - optional fields ✓
-    - required fields ✓
-    - nullable fields ✓
-    - non-nullable fields ✓
-    - extraneous fields ✓
-    - input validations ✓
-    - result validations ✓
-      - primitive results ✓
-      - nullable results ✓
-      - non-nullable results ✓
-    - input validation error ✓
-    - result validation error ✓
-    */
-
     describe('primitives', () => {
       const ast = parseProfileFromSource(`
         usecase Test {
@@ -467,6 +441,7 @@ describe('ProfileParameterValidator', () => {
         usecase Test {
           result {
             foo string
+            bar string!
           }
         }
       `);
@@ -757,7 +732,6 @@ describe('ProfileParameterValidator', () => {
 
         expect(result.isErr() && result.error).toBeInstanceOf(ResultValidationError);
       });
-
 
       describe('for wrong type', () => {
         let result: Result<undefined, ProfileParameterError | UnexpectedError>;

--- a/src/core/interpreter/profile-parameter-validator.test.ts
+++ b/src/core/interpreter/profile-parameter-validator.test.ts
@@ -636,16 +636,8 @@ describe('ProfileParameterValidator', () => {
           parameterValidator = new ProfileParameterValidator(ast);
         });
 
-        it('returns ok for `OK` as result', () => {
-          expect(parameterValidator.validate('OK', 'result', 'Test').isOk()).toBeTruthy();
-        });
-
-        it('returns ok for `null` as result', () => {
-          expect(parameterValidator.validate(null, 'result', 'Test').isOk()).toBeTruthy();
-        });
-
-        it('returns error for `undefined` as result', () => {
-          expect(parameterValidator.validate(undefined, 'result', 'Test').isErr()).toBeTruthy();
+        it.each(['OK', undefined, null])('returns ok for %p as result', (value) => {
+          expect(parameterValidator.validate(value, 'result', 'Test').isOk()).toBeTruthy();
         });
       });
 
@@ -691,7 +683,7 @@ describe('ProfileParameterValidator', () => {
         });
       });
 
-      describe('non-nullable', () => {
+      describe('required value', () => {
         const ast = parseProfileFromSource(`
           usecase Test {
             result string!
@@ -702,8 +694,8 @@ describe('ProfileParameterValidator', () => {
           parameterValidator = new ProfileParameterValidator(ast);
         });
 
-        it('returns error for `null` as result', () => {
-          expect(parameterValidator.validate(null, 'result', 'Test').isErr()).toBeTruthy();
+        it.each([undefined, null])('returns error for %p as result', (value) => {
+          expect(parameterValidator.validate(value, 'result', 'Test').isErr()).toBeTruthy();
         });
       });
     });

--- a/src/core/interpreter/profile-parameter-validator.test.ts
+++ b/src/core/interpreter/profile-parameter-validator.test.ts
@@ -652,12 +652,8 @@ describe('ProfileParameterValidator', () => {
           parameterValidator = new ProfileParameterValidator(ast);
         });
 
-        it.each([null, [], ['value']])('returns ok for `%p` as result', (value) => {
+        it.each([undefined, null, [], ['value']])('returns ok for `%p` as result', (value) => {
           expect(parameterValidator.validate(value, 'result', 'Test').isOk()).toBeTruthy();
-        });
-
-        it('returns error for `undefined` as result', () => {
-          expect(parameterValidator.validate(undefined, 'result', 'Test').isErr()).toBeTruthy();
         });
       });
 
@@ -674,12 +670,8 @@ describe('ProfileParameterValidator', () => {
           parameterValidator = new ProfileParameterValidator(ast);
         });
 
-        it.each([null, {}, { foo: 'value' }])('returns ok for `%p` as result', (value) => {
+        it.each([undefined, null, {}, { foo: 'value' }])('returns ok for `%p` as result', (value) => {
           expect(parameterValidator.validate(value, 'result', 'Test').isOk()).toBeTruthy();
-        });
-
-        it('returns error for `undefined` as result', () => {
-          expect(parameterValidator.validate(undefined, 'result', 'Test').isErr()).toBeTruthy();
         });
       });
 

--- a/src/core/interpreter/profile-parameter-validator.test.ts
+++ b/src/core/interpreter/profile-parameter-validator.test.ts
@@ -608,7 +608,7 @@ describe('ProfileParameterValidator', () => {
       describe('primitive', () => {
         const ast = parseProfileFromSource(`
           usecase Test {
-            result string!
+            result string
           }
         `);
 
@@ -616,11 +616,11 @@ describe('ProfileParameterValidator', () => {
           parameterValidator = new ProfileParameterValidator(ast);
         });
 
-        it("returns ok for `'value'` as result", () => {
-          expect(parameterValidator.validate('value', 'result', 'Test').isOk()).toBeTruthy();
+        it.each([null, undefined, 'value'])('returns ok for %p as result', (value) => {
+          expect(parameterValidator.validate(value, 'result', 'Test').isOk()).toBeTruthy();
         });
 
-        it.each([null, undefined, 1, true, {}])('returns error for `%p` as result', (value) => {
+        it.each([1, true, {}])('returns error for `%p` as result', (value) => {
           expect(parameterValidator.validate(value, 'result', 'Test').isErr()).toBeTruthy();
         });
       });

--- a/src/core/interpreter/profile-parameter-validator.test.ts
+++ b/src/core/interpreter/profile-parameter-validator.test.ts
@@ -480,7 +480,7 @@ describe('ProfileParameterValidator', () => {
         expect(parameterValidator.validate({ foo: value }, 'result', 'Test').isErr()).toBeTruthy();
       });
 
-      it('returns error for foo not being passed', () => {
+      it('returns error for foo not being set', () => {
         expect(parameterValidator.validate({}, 'result', 'Test').isErr()).toBeTruthy();
       });
     });
@@ -558,7 +558,7 @@ describe('ProfileParameterValidator', () => {
         parameterValidator = new ProfileParameterValidator(ast);
       });
 
-      it('returns ok for passed extra field', () => {
+      it('returns ok for set extra field', () => {
         expect(parameterValidator.validate({ foo: 'value', bar: 1 }, 'result', 'Test').isOk()).toBeTruthy();
       });
 

--- a/src/core/interpreter/profile-parameter-validator.test.ts
+++ b/src/core/interpreter/profile-parameter-validator.test.ts
@@ -383,7 +383,6 @@ describe('ProfileParameterValidator', () => {
       it('returns ok for valid object in bar', () => {
         expect(parameterValidator.validate({ bar: { foo: 'value' } }, 'result', 'Test').isOk()).toBeTruthy();
         expect(parameterValidator.validate({ bar: { foo: 1, bar: 'value' } }, 'result', 'Test').isOk()).toBeTruthy();
-        expect(parameterValidator.validate({ bar: { foo: 'value', bar: 'value' } }, 'result', 'Test').isOk()).toBeTruthy();
       });
 
       it('returns ok for boolean in baz', () => {
@@ -408,6 +407,7 @@ describe('ProfileParameterValidator', () => {
 
       it('returns error for invalid value in bar', () => {
         expect(parameterValidator.validate({ bar: { foo: true } }, 'result', 'Test').isErr()).toBeTruthy();
+        expect(parameterValidator.validate({ bar: { foo: 'value', bar: 'value' } }, 'result', 'Test').isErr()).toBeTruthy();
       });
 
       it('returns error for invalid value in baz', () => {

--- a/src/core/interpreter/profile-parameter-validator.ts
+++ b/src/core/interpreter/profile-parameter-validator.ts
@@ -265,23 +265,25 @@ export class ProfileParameterValidator implements ProfileVisitor {
     usecase: string
   ): ValidationFunction {
     return (input: unknown): ValidationResult => {
-      const field = objectHasKey(input, node.fieldName)
-        ? input[node.fieldName]
-        : undefined;
+      if (objectHasKey(input, node.fieldName)) {
+        const fieldValue = objectHasKey(input, node.fieldName) ? input[node.fieldName] : undefined;
 
-      if (!node.type) {
+        if (node.type) {
+          return this.visit(node.type, kind, usecase)(fieldValue);
+        }
+
         if (this.namedFieldDefinitions[node.fieldName] !== undefined) {
-          return this.namedFieldDefinitions[node.fieldName](field);
+          return this.namedFieldDefinitions[node.fieldName](fieldValue);
         }
 
         return [true];
       }
 
-      if (node.required && field === undefined) {
+      if (node.required) {
         return [false, [{ kind: 'missingRequired' }]];
+      } else {
+        return [true];
       }
-
-      return this.visit(node.type, kind, usecase)(field);
     };
   }
 

--- a/src/core/interpreter/profile-parameter-validator.ts
+++ b/src/core/interpreter/profile-parameter-validator.ts
@@ -1,6 +1,7 @@
 import type {
   ComlinkAssignmentNode,
   ComlinkListLiteralNode,
+  ComlinkNoneLiteralNode,
   ComlinkObjectLiteralNode,
   ComlinkPrimitiveLiteralNode,
   EnumDefinitionNode,
@@ -150,6 +151,8 @@ export class ProfileParameterValidator implements ProfileVisitor {
         return this.visitComlinkObjectLiteralNode(node, kind, usecase);
       case 'ComlinkPrimitiveLiteral':
         return this.visitComlinkPrimitiveLiteralNode(node, kind, usecase);
+      case 'ComlinkNoneLiteral':
+        return this.visitComlinkNoneLiteralNode(node, kind, usecase);
       case 'ComlinkAssignment':
         return this.visitComlinkAssignmentNode(node, kind, usecase);
       case 'EnumDefinition':
@@ -208,6 +211,14 @@ export class ProfileParameterValidator implements ProfileVisitor {
 
   public visitComlinkPrimitiveLiteralNode(
     _node: ComlinkPrimitiveLiteralNode,
+    _kind: ProfileParameterKind,
+    _usecase: string
+  ): never {
+    throw new UnexpectedError('Method not implemented.');
+  }
+
+  public visitComlinkNoneLiteralNode(
+    _node: ComlinkNoneLiteralNode,
     _kind: ProfileParameterKind,
     _usecase: string
   ): never {

--- a/src/core/interpreter/profile-parameter-validator.ts
+++ b/src/core/interpreter/profile-parameter-validator.ts
@@ -33,7 +33,7 @@ import type {
   ProfileParameterError,
 } from '../../interfaces';
 import type { Result } from '../../lib';
-import { err, ok, UnexpectedError } from '../../lib';
+import { err, isNone, ok, UnexpectedError } from '../../lib';
 import type { ProfileVisitor } from './interfaces';
 import type { ValidationError } from './profile-parameter-validator.errors';
 import {
@@ -228,7 +228,7 @@ export class ProfileParameterValidator implements ProfileVisitor {
     usecase: string
   ): ValidationFunction {
     return (input: unknown): ValidationResult => {
-      if (input === undefined || input === null) {
+      if (isNone(input)) {
         return [true];
       }
 
@@ -291,7 +291,7 @@ export class ProfileParameterValidator implements ProfileVisitor {
     usecase: string
   ): ValidationFunction {
     return (input: unknown): ValidationResult => {
-      if (input === undefined) {
+      if (isNone(input)) {
         return [true];
       }
 
@@ -369,7 +369,7 @@ export class ProfileParameterValidator implements ProfileVisitor {
     usecase: string
   ): ValidationFunction {
     return (input: unknown): ValidationResult => {
-      if (input === null) {
+      if (isNone(input)) {
         return [false, [{ kind: 'nullInNonNullable' }]];
       }
 
@@ -383,11 +383,11 @@ export class ProfileParameterValidator implements ProfileVisitor {
     usecase: string
   ): ValidationFunction {
     return (input: unknown): ValidationResult => {
-      if (input === undefined) {
+      if (isNone(input)) {
         return [true];
       }
 
-      if (typeof input !== 'object' || input === null) {
+      if (typeof input !== 'object') {
         return [
           false,
           [
@@ -433,7 +433,7 @@ export class ProfileParameterValidator implements ProfileVisitor {
     _usecase: string
   ): ValidationFunction {
     return (input: unknown): ValidationResult => {
-      if (input === undefined || input === null) {
+      if (isNone(input)) {
         return [true];
       }
 

--- a/src/core/interpreter/profile-parameter-validator.ts
+++ b/src/core/interpreter/profile-parameter-validator.ts
@@ -266,7 +266,9 @@ export class ProfileParameterValidator implements ProfileVisitor {
   ): ValidationFunction {
     return (input: unknown): ValidationResult => {
       if (objectHasKey(input, node.fieldName)) {
-        const fieldValue = objectHasKey(input, node.fieldName) ? input[node.fieldName] : undefined;
+        const fieldValue = objectHasKey(input, node.fieldName)
+          ? input[node.fieldName]
+          : undefined;
 
         if (node.type) {
           return this.visit(node.type, kind, usecase)(fieldValue);

--- a/src/core/interpreter/profile-parameter-validator.ts
+++ b/src/core/interpreter/profile-parameter-validator.ts
@@ -570,7 +570,9 @@ export class ProfileParameterValidator implements ProfileVisitor {
   ): ValidationFunction {
     if (kind === 'input' && node.input) {
       return addPath(this.visit(node.input.value, kind, usecase), 'input');
-    } else if (kind === 'result' && node.result) {
+    }
+
+    if (kind === 'result' && node.result) {
       return addPath(this.visit(node.result.value, kind, usecase), 'result');
     }
 

--- a/src/core/profile-provider/bound-profile-provider.ts
+++ b/src/core/profile-provider/bound-profile-provider.ts
@@ -18,7 +18,7 @@ import type {
   NonPrimitive,
   Result,
   SDKExecutionError,
-  UnexpectedError,
+  UnexpectedError
 } from '../../lib';
 import {
   castToNonPrimitive,
@@ -136,10 +136,10 @@ export class BoundProfileProvider implements IBoundProfileProvider {
 
     const security = securityValues
       ? resolveSecurityConfiguration(
-          this.provider.securitySchemes ?? [],
-          securityValues,
-          this.provider.name
-        )
+        this.provider.securitySchemes ?? [],
+        securityValues,
+        this.provider.name
+      )
       : this.configuration.security;
 
     // create and perform interpreter instance
@@ -192,11 +192,9 @@ export class BoundProfileProvider implements IBoundProfileProvider {
   ): NonPrimitive | undefined {
     let composed = input;
 
-    const defaultInput = castToNonPrimitive(
-      this.configuration.profileProviderSettings?.defaults[usecase]?.input
-    );
+    const defaultInput = this.configuration.profileProviderSettings?.defaults[usecase]?.input;
     if (defaultInput !== undefined) {
-      composed = mergeVariables(defaultInput, input ?? {});
+      composed = mergeVariables(castToNonPrimitive(defaultInput), input ?? {});
       this.logSensitive?.('Composed input with defaults: %O', composed);
     }
 

--- a/src/core/profile-provider/bound-profile-provider.ts
+++ b/src/core/profile-provider/bound-profile-provider.ts
@@ -18,7 +18,7 @@ import type {
   NonPrimitive,
   Result,
   SDKExecutionError,
-  UnexpectedError
+  UnexpectedError,
 } from '../../lib';
 import {
   castToNonPrimitive,
@@ -136,10 +136,10 @@ export class BoundProfileProvider implements IBoundProfileProvider {
 
     const security = securityValues
       ? resolveSecurityConfiguration(
-        this.provider.securitySchemes ?? [],
-        securityValues,
-        this.provider.name
-      )
+          this.provider.securitySchemes ?? [],
+          securityValues,
+          this.provider.name
+        )
       : this.configuration.security;
 
     // create and perform interpreter instance
@@ -192,7 +192,8 @@ export class BoundProfileProvider implements IBoundProfileProvider {
   ): NonPrimitive | undefined {
     let composed = input;
 
-    const defaultInput = this.configuration.profileProviderSettings?.defaults[usecase]?.input;
+    const defaultInput =
+      this.configuration.profileProviderSettings?.defaults[usecase]?.input;
     if (defaultInput !== undefined) {
       composed = mergeVariables(castToNonPrimitive(defaultInput), input ?? {});
       this.logSensitive?.('Composed input with defaults: %O', composed);

--- a/src/core/registry/registry.test.ts
+++ b/src/core/registry/registry.test.ts
@@ -179,7 +179,7 @@ describe('registry', () => {
       expect(request).toHaveBeenCalledTimes(1);
       expect(request).toHaveBeenCalledWith('/providers/test', {
         method: 'GET',
-        headers: [`Authorization: SUPERFACE-SDK-TOKEN ${TEST_SDK_TOKEN}`],
+        headers: { Authorization: `SUPERFACE-SDK-TOKEN ${TEST_SDK_TOKEN}` },
         baseUrl: TEST_REGISTRY_URL,
         accept: 'application/json',
         contentType: 'application/json',
@@ -297,7 +297,7 @@ describe('registry', () => {
       expect(request).toHaveBeenCalledTimes(1);
       expect(request).toHaveBeenCalledWith('/registry/bind', {
         method: 'POST',
-        headers: [`Authorization: SUPERFACE-SDK-TOKEN ${TEST_SDK_TOKEN}`],
+        headers: { Authorization: `SUPERFACE-SDK-TOKEN ${TEST_SDK_TOKEN}` },
         baseUrl: TEST_REGISTRY_URL,
         accept: 'application/json',
         contentType: 'application/json',
@@ -353,7 +353,7 @@ describe('registry', () => {
         baseUrl: TEST_REGISTRY_URL,
         accept: 'application/json',
         contentType: 'application/json',
-        headers: [`Authorization: SUPERFACE-SDK-TOKEN ${MOCK_TOKEN}`],
+        headers: { Authorization: `SUPERFACE-SDK-TOKEN ${MOCK_TOKEN}` },
         body: {
           profile_id: 'test-profile-id',
           provider: 'test-provider',
@@ -618,7 +618,7 @@ describe('registry', () => {
         method: 'GET',
         baseUrl: TEST_REGISTRY_URL,
         accept: 'application/vnd.superface.profile+json',
-        headers: [`Authorization: SUPERFACE-SDK-TOKEN ${TEST_SDK_TOKEN}`],
+        headers: { Authorization: `SUPERFACE-SDK-TOKEN ${TEST_SDK_TOKEN}` },
       });
     });
 
@@ -647,7 +647,7 @@ describe('registry', () => {
         method: 'GET',
         baseUrl: TEST_REGISTRY_URL,
         accept: 'application/vnd.superface.profile+json',
-        headers: [`Authorization: SUPERFACE-SDK-TOKEN ${TEST_SDK_TOKEN}`],
+        headers: { Authorization: `SUPERFACE-SDK-TOKEN ${TEST_SDK_TOKEN}` },
       });
     });
 
@@ -681,7 +681,7 @@ describe('registry', () => {
         method: 'GET',
         baseUrl: TEST_REGISTRY_URL,
         accept: 'application/vnd.superface.profile+json',
-        headers: [`Authorization: SUPERFACE-SDK-TOKEN ${TEST_SDK_TOKEN}`],
+        headers: { Authorization: `SUPERFACE-SDK-TOKEN ${TEST_SDK_TOKEN}` },
       });
     });
   });
@@ -722,7 +722,7 @@ describe('registry', () => {
         method: 'GET',
         baseUrl: TEST_REGISTRY_URL,
         accept: 'application/vnd.superface.map+json',
-        headers: [`Authorization: SUPERFACE-SDK-TOKEN ${TEST_SDK_TOKEN}`],
+        headers: { Authorization: `SUPERFACE-SDK-TOKEN ${TEST_SDK_TOKEN}` },
       });
     });
 
@@ -753,7 +753,7 @@ describe('registry', () => {
         method: 'GET',
         baseUrl: TEST_REGISTRY_URL,
         accept: 'application/vnd.superface.map+json',
-        headers: [`Authorization: SUPERFACE-SDK-TOKEN ${TEST_SDK_TOKEN}`],
+        headers: { Authorization: `SUPERFACE-SDK-TOKEN ${TEST_SDK_TOKEN}` },
       });
     });
   });

--- a/src/core/registry/registry.ts
+++ b/src/core/registry/registry.ts
@@ -117,7 +117,7 @@ export async function fetchProviderInfo(
       method: 'GET',
       headers:
         sdkToken !== undefined
-          ? [`Authorization: SUPERFACE-SDK-TOKEN ${sdkToken}`]
+          ? { Authorization: `SUPERFACE-SDK-TOKEN ${sdkToken}` }
           : undefined,
       baseUrl: config.superfaceApiUrl,
       accept: 'application/json',
@@ -248,7 +248,7 @@ export async function fetchBind(
     method: 'POST',
     headers:
       sdkToken !== undefined
-        ? [`Authorization: SUPERFACE-SDK-TOKEN ${sdkToken}`]
+        ? { 'Authorization': `SUPERFACE-SDK-TOKEN ${sdkToken}` }
         : undefined,
     baseUrl: config.superfaceApiUrl,
     accept: 'application/json',
@@ -282,7 +282,7 @@ export async function fetchProfileAst(
     method: 'GET',
     headers:
       sdkToken !== undefined
-        ? [`Authorization: SUPERFACE-SDK-TOKEN ${sdkToken}`]
+        ? { Authorization: `SUPERFACE-SDK-TOKEN ${sdkToken}` }
         : undefined,
     baseUrl: config.superfaceApiUrl,
     accept: 'application/vnd.superface.profile+json',
@@ -310,7 +310,7 @@ export async function fetchMapAST(
     method: 'GET',
     headers:
       sdkToken !== undefined
-        ? [`Authorization: SUPERFACE-SDK-TOKEN ${sdkToken}`]
+        ? { Authorization: `SUPERFACE-SDK-TOKEN ${sdkToken}` }
         : undefined,
     baseUrl: config.superfaceApiUrl,
     accept: 'application/vnd.superface.map+json',

--- a/src/core/registry/registry.ts
+++ b/src/core/registry/registry.ts
@@ -248,7 +248,7 @@ export async function fetchBind(
     method: 'POST',
     headers:
       sdkToken !== undefined
-        ? { 'Authorization': `SUPERFACE-SDK-TOKEN ${sdkToken}` }
+        ? { Authorization: `SUPERFACE-SDK-TOKEN ${sdkToken}` }
         : undefined,
     baseUrl: config.superfaceApiUrl,
     accept: 'application/json',

--- a/src/interfaces/errors/map-interpreter.errors.ts
+++ b/src/interfaces/errors/map-interpreter.errors.ts
@@ -1,5 +1,7 @@
 import type { MapASTNode, MapDocumentNode } from '@superfaceai/ast';
 
+import type { HttpMultiMap } from '../../core/interpreter/http';
+
 export interface ErrorMetadata {
   node?: MapASTNode;
   ast?: MapDocumentNode;
@@ -27,12 +29,12 @@ export interface IHTTPError extends Error {
   statusCode?: number;
   request?: {
     body?: unknown;
-    headers?: Record<string, string>;
+    headers?: HttpMultiMap;
     url?: string;
   };
   response?: {
     body?: unknown;
-    headers?: Record<string, string>;
+    headers?: HttpMultiMap;
   };
 }
 

--- a/src/lib/object/object.test.ts
+++ b/src/lib/object/object.test.ts
@@ -8,7 +8,7 @@ describe('recursiveKeyList', () => {
       nope: undefined,
     };
 
-    expect(recursiveKeyList(object).sort()).toMatchObject(['2', 'a']);
+    expect(recursiveKeyList(object).sort()).toMatchObject(['2', 'a', 'nope']);
   });
 
   it('should return all objects keys from a nested object', () => {
@@ -25,7 +25,7 @@ describe('recursiveKeyList', () => {
       },
     };
 
-    expect(recursiveKeyList(object).sort()).toMatchObject([
+    expect(recursiveKeyList(object, v => v !== undefined).sort()).toMatchObject([
       'a',
       'b',
       'b.c',

--- a/src/lib/object/object.test.ts
+++ b/src/lib/object/object.test.ts
@@ -25,14 +25,9 @@ describe('recursiveKeyList', () => {
       },
     };
 
-    expect(recursiveKeyList(object, v => v !== undefined).sort()).toMatchObject([
-      'a',
-      'b',
-      'b.c',
-      'b.c.d',
-      'b.c.d.e',
-      'b.c.f',
-    ]);
+    expect(recursiveKeyList(object, v => v !== undefined).sort()).toMatchObject(
+      ['a', 'b', 'b.c', 'b.c.d', 'b.c.d.e', 'b.c.f']
+    );
   });
 });
 

--- a/src/lib/object/object.ts
+++ b/src/lib/object/object.ts
@@ -1,5 +1,6 @@
 import { UnexpectedError } from '../error';
-import { isClassInstance } from '../variables';
+import type { None } from '../variables';
+import { isClassInstance, isNone } from '../variables';
 
 /**
  * Creates a deep clone of the value.
@@ -50,17 +51,30 @@ export function isRecord(input: unknown): input is Record<string, unknown> {
   return true;
 }
 
+export function fromEntriesOptional<T extends Exclude<unknown, None>>(...entries: [key: string, value: T | None][]): Record<string, T> {
+  const base: Record<string, T> = {};
+
+  for (const [key, value] of entries) {
+    if (!isNone(value)) {
+      base[key] = value;
+    }
+  }
+
+  return base;
+}
+
 /**
  * Recursively descends the record and returns a list of enumerable keys
  */
 export function recursiveKeyList(
   record: Record<string, unknown>,
+  filter?: (value: unknown) => boolean,
   base?: string
 ): string[] {
   const keys: string[] = [];
 
   for (const [key, value] of Object.entries(record)) {
-    if (value === undefined) {
+    if (filter !== undefined && !filter(value)) {
       continue;
     }
 
@@ -72,7 +86,7 @@ export function recursiveKeyList(
 
     if (typeof value === 'object' && value !== null) {
       keys.push(
-        ...recursiveKeyList(value as Record<string, unknown>, basedKey)
+        ...recursiveKeyList(value as Record<string, unknown>, filter, basedKey)
       );
     }
   }

--- a/src/lib/object/object.ts
+++ b/src/lib/object/object.ts
@@ -51,7 +51,9 @@ export function isRecord(input: unknown): input is Record<string, unknown> {
   return true;
 }
 
-export function fromEntriesOptional<T extends Exclude<unknown, None>>(...entries: [key: string, value: T | None][]): Record<string, T> {
+export function fromEntriesOptional<T extends Exclude<unknown, None>>(
+  ...entries: [key: string, value: T | None][]
+): Record<string, T> {
   const base: Record<string, T> = {};
 
   for (const [key, value] of entries) {

--- a/src/lib/variables/variables.test.ts
+++ b/src/lib/variables/variables.test.ts
@@ -1,6 +1,5 @@
 import type { NonPrimitive } from './variables';
 import {
-  getValue,
   isEmptyRecord,
   isNone,
   isNonPrimitive,
@@ -130,47 +129,6 @@ describe('Variables', () => {
 
         expect(result).toEqual({ overwritten: ['seven'] });
       }
-    });
-  });
-
-  describe('getValue', () => {
-    it('gets values correctly', () => {
-      const variables: NonPrimitive = {
-        some: {
-          deeply: {
-            nested: {
-              value: 42,
-            },
-          },
-          other: {
-            stuff: 666,
-          },
-        },
-      };
-      expect(
-        getValue(variables, ['some', 'deeply', 'nested', 'value'])
-      ).toEqual(42);
-      expect(getValue(variables, ['some', 'other', 'stuff'])).toEqual(666);
-      expect(getValue(variables, ['some', 'other'])).toEqual({ stuff: 666 });
-    });
-
-    it('should return undefined when the value is not present', () => {
-      const variables: NonPrimitive = {
-        some: {
-          deeply: {
-            nested: {
-              value: 42,
-            },
-          },
-          other: {
-            stuff: 666,
-          },
-        },
-      };
-      expect(getValue(variables, [])).toBeUndefined();
-      expect(
-        getValue(variables, ['some', 'nonexistant', 'stuff'])
-      ).toBeUndefined();
     });
   });
 

--- a/src/lib/variables/variables.test.ts
+++ b/src/lib/variables/variables.test.ts
@@ -1,42 +1,66 @@
 import type { NonPrimitive } from './variables';
 import {
-  assertIsVariables,
   getValue,
+  isEmptyRecord,
+  isNone,
   isNonPrimitive,
   isPrimitive,
   mergeVariables,
   variablesToStrings,
+  variableToString,
 } from './variables';
 
 describe('Variables', () => {
-  test('assertIsVariables works correctly', () => {
-    expect(() => assertIsVariables('string')).not.toThrow();
-    expect(() => assertIsVariables(123)).not.toThrow();
-    expect(() => assertIsVariables({ x: 1 })).not.toThrow();
-    expect(() => assertIsVariables(true)).not.toThrow();
-    expect(() => assertIsVariables(undefined)).not.toThrow();
-    expect(() => assertIsVariables(['heeelo'])).not.toThrow();
-    expect(() => assertIsVariables(() => 'boom!')).toThrow();
+  describe('isNone', () => {
+    it.each([undefined, null])('returns true for %p', (input) => {
+      expect(isNone(input)).toBe(true);
+    });
+
+    it.each([0, 1, '', Buffer.alloc(0)])('returns false for %p', (input) => {
+      expect(isNone(input)).toBe(false);
+    });
   });
 
-  test('isPrimitive works correctly', () => {
-    expect(isPrimitive('string')).toBe(true);
-    expect(isPrimitive(123)).toBe(true);
-    expect(isPrimitive(false)).toBe(true);
-    expect(isPrimitive(['heeeelo'])).toBe(true);
-    expect(isPrimitive({ x: 1 })).toBe(false);
+  describe('isPrimitive', () => {
+    it.each([
+      'string', 123, false, ['heeeelo'], null, undefined,
+    ])('returns true for %p', (input) => {
+      expect(isPrimitive(input)).toBe(true);
+    });
+
+    it.each([
+      { x: 1 }
+    ])('returns false for %p', (input) => {
+      expect(isPrimitive(input)).toBe(false);
+    });
   });
 
-  test('isNonPrimitive works correctly', () => {
-    expect(isNonPrimitive('string')).toBe(false);
-    expect(isNonPrimitive(123)).toBe(false);
-    expect(isNonPrimitive(false)).toBe(false);
-    expect(isNonPrimitive(['heeeelo'])).toBe(false);
-    expect(isNonPrimitive({ x: 1 })).toBe(true);
+  describe('isNonPrimitive', () => {
+    it.each([
+      'string', 123, false, ['heeeelo']
+    ])('returns false for %p', (input) => {
+      expect(isNonPrimitive(input)).toBe(false);
+    });
+
+    it.each([
+      { x: 1 }
+    ])('returns true for %p', (input) => {
+      expect(isNonPrimitive(input)).toBe(true);
+    });
   });
+
+  describe('isEmptyRecord', () => {
+    it('returns true for {}', () => {
+      expect(isEmptyRecord({})).toBe(true);
+    });
+
+    it('returns false fror { a: 1 }', () => {
+      expect(isEmptyRecord({ a: 1 })).toBe(false);
+    });
+  })
 
   describe('mergeVariables', () => {
-    it('should correctly merge two simple objects', () => {
+    it('merges two simple objects', () => {
       {
         const left = {};
         const right = { x: 1 };
@@ -60,7 +84,7 @@ describe('Variables', () => {
       }
     });
 
-    it('should correctly merge complex objects', () => {
+    it('merges complex objects', () => {
       {
         const left = {};
         const right = { ne: { st: 'ed' } };
@@ -84,7 +108,7 @@ describe('Variables', () => {
       }
     });
 
-    it('should overwrite from left to right', () => {
+    it('overwrites from left to right', () => {
       {
         const left = { overwritten: false };
         const right = { overwritten: true };
@@ -110,7 +134,7 @@ describe('Variables', () => {
   });
 
   describe('getValue', () => {
-    it('should get values correctly', () => {
+    it('gets values correctly', () => {
       const variables: NonPrimitive = {
         some: {
           deeply: {
@@ -147,18 +171,34 @@ describe('Variables', () => {
       expect(
         getValue(variables, ['some', 'nonexistant', 'stuff'])
       ).toBeUndefined();
-      expect(getValue(undefined, ['some', 'stuff'])).toBeUndefined();
     });
   });
 
-  describe('valuesToStrings', () => {
-    it('should correctly stringify values', () => {
+  describe('variableToString', () => {
+    it.each([
+      ['1', 1],
+      ['undefined', undefined],
+      ['null', null],
+      ['false', false,],
+    ])('returns %p for %p', (result, input) => {
+      expect(variableToString(input)).toBe(result);
+    });
+
+    it('returns stringified Buffer', () => {
+      expect(variableToString(Buffer.from('123'))).toBe('123');
+    })
+  });
+
+  describe('variablesToStrings', () => {
+    it('stringifies values', () => {
       const variables: NonPrimitive = {
         some: 'value',
         and: 17,
         not: undefined,
+        soNot: null,
         array: ['some', 'array'],
       };
+
       expect(variablesToStrings(variables)).toEqual({
         some: 'value',
         and: '17',

--- a/src/lib/variables/variables.test.ts
+++ b/src/lib/variables/variables.test.ts
@@ -37,7 +37,7 @@ describe('Variables', () => {
 
   describe('isNonPrimitive', () => {
     it.each([
-      'string', 123, false, ['heeeelo']
+      'string', 123, false, ['heeeelo'], null
     ])('returns false for %p', (input) => {
       expect(isNonPrimitive(input)).toBe(false);
     });

--- a/src/lib/variables/variables.test.ts
+++ b/src/lib/variables/variables.test.ts
@@ -11,39 +11,37 @@ import {
 
 describe('Variables', () => {
   describe('isNone', () => {
-    it.each([undefined, null])('returns true for %p', (input) => {
+    it.each([undefined, null])('returns true for %p', input => {
       expect(isNone(input)).toBe(true);
     });
 
-    it.each([0, 1, '', Buffer.alloc(0)])('returns false for %p', (input) => {
+    it.each([0, 1, '', Buffer.alloc(0)])('returns false for %p', input => {
       expect(isNone(input)).toBe(false);
     });
   });
 
   describe('isPrimitive', () => {
-    it.each([
-      'string', 123, false, ['heeeelo'], null, undefined,
-    ])('returns true for %p', (input) => {
-      expect(isPrimitive(input)).toBe(true);
-    });
+    it.each(['string', 123, false, ['heeeelo'], null, undefined])(
+      'returns true for %p',
+      input => {
+        expect(isPrimitive(input)).toBe(true);
+      }
+    );
 
-    it.each([
-      { x: 1 }
-    ])('returns false for %p', (input) => {
+    it.each([{ x: 1 }])('returns false for %p', input => {
       expect(isPrimitive(input)).toBe(false);
     });
   });
 
   describe('isNonPrimitive', () => {
-    it.each([
-      'string', 123, false, ['heeeelo'], null
-    ])('returns false for %p', (input) => {
-      expect(isNonPrimitive(input)).toBe(false);
-    });
+    it.each(['string', 123, false, ['heeeelo'], null])(
+      'returns false for %p',
+      input => {
+        expect(isNonPrimitive(input)).toBe(false);
+      }
+    );
 
-    it.each([
-      { x: 1 }
-    ])('returns true for %p', (input) => {
+    it.each([{ x: 1 }])('returns true for %p', input => {
       expect(isNonPrimitive(input)).toBe(true);
     });
   });
@@ -56,7 +54,7 @@ describe('Variables', () => {
     it('returns false fror { a: 1 }', () => {
       expect(isEmptyRecord({ a: 1 })).toBe(false);
     });
-  })
+  });
 
   describe('mergeVariables', () => {
     it('merges two simple objects', () => {
@@ -137,7 +135,7 @@ describe('Variables', () => {
       ['1', 1],
       ['undefined', undefined],
       ['null', null],
-      ['false', false,],
+      ['false', false],
     ])('returns %p for %p', (result, input) => {
       expect(variableToString(input)).toBe(result);
     });

--- a/src/lib/variables/variables.test.ts
+++ b/src/lib/variables/variables.test.ts
@@ -144,7 +144,7 @@ describe('Variables', () => {
 
     it('returns stringified Buffer', () => {
       expect(variableToString(Buffer.from('123'))).toBe('123');
-    })
+    });
   });
 
   describe('variablesToStrings', () => {

--- a/src/lib/variables/variables.ts
+++ b/src/lib/variables/variables.ts
@@ -61,9 +61,7 @@ export function isEmptyRecord(
   return isNonPrimitive(input) && Object.keys(input).length === 0;
 }
 
-export function assertIsVariables(
-  input: unknown
-): asserts input is Variables {
+export function assertIsVariables(input: unknown): asserts input is Variables {
   if (!isVariables(input)) {
     throw new UnexpectedError(`Invalid result type: ${typeof input}`);
   }

--- a/src/lib/variables/variables.ts
+++ b/src/lib/variables/variables.ts
@@ -1,7 +1,6 @@
 import type { IBinaryData } from '../../interfaces';
 import { isBinaryData } from '../../interfaces';
 import { UnexpectedError } from '../error';
-import { indexRecord } from '../object';
 
 export type None = undefined | null;
 export type Primitive =
@@ -110,28 +109,6 @@ export function mergeVariables(
       result[key] = right[key];
     }
   }
-
-  return result;
-}
-
-export function getValue(
-  variables: NonPrimitive,
-  key: string[]
-): Variables | undefined {
-  if (variables === undefined) {
-    return undefined;
-  }
-
-  let result;
-  try {
-    result = indexRecord(variables, key);
-  } catch (_err) {
-    // return undefined on error to preserve the original behavior of this function
-    return undefined;
-  }
-
-  // sanity check, but if the input `variables` is correct then the result will be also
-  assertIsVariables(result);
 
   return result;
 }

--- a/src/lib/variables/variables.ts
+++ b/src/lib/variables/variables.ts
@@ -44,6 +44,7 @@ export function isPrimitive(input: unknown): input is Primitive {
 export function isNonPrimitive(input: unknown): input is NonPrimitive {
   return (
     typeof input === 'object' &&
+    input !== null &&
     !Array.isArray(input) &&
     !isBinaryData(input) &&
     !Buffer.isBuffer(input) &&

--- a/src/lib/variables/variables.ts
+++ b/src/lib/variables/variables.ts
@@ -133,7 +133,7 @@ export function variableToString(variable: Variables): string {
 }
 
 /**
- * Stringifies a Record of variables. `undefined` values are removed.
+ * Stringifies a Record of variables. `None` values are removed.
  */
 export function variablesToStrings(
   variables: NonPrimitive

--- a/src/lib/variables/variables.ts
+++ b/src/lib/variables/variables.ts
@@ -3,16 +3,17 @@ import { isBinaryData } from '../../interfaces';
 import { UnexpectedError } from '../error';
 import { indexRecord } from '../object';
 
-// Arrays should be considered opaque value and therefore act as a primitive, same with
+export type None = undefined | null;
 export type Primitive =
   | string
   | boolean
   | number
-  | unknown[]
+  | unknown[] // Arrays should be considered opaque value and therefore act as a primitive, same with
+  | None
   | IBinaryData
   | Buffer;
 export type NonPrimitive = {
-  [key: string]: Primitive | NonPrimitive | undefined;
+  [key: string]: Primitive | NonPrimitive;
 };
 export type Variables = Primitive | NonPrimitive;
 
@@ -25,72 +26,70 @@ export function isClassInstance(input: unknown): boolean {
   );
 }
 
-export function assertIsVariables(
-  input: unknown
-): asserts input is Variables | undefined {
-  if (
-    !['string', 'number', 'boolean', 'object', 'undefined'].includes(
-      typeof input
-    )
-  ) {
-    throw new UnexpectedError(`Invalid result type: ${typeof input}`);
-  }
+export function isNone(input: unknown): input is None {
+  return input === undefined || input === null;
 }
 
-export function castToVariables(input: unknown): Variables | undefined {
-  assertIsVariables(input);
-
-  return input;
-}
-
-export function castToNonPrimitive(input: unknown): NonPrimitive | undefined {
-  const variables = castToVariables(input);
-  if (variables === undefined) {
-    return undefined;
-  }
-
-  if (!isNonPrimitive(variables)) {
-    throw new UnexpectedError('Input is not NonPrimitive');
-  }
-
-  return variables;
-}
-
-export function isPrimitive(input: Variables): input is Primitive {
+export function isPrimitive(input: unknown): input is Primitive {
   return (
     ['string', 'number', 'boolean'].includes(typeof input) ||
     Array.isArray(input) ||
-    isClassInstance(input) ||
+    isNone(input) ||
+    isBinaryData(input) ||
     Buffer.isBuffer(input) ||
-    isBinaryData(input)
+    isClassInstance(input)
   );
 }
 
-export function isNonPrimitive(input: Variables): input is NonPrimitive {
+export function isNonPrimitive(input: unknown): input is NonPrimitive {
   return (
     typeof input === 'object' &&
     !Array.isArray(input) &&
-    !isClassInstance(input) &&
+    !isBinaryData(input) &&
     !Buffer.isBuffer(input) &&
-    !isBinaryData(input)
+    !isClassInstance(input)
   );
+}
+
+export function isVariables(input: unknown): input is Variables {
+  return isPrimitive(input) || isNonPrimitive(input);
 }
 
 export function isEmptyRecord(
   input: Record<string, unknown>
 ): input is Record<never, never> {
+  return isNonPrimitive(input) && Object.keys(input).length === 0;
+}
+
+export function assertIsVariables(
+  input: unknown
+): asserts input is Variables {
+  if (!isVariables(input)) {
+    throw new UnexpectedError(`Invalid result type: ${typeof input}`);
+  }
+}
+
+export function castToVariables(input: unknown): Variables {
   assertIsVariables(input);
 
-  return isNonPrimitive(input) && Object.keys(input).length === 0;
+  return input;
+}
+
+export function castToNonPrimitive(input: unknown): NonPrimitive {
+  if (!isNonPrimitive(input)) {
+    throw new UnexpectedError('Input is not NonPrimitive');
+  }
+
+  return input;
 }
 
 /**
  * Recursively merges variables from `left` and then from `right` into a new object.
  */
-export const mergeVariables = (
+export function mergeVariables(
   left: NonPrimitive,
   right: NonPrimitive
-): NonPrimitive => {
+): NonPrimitive {
   const result: NonPrimitive = {};
 
   for (const key of Object.keys(left)) {
@@ -112,12 +111,12 @@ export const mergeVariables = (
   }
 
   return result;
-};
+}
 
-export const getValue = (
-  variables: NonPrimitive | undefined,
+export function getValue(
+  variables: NonPrimitive,
   key: string[]
-): Variables | undefined => {
+): Variables | undefined {
   if (variables === undefined) {
     return undefined;
   }
@@ -134,35 +133,42 @@ export const getValue = (
   assertIsVariables(result);
 
   return result;
-};
+}
 
 /**
  * Turns a variable (both primitive and non-primitive) into a string.
  */
-export const variableToString = (variable: Variables): string => {
+export function variableToString(variable: Variables): string {
   if (typeof variable === 'string') {
     return variable;
   }
 
+  if (variable === undefined) {
+    return 'undefined'; // TODO: for both undefined and null, return 'None'?
+  }
+
+  if (Buffer.isBuffer(variable)) {
+    return variable.toString();
+  }
+
   return JSON.stringify(variable);
-};
+}
 
 /**
  * Stringifies a Record of variables. `undefined` values are removed.
  */
-export const variablesToStrings = (
-  variables?: Variables
-): Record<string, string> => {
+export function variablesToStrings(
+  variables: Variables
+): Record<string, string> {
   const result: Record<string, string> = {};
 
-  if (variables !== undefined) {
+  if (!isNone(variables)) {
     for (const [key, value] of Object.entries(variables)) {
-      const variableValue = castToVariables(value);
-      if (variableValue !== undefined) {
-        result[key] = variableToString(variableValue);
+      if (!isNone(value)) {
+        result[key] = variableToString(value);
       }
     }
   }
 
   return result;
-};
+}

--- a/src/lib/variables/variables.ts
+++ b/src/lib/variables/variables.ts
@@ -120,7 +120,7 @@ export function variableToString(variable: Variables): string {
   }
 
   if (variable === undefined) {
-    return 'undefined'; // TODO: for both undefined and null, return 'None'?
+    return 'undefined';
   }
 
   if (Buffer.isBuffer(variable)) {

--- a/src/lib/variables/variables.ts
+++ b/src/lib/variables/variables.ts
@@ -136,15 +136,13 @@ export function variableToString(variable: Variables): string {
  * Stringifies a Record of variables. `undefined` values are removed.
  */
 export function variablesToStrings(
-  variables: Variables
+  variables: NonPrimitive
 ): Record<string, string> {
   const result: Record<string, string> = {};
 
-  if (!isNone(variables)) {
-    for (const [key, value] of Object.entries(variables)) {
-      if (!isNone(value)) {
-        result[key] = variableToString(value);
-      }
+  for (const [key, value] of Object.entries(variables)) {
+    if (!isNone(value)) {
+      result[key] = variableToString(value);
     }
   }
 

--- a/src/node/fetch/fetch.node.test.ts
+++ b/src/node/fetch/fetch.node.test.ts
@@ -8,19 +8,15 @@ import { MockTimers } from '../../mock';
 import { NodeTimers } from '../timers';
 import { NodeFetch } from './fetch.node';
 
-// Maybe this can be done better?
-// The issue here is that we need to mock the default export (fetch) while
-// preserving everything as as actual implementation.
 jest.mock('node-fetch', () => {
-  const actual = jest.requireActual('node-fetch');
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const actual = jest.requireActual<typeof import('node-fetch')>('node-fetch');
 
-  const base: any = jest.fn();
-  for (const [key, value] of Object.entries(actual)) {
-    base[key] = value;
-  }
-  base['default'] = base;
-
-  return base as unknown;
+  return {
+    __esModule: true,
+    ...actual,
+    default: jest.fn(),
+  };
 });
 
 const mockServer = getLocal();

--- a/src/node/fetch/fetch.node.test.ts
+++ b/src/node/fetch/fetch.node.test.ts
@@ -385,16 +385,20 @@ describe('NodeFetch', () => {
         .mocked(fetch)
         .mockImplementation(jest.requireActual('node-fetch').default);
 
-      await mockServer.forGet('/test').thenCallback((req) => {
+      await mockServer.forGet('/test').thenCallback(req => {
         expect(req.rawHeaders).toEqual(
-          expect.arrayContaining([['first', 'abc'], ['second', 'ab'], ['second', 'bc']])
+          expect.arrayContaining([
+            ['first', 'abc'],
+            ['second', 'ab'],
+            ['second', 'bc'],
+          ])
         );
 
         return {
           statusCode: 200,
           headers: {
             foo: 'string',
-            bar: ['a', 'b', 'c']
+            bar: ['a', 'b', 'c'],
           },
           body: 'Ok',
         };
@@ -406,8 +410,8 @@ describe('NodeFetch', () => {
         headers: {
           first: 'abc',
           second: ['ab', 'bc'],
-          connection: 'close'
-        }
+          connection: 'close',
+        },
       });
 
       if (result.status !== 200) {

--- a/src/node/fetch/fetch.node.test.ts
+++ b/src/node/fetch/fetch.node.test.ts
@@ -383,7 +383,8 @@ describe('NodeFetch', () => {
 
     // this test works under the assumption that node-fetch returns multi-valued headers as arrays
     // this is not true for node-fetch 2.x
-    it('should correctly send and receive multi-valued headers', async () => {
+    // eslint-disable-next-line jest/no-disabled-tests
+    it.skip('should correctly send and receive multi-valued headers', async () => {
       jest.mocked(fetch).mockImplementation(
         async (url, options) => {
           expect(url).toStrictEqual('http://test.local');

--- a/src/node/fetch/fetch.node.ts
+++ b/src/node/fetch/fetch.node.ts
@@ -42,6 +42,9 @@ export class NodeFetch implements IFetch, Interceptable, AuthCache {
       return headers;
     }
 
+    // Header values are folded as fetch uses message.headers
+    //   https://github.com/node-fetch/node-fetch/blob/2.x/src/index.js#L163
+    //   https://nodejs.org/dist/latest-v19.x/docs/api/http.html#messageheaders
     for (const [key, value] of Object.entries(map)) {
       let valueArray = value;
       if (!Array.isArray(value)) {

--- a/src/node/fetch/fetch.node.ts
+++ b/src/node/fetch/fetch.node.ts
@@ -64,8 +64,10 @@ export class NodeFetch implements IFetch, Interceptable, AuthCache {
     _accept: string[] | undefined
   ): boolean {
     if (
-      contentType !== undefined
-      && contentType.some(v => v.includes(JSON_CONTENT) || v.includes(JSON_PROBLEM_CONTENT))
+      contentType !== undefined &&
+      contentType.some(
+        v => v.includes(JSON_CONTENT) || v.includes(JSON_PROBLEM_CONTENT)
+      )
     ) {
       return true;
     }
@@ -78,15 +80,15 @@ export class NodeFetch implements IFetch, Interceptable, AuthCache {
     accept: string[] | undefined
   ): boolean {
     if (
-      contentType !== undefined
-      && contentType.some(v => BINARY_CONTENT_REGEXP.test(v))
+      contentType !== undefined &&
+      contentType.some(v => BINARY_CONTENT_REGEXP.test(v))
     ) {
       return true;
     }
 
     if (
-      accept !== undefined
-      && accept.some(v => BINARY_CONTENT_REGEXP.test(v))
+      accept !== undefined &&
+      accept.some(v => BINARY_CONTENT_REGEXP.test(v))
     ) {
       return true;
     }
@@ -98,7 +100,7 @@ export class NodeFetch implements IFetch, Interceptable, AuthCache {
   public events: Events | undefined;
   public digest: SuperCache<string> = new SuperCache();
 
-  constructor(private readonly timers: ITimers) { }
+  constructor(private readonly timers: ITimers) {}
 
   @eventInterceptor({
     eventName: 'fetch',

--- a/src/node/fetch/fetch.node.ts
+++ b/src/node/fetch/fetch.node.ts
@@ -150,26 +150,21 @@ export class NodeFetch implements IFetch, Interceptable, AuthCache {
     return new RequestFetchError('abort');
   }
 
-  private queryParameters(parameters?: Record<string, string>): string {
-    if (parameters && Object.keys(parameters).length) {
-      const definedParameters = Object.entries(parameters).reduce(
-        (result, [key, value]) => {
-          if (value === undefined) {
-            return result;
-          }
-
-          return {
-            ...result,
-            [key]: value,
-          };
-        },
-        {}
-      );
-
-      return '?' + new URLSearchParams(definedParameters).toString();
+  private queryParameters(parameters?: Record<string, string | string[]>): string {
+    if (parameters === undefined || Object.keys(parameters).length === 0) {
+      return '';
     }
 
-    return '';
+    const params = new URLSearchParams();
+    for (const [key, param] of Object.entries(parameters)) {
+      if (typeof param === 'string') {
+        params.append(key, param);
+      } else {
+        param.forEach(v => params.append(key, v));
+      }
+    }
+
+    return '?' + params.toString();
   }
 
   private body(

--- a/src/node/fetch/fetch.node.ts
+++ b/src/node/fetch/fetch.node.ts
@@ -10,6 +10,7 @@ import type {
   FetchBody,
   FetchError,
   FetchResponse,
+  HttpMultiMap,
   IFetch,
   Interceptable,
   InterceptableMetadata,
@@ -150,7 +151,7 @@ export class NodeFetch implements IFetch, Interceptable, AuthCache {
     return new RequestFetchError('abort');
   }
 
-  private queryParameters(parameters?: Record<string, string | string[]>): string {
+  private queryParameters(parameters?: HttpMultiMap): string {
     if (parameters === undefined || Object.keys(parameters).length === 0) {
       return '';
     }
@@ -228,7 +229,7 @@ export class NodeFetch implements IFetch, Interceptable, AuthCache {
 
   private isBinaryContent(
     responseHeaders: Record<string, string>,
-    requestHeaders?: Record<string, string | string[]>
+    requestHeaders?: HttpMultiMap
   ): boolean {
     if (
       responseHeaders['content-type'] &&

--- a/src/schema-tools/superjson/mutate.ts
+++ b/src/schema-tools/superjson/mutate.ts
@@ -279,11 +279,11 @@ function ensureProfileWithProviders(
   environment?: IEnvironment,
   logger?: ILogger
 ): [
-    boolean,
-    Exclude<ProfileEntry, string> & {
-      providers: Record<string, ProfileProviderEntry>;
-    }
-  ] {
+  boolean,
+  Exclude<ProfileEntry, string> & {
+    providers: Record<string, ProfileProviderEntry>;
+  }
+] {
   let changed = false;
 
   if (document.profiles === undefined) {

--- a/src/schema-tools/superjson/mutate.ts
+++ b/src/schema-tools/superjson/mutate.ts
@@ -68,8 +68,8 @@ export function mergeProfileDefaults(
     if (targetedProfile.defaults) {
       // Merge existing with new
       defaults = mergeVariables(
-        castToNonPrimitive(targetedProfile.defaults) || {},
-        castToNonPrimitive(payload) || {}
+        castToNonPrimitive(targetedProfile.defaults ?? {}),
+        castToNonPrimitive(payload ?? {})
       ) as UsecaseDefaults;
       document.profiles[profileName] = {
         ...targetedProfile,
@@ -181,8 +181,8 @@ export function mergeProfile(
       } else {
         // Merge existing with new
         defaults = mergeVariables(
-          castToNonPrimitive(targetedProfile.defaults) || {},
-          castToNonPrimitive(payload.defaults) || {}
+          castToNonPrimitive(targetedProfile.defaults ?? {}),
+          castToNonPrimitive(payload.defaults ?? {})
         ) as UsecaseDefaults;
       }
     }
@@ -279,11 +279,11 @@ function ensureProfileWithProviders(
   environment?: IEnvironment,
   logger?: ILogger
 ): [
-  boolean,
-  Exclude<ProfileEntry, string> & {
-    providers: Record<string, ProfileProviderEntry>;
-  }
-] {
+    boolean,
+    Exclude<ProfileEntry, string> & {
+      providers: Record<string, ProfileProviderEntry>;
+    }
+  ] {
   let changed = false;
 
   if (document.profiles === undefined) {
@@ -403,8 +403,8 @@ export function mergeProfileProvider(
       // Change
       // Merge existing with new
       defaults = mergeVariables(
-        castToNonPrimitive(profileProvider.defaults) || {},
-        castToNonPrimitive(payload.defaults) || {}
+        castToNonPrimitive(profileProvider.defaults ?? {}),
+        castToNonPrimitive(payload.defaults ?? {})
       ) as ProfileProviderDefaults;
     } else if (!profileProvider.defaults && payload.defaults) {
       defaults = payload.defaults;

--- a/src/schema-tools/superjson/mutate.ts
+++ b/src/schema-tools/superjson/mutate.ts
@@ -65,22 +65,22 @@ export function mergeProfileDefaults(
       return true;
     }
   } else {
-    if (targetedProfile.defaults) {
-      // Merge existing with new
-      defaults = mergeVariables(
-        castToNonPrimitive(targetedProfile.defaults ?? {}),
-        castToNonPrimitive(payload ?? {})
-      ) as UsecaseDefaults;
+    if (targetedProfile.defaults === undefined) {
       document.profiles[profileName] = {
         ...targetedProfile,
-        defaults,
+        defaults: payload,
       };
 
       return true;
     } else {
+      // Merge existing with new
+      defaults = mergeVariables(
+        castToNonPrimitive(targetedProfile.defaults),
+        castToNonPrimitive(payload)
+      ) as UsecaseDefaults;
       document.profiles[profileName] = {
         ...targetedProfile,
-        defaults: payload,
+        defaults,
       };
 
       return true;

--- a/src/schema-tools/superjson/normalize.ts
+++ b/src/schema-tools/superjson/normalize.ts
@@ -180,7 +180,7 @@ export function normalizeUsecaseDefaults(
   const normalized: NormalizedUsecaseDefaults =
     base !== undefined ? clone(base) : {};
   for (const [usecase, defs] of Object.entries(defaults)) {
-    const previousInput = castToNonPrimitive(normalized[usecase]?.input) ?? {};
+    const previousInput = castToNonPrimitive(normalized[usecase]?.input ?? {});
 
     let providerFailover = defs.providerFailover;
     if (providerFailover === undefined) {
@@ -190,7 +190,7 @@ export function normalizeUsecaseDefaults(
     normalized[usecase] = {
       input: mergeVariables(
         previousInput,
-        castToNonPrimitive(defs.input) ?? {}
+        castToNonPrimitive(defs.input ?? {})
       ),
       providerFailover: providerFailover ?? false,
     };
@@ -219,12 +219,12 @@ export function normalizeProfileProviderDefaults(
 
   const normalized: NormalizedProfileProviderDefaults = {};
   for (const [usecase, defs] of Object.entries(defaults)) {
-    const previousInput = castToNonPrimitive(base?.[usecase]?.input) ?? {};
+    const previousInput = castToNonPrimitive(base?.[usecase]?.input ?? {});
 
     normalized[usecase] = {
       input: mergeVariables(
         previousInput,
-        castToNonPrimitive(defs.input) ?? {}
+        castToNonPrimitive(defs.input ?? {})
       ),
       retryPolicy: normalizeRetryPolicy(defs.retryPolicy),
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -953,20 +953,20 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@superfaceai/ast@1.2.0", "@superfaceai/ast@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@superfaceai/ast/-/ast-1.2.0.tgz#f41823d550e0b0a05a8398be22a68b7b3912dde3"
-  integrity sha512-HMmdSUNzKuVgQ9g9YS/eiv3/CitSZks8eury8sAi2QbwT+n5f9SsVcmHxL2/QbkRCmlPpRqHJ6YSCqvBZ2fu1g==
+"@superfaceai/ast@1.3.0", "@superfaceai/ast@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@superfaceai/ast/-/ast-1.3.0.tgz#15b8ef512616652478592b2469ba06303b713622"
+  integrity sha512-6zTaJKaZkR5kqk3axiE05FheRWYb0ykRSMy6quwrVn4fJmP/Z6KQ14KifqMtZTmWak+GsFPfun1n1reyGyHbJg==
   dependencies:
     ajv "^8.8.2"
     ajv-formats "^2.1.1"
 
-"@superfaceai/parser@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@superfaceai/parser/-/parser-1.2.0.tgz#e89e64c9ec98ff2d1e4760c1441d88d945978a1d"
-  integrity sha512-8nQ4x15F8mygKg4BcWwzqgDVTaY5BXanvCcxirL/jKLgpGUxH+808t0KmVc2Ke9o2MdiYt/2UD2hyfpwwqN9DA==
+"@superfaceai/parser@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@superfaceai/parser/-/parser-2.1.0.tgz#0ddaeac6c6f7caa18a1590f27c39736a8262dcb2"
+  integrity sha512-/sbjFcs4qUo5bJx+pX/N8XClnfkQjz68XGZ+w9gzPOObMNyg1pImAf+/bE9no4bkiGfFtph0VwYjmhAY33/yXQ==
   dependencies:
-    "@superfaceai/ast" "^1.2.0"
+    "@superfaceai/ast" "^1.3.0"
     "@types/debug" "^4.1.5"
     debug "^4.3.3"
     typescript "^4"


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->

Adds `None` as possible `Variables` value.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Incorrect handling of `null` and `undefined` lead to confusion by end users, and we internally introduced bugs as TypeScript types didn't allow `null` as a possible value.

Updated specification: https://github.com/superfaceai/spec/pull/47

[Decision Record](https://www.notion.so/superface/None-type-fc921ac39d764a88ad5ba3b1cc3d148a) _internal_

### Context

When we were implementing Binary Data, we discovered a major flaw in types and how they interact with required/optional fields and nullable values. 

We now have only JavaScript environment.

### Decision

`None` is defined as union of `undefined` and `null`.

It will be added as possible `Variables` value.

`None` CANNOT be used as primitive type, it is implicit type for `nullable` values.

We will add `NoneLiteral` to support `undefined` and `null` values in Examples.

By default, fields are `Optional`.

Required field MUST fail validation only if the field in the object isn’t defined at all. So, it doesn’t matter whether the value is `None` or any other Model. Behaviour similar to `Object.hasOwn()` in JavaScript.

By default, value is `Optional`.

`Required` value CANNOT be `None`.

#### Example

```rust
usecase Example {
  input {
    field1 string // optional value can be String or None, in JS: 'value', undefined, null
    field2 string! // required value can be String, in JS: 'value'
  }

  example Success {
    input {
      field1 = None
			field2 = 'value'
    }
  }
}
```

If we surfaced types for profile’s input, field1 would be typed as `Optional<string>`, which can be represented also as `string | None` and fully expanded as `string | null | undefined`.

For field2, type is simply `string`.

### Consequences

Clearly defined behaviour of absence of the value for user, as well internal handling of `undefined` and `null` values.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [ ] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
