### PR TITLE
feat: ensure None type behaves correctly

### DIFF
--- a/src/core/errors/errors.helpers.ts
+++ b/src/core/errors/errors.helpers.ts
@@ -351,26 +351,26 @@ export function invalidBackoffEntryError(kind: string): SDKExecutionError {
   );
 }
 
-export function missingPathReplacementError(
-  missing: string[],
+export function invalidPathReplacementError(
+  invalid: string[],
   url: string,
   all: string[],
   available: string[]
 ): SDKExecutionError {
   return new SDKExecutionError(
-    `Missing values for URL path replacement: ${missing.join(', ')}`,
+    `Missing or mistyped values for URL path replacement: ${invalid.join(', ')}`,
     [
       `Trying to replace path keys for url: ${url}`,
       all.length > 0
         ? `Found these path keys: ${all.join(', ')}`
         : 'Found no path keys',
       available.length > 0
-        ? `But only found these potential variables: ${available.join(', ')}`
-        : 'But found no potential variables',
+        ? `But only found these string variables: ${available.join(', ')}`
+        : 'But found no string variables',
     ],
     [
-      'Make sure the url path variable refers to an available variable',
-      'Consider introducing a new variable with the correct name and desired value',
+      'Make sure the url path variable refers to an available string variable',
+      'Consider introducing a new variable with the correct name and desired string value',
     ]
   );
 }
@@ -485,6 +485,22 @@ export function profileIdsDoNotMatchError(
     ],
     ['Pass profile id that matches to profile id in map or provide correct map']
   );
+}
+
+export function invalidHTTPMapValueType(
+  kind: 'header' | 'query parameter',
+  key: string,
+  type: string
+): SDKExecutionError {
+  return new SDKExecutionError(
+    `Invalid HTTP ${kind} value type: ${key}`,
+    [
+      `Value is of type ${type} but string was expected`
+    ],
+    [
+      'Stringify value before passing it to the HTTP request'
+    ]
+  )
 }
 
 export function digestHeaderNotFound(

--- a/src/core/errors/errors.helpers.ts
+++ b/src/core/errors/errors.helpers.ts
@@ -365,12 +365,12 @@ export function invalidPathReplacementError(
         ? `Found these path keys: ${all.join(', ')}`
         : 'Found no path keys',
       available.length > 0
-        ? `But only found these string variables: ${available.join(', ')}`
-        : 'But found no string variables',
+        ? `But only found these variables with supported types: ${available.join(', ')}`
+        : 'But found no variables with supported types',
     ],
     [
-      'Make sure the url path variable refers to an available string variable',
-      'Consider introducing a new variable with the correct name and desired string value',
+      'Make sure the url path variable refers to an available string, number or boolean variable',
+      'Consider introducing a new variable with the correct name and desired value',
     ]
   );
 }

--- a/src/core/interpreter/http/filters.ts
+++ b/src/core/interpreter/http/filters.ts
@@ -229,7 +229,7 @@ export const queryParametersFilter: Filter = ({
 }: FilterInputOutput) => {
   const queryParameters = {
     ...request?.queryParameters,
-    ...variablesToStrings(parameters.queryParameters ?? {}),
+    ...(parameters.queryParameters ?? {})
   };
 
   return {
@@ -264,7 +264,7 @@ export const headersFilter: Filter = ({
   request,
   response,
 }: FilterInputOutput) => {
-  const headers: Record<string, string> = parameters.headers ?? {};
+  const headers: Record<string, string | string[]> = parameters.headers ?? {};
 
   setHeader(headers, 'user-agent', USER_AGENT);
   setHeader(headers, 'accept', parameters.accept ?? '*/*');
@@ -360,7 +360,7 @@ export function isCompleteHttpRequest(
 
     if (
       !Object.values(input.queryParameters).every(
-        value => typeof value === 'string'
+        value => typeof value === 'string' || Array.isArray(value)
       )
     ) {
       return false;

--- a/src/core/interpreter/http/filters.ts
+++ b/src/core/interpreter/http/filters.ts
@@ -9,7 +9,7 @@ import {
 } from '../../../lib';
 import { USER_AGENT } from '../../../user-agent';
 import { unsupportedContentType } from '../../errors';
-import type { FetchBody, IFetch } from './interfaces';
+import type { FetchBody, HttpMultiMap, IFetch } from './interfaces';
 import {
   BINARY_CONTENT_REGEXP,
   BINARY_CONTENT_TYPES,
@@ -264,7 +264,7 @@ export const headersFilter: Filter = ({
   request,
   response,
 }: FilterInputOutput) => {
-  const headers: Record<string, string | string[]> = parameters.headers ?? {};
+  const headers: HttpMultiMap = parameters.headers ?? {};
 
   setHeader(headers, 'user-agent', USER_AGENT);
   setHeader(headers, 'accept', parameters.accept ?? '*/*');

--- a/src/core/interpreter/http/http.ts
+++ b/src/core/interpreter/http/http.ts
@@ -3,9 +3,9 @@ import { HttpScheme, SecurityType } from '@superfaceai/ast';
 
 import type { ICrypto, ILogger } from '../../../interfaces';
 import type { NonPrimitive, Variables } from '../../../lib';
-import { UnexpectedError, variablesToStrings } from '../../../lib';
+import { UnexpectedError } from '../../../lib';
 import { pipe } from '../../../lib/pipe/pipe';
-import { missingSecurityValuesError } from '../../errors';
+import { invalidHTTPMapValueType, missingSecurityValuesError } from '../../errors';
 import {
   authenticateFilter,
   fetchFilter,
@@ -23,6 +23,7 @@ import type {
 } from './security';
 import { ApiKeyHandler, DigestHandler, HttpHandler } from './security';
 import type { HttpResponse } from './types';
+import { variablesToHttpMap } from './utils';
 
 export enum NetworkErrors {
   TIMEOUT_ERROR = 'TIMEOUT_ERROR',
@@ -54,7 +55,14 @@ export class HttpClient {
     const requestParameters: RequestParameters = {
       url,
       ...parameters,
-      headers: variablesToStrings(parameters.headers ?? {}),
+      queryParameters: variablesToHttpMap(parameters.queryParameters ?? {}).match(
+        v => v,
+        ([key, value]) => { throw invalidHTTPMapValueType('header', key, typeof value); }
+      ),
+      headers: variablesToHttpMap(parameters.headers ?? {}).match(
+        v => v,
+        ([key, value]) => { throw invalidHTTPMapValueType('query parameter', key, typeof value); }
+      ),
     };
 
     const handler = createSecurityHandler(

--- a/src/core/interpreter/http/interfaces.ts
+++ b/src/core/interpreter/http/interfaces.ts
@@ -46,7 +46,7 @@ export type FetchParameters = {
   headers?: Record<string, string | string[]>;
   method: string;
   body?: FetchBody;
-  queryParameters?: Record<string, string>;
+  queryParameters?: Record<string, string | string[]>;
   timeout?: number;
 };
 

--- a/src/core/interpreter/http/interfaces.ts
+++ b/src/core/interpreter/http/interfaces.ts
@@ -42,11 +42,13 @@ export type FetchBody =
   | URLSearchParamsBody
   | BinaryBody;
 
+export type HttpMultiMap = Record<string, string | string[]>;
+
 export type FetchParameters = {
-  headers?: Record<string, string | string[]>;
+  headers?: HttpMultiMap;
   method: string;
   body?: FetchBody;
-  queryParameters?: Record<string, string | string[]>;
+  queryParameters?: HttpMultiMap;
   timeout?: number;
 };
 

--- a/src/core/interpreter/http/security/api-key/api-key.ts
+++ b/src/core/interpreter/http/security/api-key/api-key.ts
@@ -5,8 +5,8 @@ import type {
 import { ApiKeyPlacement } from '@superfaceai/ast';
 
 import type { ILogger, LogFunction } from '../../../../../interfaces';
-import { isBinaryData } from '../../../../../interfaces';
 import type { Variables } from '../../../../../lib';
+import { isPrimitive } from '../../../../../lib';
 import { apiKeyInBodyError } from '../../../../errors';
 import type {
   AuthenticateRequestAsync,
@@ -32,7 +32,7 @@ export class ApiKeyHandler implements ISecurityHandler {
     parameters: RequestParameters
   ) => {
     let body: Variables | undefined = parameters.body;
-    const headers: Record<string, string> = parameters.headers ?? {};
+    const headers: Record<string, string | string[]> = parameters.headers ?? {};
     const pathParameters = parameters.pathParameters ?? {};
     const queryParameters = parameters.queryParameters ?? {};
 
@@ -80,12 +80,7 @@ function applyApiKeyAuthInBody(
   apikey: string,
   visitedReferenceTokens: string[] = []
 ): Variables {
-  if (
-    typeof requestBody !== 'object' ||
-    Array.isArray(requestBody) ||
-    Buffer.isBuffer(requestBody) ||
-    isBinaryData(requestBody)
-  ) {
+  if (isPrimitive(requestBody)) {
     const valueLocation = visitedReferenceTokens.length
       ? `value at /${visitedReferenceTokens.join('/')}`
       : 'body';

--- a/src/core/interpreter/http/security/api-key/api-key.ts
+++ b/src/core/interpreter/http/security/api-key/api-key.ts
@@ -8,6 +8,7 @@ import type { ILogger, LogFunction } from '../../../../../interfaces';
 import type { Variables } from '../../../../../lib';
 import { isPrimitive } from '../../../../../lib';
 import { apiKeyInBodyError } from '../../../../errors';
+import type { HttpMultiMap } from '../../interfaces';
 import type {
   AuthenticateRequestAsync,
   ISecurityHandler,
@@ -32,7 +33,7 @@ export class ApiKeyHandler implements ISecurityHandler {
     parameters: RequestParameters
   ) => {
     let body: Variables | undefined = parameters.body;
-    const headers: Record<string, string | string[]> = parameters.headers ?? {};
+    const headers: HttpMultiMap = parameters.headers ?? {};
     const pathParameters = parameters.pathParameters ?? {};
     const queryParameters = parameters.queryParameters ?? {};
 

--- a/src/core/interpreter/http/security/digest/digest.ts
+++ b/src/core/interpreter/http/security/digest/digest.ts
@@ -96,7 +96,7 @@ export class DigestHandler implements ISecurityHandler {
   public authenticate: AuthenticateRequestAsync = async (
     parameters: RequestParameters
   ) => {
-    const headers: Record<string, string> = parameters.headers || {};
+    const headers: Record<string, string | string[]> = parameters.headers ?? {};
 
     const credentials = await this.fetchInstance.digest.getCached(
       hashDigestConfiguration(this.configuration, this.crypto),

--- a/src/core/interpreter/http/security/digest/digest.ts
+++ b/src/core/interpreter/http/security/digest/digest.ts
@@ -16,7 +16,7 @@ import {
   prepareRequestFilter,
   withRequest,
 } from '../../filters';
-import type { IFetch } from '../../interfaces';
+import type { HttpMultiMap, IFetch } from '../../interfaces';
 import type { HttpResponse } from '../../types';
 import type {
   AuthCache,
@@ -96,7 +96,7 @@ export class DigestHandler implements ISecurityHandler {
   public authenticate: AuthenticateRequestAsync = async (
     parameters: RequestParameters
   ) => {
-    const headers: Record<string, string | string[]> = parameters.headers ?? {};
+    const headers: HttpMultiMap = parameters.headers ?? {};
 
     const credentials = await this.fetchInstance.digest.getCached(
       hashDigestConfiguration(this.configuration, this.crypto),

--- a/src/core/interpreter/http/security/http/http.ts
+++ b/src/core/interpreter/http/security/http/http.ts
@@ -2,6 +2,7 @@ import type { SecurityType } from '@superfaceai/ast';
 import { HttpScheme } from '@superfaceai/ast';
 
 import type { ILogger, LogFunction } from '../../../../../interfaces';
+import type { HttpMultiMap } from '../../interfaces';
 import type {
   AuthenticateRequestAsync,
   ISecurityHandler,
@@ -27,7 +28,7 @@ export class HttpHandler implements ISecurityHandler {
   public authenticate: AuthenticateRequestAsync = async (
     parameters: RequestParameters
   ) => {
-    const headers: Record<string, string | string[]> = parameters.headers ?? {};
+    const headers: HttpMultiMap = parameters.headers ?? {};
 
     switch (this.configuration.scheme) {
       case HttpScheme.BASIC:

--- a/src/core/interpreter/http/security/http/http.ts
+++ b/src/core/interpreter/http/security/http/http.ts
@@ -27,7 +27,7 @@ export class HttpHandler implements ISecurityHandler {
   public authenticate: AuthenticateRequestAsync = async (
     parameters: RequestParameters
   ) => {
-    const headers: Record<string, string> = parameters.headers || {};
+    const headers: Record<string, string | string[]> = parameters.headers ?? {};
 
     switch (this.configuration.scheme) {
       case HttpScheme.BASIC:

--- a/src/core/interpreter/http/security/interfaces.ts
+++ b/src/core/interpreter/http/security/interfaces.ts
@@ -59,8 +59,8 @@ export type SecurityConfiguration =
 export type RequestParameters = {
   url: string;
   method: string;
-  headers?: Record<string, string>;
-  queryParameters?: NonPrimitive;
+  headers?: Record<string, string | string[]>;
+  queryParameters?: Record<string, string | string[]>;
   body?: Variables;
   contentType?: string;
   accept?: string;

--- a/src/core/interpreter/http/security/interfaces.ts
+++ b/src/core/interpreter/http/security/interfaces.ts
@@ -11,7 +11,7 @@ import type {
 } from '@superfaceai/ast';
 
 import type { NonPrimitive, SuperCache, Variables } from '../../../../lib';
-import type { FetchParameters } from '../interfaces';
+import type { FetchParameters, HttpMultiMap } from '../interfaces';
 import type { HttpResponse } from '../types';
 
 export const DEFAULT_AUTHORIZATION_HEADER_NAME = 'Authorization';
@@ -59,8 +59,8 @@ export type SecurityConfiguration =
 export type RequestParameters = {
   url: string;
   method: string;
-  headers?: Record<string, string | string[]>;
-  queryParameters?: Record<string, string | string[]>;
+  headers?: HttpMultiMap;
+  queryParameters?: HttpMultiMap;
   body?: Variables;
   contentType?: string;
   accept?: string;

--- a/src/core/interpreter/http/utils.test.ts
+++ b/src/core/interpreter/http/utils.test.ts
@@ -104,7 +104,19 @@ describe('interpreter · http · utils', () => {
           {
             baseUrl: 'http://example.com',
             pathParameters: { FOO: 'foo' }
-          })).toThrow('Missing values for URL path replacement: BAR')
+          })
+      ).toThrow('Missing or mistyped values for URL path replacement: BAR')
+    });
+
+    it('throws mistyped key error if path parameter for inputUrl is not string', () => {
+      expect(
+        () => createUrl(
+          '/{FOO}/{BAR}',
+          {
+            baseUrl: 'http://example.com',
+            pathParameters: { FOO: 'foo', BAR: [1, 2, 3] }
+          })
+      ).toThrow('Missing or mistyped values for URL path replacement: BAR')
     });
   });
 });

--- a/src/core/interpreter/http/utils.test.ts
+++ b/src/core/interpreter/http/utils.test.ts
@@ -1,3 +1,6 @@
+import { err, ok } from '../../../lib';
+import { getHeaderMulti, variablesToHttpMap } from '..';
+import type { HttpMultiMap } from './interfaces';
 import {
   createUrl,
   deleteHeader,
@@ -117,6 +120,36 @@ describe('interpreter · http · utils', () => {
             pathParameters: { FOO: 'foo', BAR: [1, 2, 3] }
           })
       ).toThrow('Missing or mistyped values for URL path replacement: BAR')
+    });
+  });
+
+  describe('variablesToHttpMap', () => {
+    it.each([
+      [{}, ok({})],
+      [{ foo: 'string', bar: ['s1', 's2'] }, ok({ foo: 'string', bar: ['s1', 's2'] })],
+      [{ foo: undefined, bar: ['s1', null, undefined, 's2'], baz: null }, ok({ bar: ['s1', 's2'] })],
+      [{ foo: 1, bar: [true, false] }, ok({ foo: '1', bar: ['true', 'false'] })],
+      [{ foo: Buffer.from([]) }, err(['foo', Buffer.from([])])],
+      [{ foo: ['s1', {}] }, err(['foo', {}])],
+      [{ foo: ['s1', []] }, err(['foo', []])],
+    ])('correctly handles "%s"', (value, expected) => {
+      const result = variablesToHttpMap(value);
+      expect(result).toStrictEqual(expected);
+    });
+  });
+
+  describe('getHeaderMulti', () => {
+    const map: HttpMultiMap = {
+      foo: 'string',
+      bar: ['a', 'b']
+    };
+    
+    it.each([
+      ['none', undefined],
+      ['foo', ['string']],
+      ['bar', ['a', 'b']]
+    ])('correctly handles "%s"', (key, expected) => {
+      expect(getHeaderMulti(map, key)).toStrictEqual(expected);
     });
   });
 });

--- a/src/core/interpreter/map-interpreter.errors.test.ts
+++ b/src/core/interpreter/map-interpreter.errors.test.ts
@@ -327,7 +327,6 @@ AST Path: definitions[0].statements[0].assignments[0].value`
 
       const ast = parseMapFromSource(`
         map Test {
-          page = input.page
           http GET "/{missing}/{alsoMissing}" {
             request {
               headers {
@@ -345,7 +344,7 @@ AST Path: definitions[0].statements[0].assignments[0].value`
       expect(() => {
         result.unwrap();
       }).toThrow(
-        'Missing values for URL path replacement: missing, alsoMissing'
+        'Missing or mistyped values for URL path replacement: missing, alsoMissing'
       );
     });
 
@@ -545,7 +544,7 @@ AST Path: definitions[0].statements[0].assignments[0].value`
       );
       const result = await interpreter.perform(ast);
       expect(result.isErr() && result.error.toString()).toMatch(
-        'Missing values for URL path replacement: path'
+        'Missing or mistyped values for URL path replacement: path'
       );
     });
   });

--- a/src/core/interpreter/map-interpreter.errors.ts
+++ b/src/core/interpreter/map-interpreter.errors.ts
@@ -9,6 +9,7 @@ import type {
   IMappedHTTPError,
 } from '../../interfaces';
 import { ErrorBase } from '../../lib';
+import type { HttpMultiMap } from './http';
 
 export class MapInterpreterErrorBase extends ErrorBase {
   private path?: string[];
@@ -99,7 +100,7 @@ export class HTTPError extends MapInterpreterErrorBase implements IHTTPError {
     public statusCode?: number,
     public request?: {
       body?: unknown;
-      headers?: Record<string, string>;
+      headers?: HttpMultiMap;
       url?: string;
     },
     public response?: {

--- a/src/core/interpreter/map-interpreter.test.ts
+++ b/src/core/interpreter/map-interpreter.test.ts
@@ -4,7 +4,7 @@ import { readFile } from 'fs/promises';
 import { getLocal } from 'mockttp';
 import * as path from 'path';
 
-import { UnexpectedError } from '../../lib';
+import { err, ok, SDKExecutionError, UnexpectedError } from '../../lib';
 import { MockTimers } from '../../mock';
 import {
   BinaryData,
@@ -16,6 +16,7 @@ import {
 import { Config } from '../config';
 import { ServiceSelector } from '../services';
 import { MapInterpreter } from './map-interpreter';
+import { JessieError } from './map-interpreter.errors';
 
 const mockServer = getLocal();
 const timers = new MockTimers();
@@ -300,7 +301,7 @@ describe('MapInterpreter', () => {
         http GET "${url}" {
           request {
             query {
-              page = input.page
+              page = input.page.toString()
             }
             headers {
               "content-type" = "application/json"
@@ -314,7 +315,7 @@ describe('MapInterpreter', () => {
       }`);
     const result = await interpreter.perform(ast);
 
-    expect(result.isOk() && result.value).toEqual(144);
+    expect(result.unwrap()).toEqual(144);
   });
 
   it('should call an API with parameters and POST request', async () => {
@@ -1036,7 +1037,6 @@ describe('MapInterpreter', () => {
     expect(baseUrl.split('')[baseUrl.length - 1]).toEqual('/');
     const ast = parseMapFromSource(`
       map Test {
-        username = input.user
         http GET "/thirteen" {
           response 200 "application/json" {
             map result {
@@ -1055,7 +1055,7 @@ describe('MapInterpreter', () => {
     );
     const result = await interpreter.perform(ast);
 
-    expect(result.isOk() && result.value).toEqual({ result: 13 });
+    expect(result.unwrap()).toEqual({ result: 13 });
   });
 
   it('should make response headers accessible', async () => {
@@ -1395,15 +1395,15 @@ describe('MapInterpreter', () => {
   });
 
   it('should preserve buffer types with foreach', async () => {
-    const ast = parseMapFromSource(`    
+    const ast = parseMapFromSource(`
     map Test {
       mappedItems = call foreach(item of input.items) mapItem(item = item)
-    
+
       map result {
         items: mappedItems
       }
     }
-    
+
     operation mapItem {
         return args.item
     }`);
@@ -1432,15 +1432,15 @@ describe('MapInterpreter', () => {
   });
 
   it('should not leak optional properties in foreach', async () => {
-    const ast = parseMapFromSource(`    
+    const ast = parseMapFromSource(`
     map Test {
       mappedItems = call foreach(item of input.items) mapItem(item = item)
-    
+
       map result {
         items: mappedItems
       }
     }
-    
+
     operation mapItem {
       return args.item
     }`);
@@ -1642,7 +1642,7 @@ describe('MapInterpreter', () => {
     map Test {
       firstBytes = input.items.peek(10) // peek is async needs to be set to variable
       allData = input.items.getAllData() // getAllData is async needs to be set to variable
-      
+
       map result {
         firstBytes: firstBytes.toString('base64'),
         items: allData.toString('binary')
@@ -1877,7 +1877,7 @@ describe('MapInterpreter', () => {
     const url = '/';
     await mockServer.forGet(url).thenJson(200, { data: 12 });
 
-    const ast = parseMapFromSource(`    
+    const ast = parseMapFromSource(`
     map Test {
       http GET "/" {
         response 200 {
@@ -1981,15 +1981,15 @@ describe('MapInterpreter', () => {
 
 
   it('should allow success outcome to be undefined', async () => {
-    const ast = parseMapFromSource(`    
+    const ast = parseMapFromSource(`
     map Test {
       map result undefined
-    
+
       map result {
         x = call Op()
       }
     }
-    
+
     operation Op {
       return undefined
     }`);
@@ -2010,7 +2010,7 @@ describe('MapInterpreter', () => {
   });
 
   it('should not allow input to be mutated', async () => {
-    const ast = parseMapFromSource(`    
+    const ast = parseMapFromSource(`
     map Test {
       input.a = input.a + 7
 
@@ -2032,7 +2032,7 @@ describe('MapInterpreter', () => {
   });
 
   it('should not allow integration parameters to be mutated', async () => {
-    const ast = parseMapFromSource(`    
+    const ast = parseMapFromSource(`
     map Test {
       parameters.a = parameters.a + "7"
 
@@ -2052,5 +2052,261 @@ describe('MapInterpreter', () => {
 
     const result = await interpreter.perform(ast);
     expect(result.isOk() && result.value).toStrictEqual('1');
+  });
+
+  describe('None type', () => {
+    it.each([
+      // this is an invalid use of the perform API, so we are just looking for sane behavior - it fails because input is not defined
+      [null, err(expect.any(JessieError))],
+      [undefined, err(expect.any(JessieError))],
+      // no special handling of nested None
+      [{ foo: null }, ok({ foo: null })],
+      [{ foo: undefined }, ok({ foo: undefined })]
+    ])('should handle input "%s"', async (value, expected) => {
+      const ast = parseMapFromSource(`
+        map Test {
+          map result input
+        }`);
+
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'Test',
+          security: [],
+          services: ServiceSelector.withDefaultUrl(''),
+          input: value as any,
+          parameters: {}
+        },
+        interpreterDependencies
+      );
+
+      const result = await interpreter.perform(ast);
+      expect(result).toStrictEqual(expected);
+    });
+
+    it.each([
+      // invalid use of API
+      [null, err(expect.any(JessieError))],
+      [undefined, err(expect.any(JessieError))], 
+      // not touched
+      [{ foo: null }, ok({ foo: null })],
+      [{ foo: undefined }, ok({ foo: undefined })]
+    ])('should handle parameters "%s"', async (value, expected) => {
+      const ast = parseMapFromSource(`
+        map Test {
+          map result parameters
+        }`);
+
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'Test',
+          security: [],
+          services: ServiceSelector.withDefaultUrl(''),
+          input: undefined,
+          parameters: value as any
+        },
+        interpreterDependencies
+      );
+
+      const result = await interpreter.perform(ast);
+      expect(result).toStrictEqual(expected);
+    });
+
+    it.each([
+      ['null', null],
+      ['undefined', undefined],
+      ['{ foo: null }', { foo: null }],
+      ['{ foo: undefined }', { foo: undefined }],
+      ['{ foo = null }', { foo: null }],
+      ['{ foo = undefined }', { foo: undefined }],
+    ])('should return literal "%s"', async (value, expected) => {
+      const ast = parseMapFromSource(`
+        map Test {
+          map result ${value}
+        }`);
+
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'Test',
+          security: [],
+          services: ServiceSelector.withDefaultUrl(''),
+          input: undefined,
+          parameters: {}
+        },
+        interpreterDependencies
+      );
+
+      const result = await interpreter.perform(ast);
+      expect(result.unwrap()).toStrictEqual(expected);
+    });
+
+    it.each([
+      ['null', err(expect.any(SDKExecutionError))],
+      ['undefined', err(expect.any(SDKExecutionError))],
+      ['{ foo: null }', err(expect.any(SDKExecutionError))],
+      ['{ foo: undefined }', err(expect.any(SDKExecutionError))],
+    ])('should handle stringifying HTTP url with "%s"', async (value, expected) => {
+      await mockServer.forAnyRequest().thenCallback(async req => {
+        return { status: 200, json: { data: req.path } };
+      });
+
+      const ast = parseMapFromSource(`
+        map Test {
+          val = ${value}
+          http GET "/test/{val}" {
+            response 200 {
+              map result body.data
+            }
+          }
+        }`);
+
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'Test',
+          security: [],
+          services: ServiceSelector.withDefaultUrl(mockServer.url),
+          input: undefined,
+          parameters: {}
+        },
+        interpreterDependencies
+      );
+
+      const result = await interpreter.perform(ast);
+      expect(result).toStrictEqual(expected);
+    });
+
+    it.each([
+      // content-type is JSON by default
+      [null, null],
+      [undefined, undefined],
+      [{ foo: null }, { foo: null }],
+      [{ foo: undefined }, {}]
+    ])('should handle HTTP body "%s"', async (value, expected) => {
+      await mockServer.forPost('/test').thenCallback(async req => {
+        return { status: 200, json: { data: await req.body.getJson() } };
+      });
+
+      const ast = parseMapFromSource(`
+        map Test {
+          http POST "/test" {
+            request {
+              body = input.foo
+            }
+
+            response 200 {
+              map result body.data
+            }
+          }
+        }`);
+
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'Test',
+          security: [],
+          services: ServiceSelector.withDefaultUrl(mockServer.url),
+          input: { foo: value as any },
+          parameters: {}
+        },
+        interpreterDependencies
+      );
+
+      const result = await interpreter.perform(ast);
+      expect(result.unwrap()).toStrictEqual(expected);
+    });
+
+    it.each([
+      // header not passed
+      [null, ok([false, expect.any(Object)])],
+      [undefined, ok([false, expect.any(Object)])],
+      // not string
+      [{ foo: null }, err(expect.any(SDKExecutionError))],
+      [{ foo: undefined }, err(expect.any(SDKExecutionError))],
+      // array filtered
+      [[null, 'value', undefined], ok([true, 'value'])],
+      [[null, 'value', undefined, 'value2'], ok([true, ['value', 'value2']])]
+    ])('should handle HTTP header "%s"', async (value, expected) => {
+      await mockServer.forGet('/test').thenCallback(async req => {
+        return { status: 200, json: { data: ['test-header' in req.headers, req.headers['test-header']] } };
+      });
+
+      const ast = parseMapFromSource(`
+        map Test {
+          http GET "/test" {
+            request {
+              headers {
+                "test-header" = input.foo
+              }
+            }
+
+            response 200 {
+              map result body.data
+            }
+          }
+        }`);
+
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'Test',
+          security: [],
+          services: ServiceSelector.withDefaultUrl(mockServer.url),
+          input: { foo: value as any },
+          parameters: {}
+        },
+        interpreterDependencies
+      );
+
+      const result = await interpreter.perform(ast);
+      expect(result).toStrictEqual(expected);
+    });
+
+    it.each([
+      // param not passed
+      [null, ok([false, expect.any(Object)])],
+      [undefined, ok([false, expect.any(Object)])],
+      // not string
+      [{ foo: null }, err(expect.any(SDKExecutionError))],
+      [{ foo: undefined }, err(expect.any(SDKExecutionError))],
+      // array filtered
+      [[null, 'value', undefined], ok([true, 'value'])],
+      [[null, 'value', undefined, 'value2'], ok([true, ['value', 'value2']])]
+    ])('should handle HTTP query parameter "%s"', async (value, expected) => {
+      await mockServer.forGet('/test').thenCallback(async req => {
+        let query: string | string[] = new URL(req.url).searchParams.getAll('test-query');
+        const present = query.length !== 0;
+        if (query.length === 1) {
+          query = query[0];
+        }
+
+        return { status: 200, json: { data: [present, query] } };
+      });
+
+      const ast = parseMapFromSource(`
+        map Test {
+          http GET "/test" {
+            request {
+              query {
+                "test-query" = input.foo
+              }
+            }
+
+            response 200 {
+              map result body.data
+            }
+          }
+        }`);
+
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'Test',
+          security: [],
+          services: ServiceSelector.withDefaultUrl(mockServer.url),
+          input: { foo: value as any },
+          parameters: {}
+        },
+        interpreterDependencies
+      );
+
+      const result = await interpreter.perform(ast);
+      expect(result).toStrictEqual(expected);
+    });
   });
 });

--- a/src/core/interpreter/map-interpreter.test.ts
+++ b/src/core/interpreter/map-interpreter.test.ts
@@ -178,186 +178,6 @@ describe('MapInterpreter', () => {
     expect(result.isOk() && result.value).toEqual(12);
   });
 
-  it('should call an API', async () => {
-    const url = '/twelve';
-    await mockServer.forGet(url).thenJson(
-      200,
-      { data: 12 },
-      {
-        'Content-Type': 'application/json; charset=utf-8',
-        'Content-Language': 'en-US, en-CA',
-      }
-    );
-    const interpreter = new MapInterpreter(
-      {
-        usecase: 'Test',
-        security: [],
-        services: mockServicesSelector,
-      },
-      interpreterDependencies
-    );
-    const ast = parseMapFromSource(`
-      map Test {
-        http GET "${url}" {
-          request {
-            headers {
-              "content-type" = "application/json"
-            }
-          }
-
-          response 200 "application/json" "en-US" {
-            map result body.data
-          }
-        }
-      }`);
-    const result = await interpreter.perform(ast);
-
-    expect(result.isOk() && result.value).toEqual(12);
-  });
-
-  it('should call an API with path parameters', async () => {
-    const url = '/twelve';
-    await mockServer.forGet(url + '/2').thenJson(200, { data: 144 });
-    const interpreter = new MapInterpreter(
-      {
-        usecase: 'Test',
-        input: { page: '2' },
-        security: [],
-        services: mockServicesSelector,
-      },
-      interpreterDependencies
-    );
-    const ast = parseMapFromSource(`
-      map Test {
-        page = input.page
-        http GET "${url}/{page}" {
-          request {
-            headers {
-              "content-type" = "application/json"
-            }
-          }
-
-          response 200 "application/json" "en-US" {
-            map result body.data
-          }
-        }
-      }`);
-    const result = await interpreter.perform(ast);
-
-    expect(result.isOk() && result.value).toEqual(144);
-  });
-
-  it('should correctly trim and parse path parameters in http call', async () => {
-    const url = '/thirteen';
-    await mockServer.forGet(url + '/2/get/now').thenJson(200, { data: 169 });
-
-    const interpreter = new MapInterpreter(
-      {
-        usecase: 'Test',
-        input: { page: '2', cmd: 'get', when: 'now' },
-        security: [],
-        services: mockServicesSelector,
-      },
-      interpreterDependencies
-    );
-    const ast = parseMapFromSource(`
-      map Test {
-        page = input.page
-        http GET "${url}/{ page     	  }/{input.cmd }/{ input.when}" {
-          request {
-            headers {
-              "content-type" = "application/json"
-            }
-          }
-
-          response 200 "application/json" "en-US" {
-            map result body.data
-          }
-        }
-      }`);
-    const result = await interpreter.perform(ast);
-
-    result.unwrap();
-    expect(result.isOk() && result.value).toEqual(169);
-  });
-
-  it('should call an API with parameters', async () => {
-    const url = '/twelve';
-    await mockServer
-      .forGet(url)
-      .withQuery({ page: 2 })
-      .thenJson(200, { data: 144 });
-    const interpreter = new MapInterpreter(
-      {
-        usecase: 'Test',
-        input: { page: 2 },
-        security: [],
-        services: mockServicesSelector,
-      },
-      interpreterDependencies
-    );
-    const ast = parseMapFromSource(`
-      map Test {
-        http GET "${url}" {
-          request {
-            query {
-              page = input.page.toString()
-            }
-            headers {
-              "content-type" = "application/json"
-            }
-          }
-
-          response 200 "application/json" "en-US" {
-            map result body.data
-          }
-        }
-      }`);
-    const result = await interpreter.perform(ast);
-
-    expect(result.unwrap()).toEqual(144);
-  });
-
-  it('should call an API with parameters and POST request', async () => {
-    const url = '/checkBody';
-    await mockServer
-      .forPost(url)
-      .withJsonBody({ anArray: [1, 2, 3] })
-      .withHeaders({ someheader: 'hello' })
-      .thenJson(201, { bodyOk: true, headerOk: true });
-    const interpreter = new MapInterpreter(
-      {
-        usecase: 'Test',
-        security: [],
-        services: mockServicesSelector,
-      },
-      interpreterDependencies
-    );
-    const ast = parseMapFromSource(`
-      map Test {
-        http POST "${url}" {
-          request {
-            headers {
-              someheader = "hello"
-            }
-            body {
-              anArray = [1, 2, 3]
-            }
-          }
-
-          response 201 {
-            map result body
-          }
-        }
-      }`);
-    const result = await interpreter.perform(ast);
-
-    expect(result.isOk() && result.value).toEqual({
-      headerOk: true,
-      bodyOk: true,
-    });
-  });
-
   it('should run multi step operation', async () => {
     const url1 = '/first';
     const url2 = '/second';
@@ -393,234 +213,6 @@ describe('MapInterpreter', () => {
     const result = await interpreter.perform(ast);
 
     expect(result.isOk() && result.value).toEqual(12 * 5);
-  });
-
-  it('should call an API with Basic auth', async () => {
-    const url = '/basic';
-    await mockServer
-      .forGet(url)
-      .withHeaders({ Authorization: 'Basic bmFtZTpwYXNzd29yZA==' })
-      .thenJson(200, { data: 12 });
-    const interpreter = new MapInterpreter(
-      {
-        usecase: 'testCase',
-        security: [
-          {
-            id: 'my_basic',
-            type: SecurityType.HTTP,
-            scheme: HttpScheme.BASIC,
-            username: 'name',
-            password: 'password',
-          },
-        ],
-        services: mockServicesSelector,
-      },
-      interpreterDependencies
-    );
-    const ast = parseMapFromSource(`
-      map testCase {
-        http GET "${url}" {
-          security "my_basic"
-
-          response 200 {
-            return map result body.data
-          }
-        }
-      }`);
-    const result = await interpreter.perform(ast);
-
-    expect(result.isOk() && result.value).toEqual(12);
-  });
-
-  it('should call an API with Bearer auth', async () => {
-    const url = '/bearer';
-    await mockServer
-      .forGet(url)
-      .withHeaders({ Authorization: 'Bearer SuperSecret' })
-      .thenJson(200, { data: 12 });
-    const interpreter = new MapInterpreter(
-      {
-        usecase: 'testCase',
-        security: [
-          {
-            id: 'my_bearer',
-            type: SecurityType.HTTP,
-            scheme: HttpScheme.BEARER,
-            token: 'SuperSecret',
-          },
-        ],
-        services: mockServicesSelector,
-      },
-      interpreterDependencies
-    );
-    const ast = parseMapFromSource(`
-      map testCase {
-        http GET "${url}" {
-          security "my_bearer"
-
-          response 200 {
-            return map result body.data
-          }
-        }
-      }`);
-    const result = await interpreter.perform(ast);
-
-    expect(result.isOk() && result.value).toEqual(12);
-  });
-
-  it('should call an API with Apikey auth in header', async () => {
-    const url = '/apikey';
-    await mockServer
-      .forGet(url)
-      .withHeaders({ Key: 'SuperSecret' })
-      .thenJson(200, { data: 12 });
-    const interpreter = new MapInterpreter(
-      {
-        usecase: 'testCase',
-        security: [
-          {
-            id: 'my_apikey',
-            type: SecurityType.APIKEY,
-            in: ApiKeyPlacement.HEADER,
-            name: 'Key',
-            apikey: 'SuperSecret',
-          },
-        ],
-        services: mockServicesSelector,
-      },
-      interpreterDependencies
-    );
-    const ast = parseMapFromSource(`
-      map testCase {
-        http GET "${url}" {
-          security "my_apikey"
-
-          response 200 {
-            return map result body.data
-          }
-        }
-      }`);
-    const result = await interpreter.perform(ast);
-
-    result.unwrap();
-    expect(result.isOk() && result.value).toEqual(12);
-  });
-
-  it('should call an API with Apikey auth in query', async () => {
-    const url = '/apikey';
-    await mockServer
-      .forGet(url)
-      .withQuery({ key: 'SuperSecret' })
-      .thenJson(200, { data: 12 });
-    const interpreter = new MapInterpreter(
-      {
-        usecase: 'testCase',
-        security: [
-          {
-            id: 'my_apikey',
-            type: SecurityType.APIKEY,
-            in: ApiKeyPlacement.QUERY,
-            name: 'key',
-            apikey: 'SuperSecret',
-          },
-        ],
-        services: mockServicesSelector,
-      },
-      interpreterDependencies
-    );
-    const ast = parseMapFromSource(`
-      map testCase {
-        http GET "${url}" {
-          security "my_apikey"
-
-          response 200 {
-            return map result body.data
-          }
-        }
-      }`);
-    const result = await interpreter.perform(ast);
-    expect(result.isOk() && result.value).toEqual(12);
-  });
-
-  it('should call an API with multipart/form-data body', async () => {
-    const url = '/formdata';
-    await mockServer.forPost(url).thenCallback(async request => {
-      const text = await request.body.getText();
-      if (
-        text !== undefined &&
-        text.includes('formData') &&
-        text.includes('myFormData') &&
-        text.includes('is') &&
-        text.includes('present')
-      ) {
-        return {
-          json: { data: 12 },
-          status: 201,
-        };
-      }
-
-      return { json: { failed: true }, statusCode: 400 };
-    });
-    const interpreter = new MapInterpreter(
-      {
-        usecase: 'testCase',
-        security: [],
-        services: mockServicesSelector,
-      },
-      interpreterDependencies
-    );
-    const ast = parseMapFromSource(`
-      map testCase {
-        http POST "${url}" {
-          request "multipart/form-data" {
-            body {
-              formData = "myFormData"
-              is = "present"
-            }
-          }
-
-          response 201 "application/json" {
-            return map result body.data
-          }
-        }
-      }`);
-    const result = await interpreter.perform(ast);
-
-    expect(result.isOk() && result.value).toEqual(12);
-  });
-
-  it('should call an API with application/x-www-form-urlencoded', async () => {
-    const url = '/urlencoded';
-    await mockServer
-      .forPost(url)
-      .withForm({ form: 'is', o: 'k' })
-      .thenJson(201, { data: 12 });
-    const interpreter = new MapInterpreter(
-      {
-        usecase: 'testCase',
-        security: [],
-        services: mockServicesSelector,
-      },
-      interpreterDependencies
-    );
-    const ast = parseMapFromSource(`
-      map testCase {
-        http POST "${url}" {
-          request "application/x-www-form-urlencoded" {
-            body {
-              form = "is"
-              o = "k"
-            }
-          }
-
-          response 201 "application/json" "en-US" {
-            return map result body.data
-          }
-        }
-      }`);
-    const result = await interpreter.perform(ast);
-
-    expect(result.isOk() && result.value).toEqual(12);
   });
 
   it('should execute Eval definition with nested result', async () => {
@@ -1004,98 +596,6 @@ describe('MapInterpreter', () => {
     expect(result.isOk() && result.value).toEqual({ results: [2, 6] });
   });
 
-  it('should be able to use input in path parameters', async () => {
-    const url = '/twelve';
-    await mockServer.forGet(url).thenJson(200, { data: 12 });
-    const ast = parseMapFromSource(`
-      map Test {
-        http GET "/{input.test}" {
-          response 200 "application/json" {
-            map result {
-              result = body.data
-            }
-          }
-        }
-      }`);
-    const interpreter = new MapInterpreter(
-      {
-        usecase: 'Test',
-        input: { test: 'twelve' },
-        security: [],
-        services: mockServicesSelector,
-      },
-      interpreterDependencies
-    );
-    const result = await interpreter.perform(ast);
-
-    expect(result.isOk() && result.value).toEqual({ result: 12 });
-  });
-
-  it('should strip trailing slash from baseUrl', async () => {
-    await mockServer.forGet('/thirteen').thenJson(200, { data: 12 });
-    const baseUrl = mockServer.urlFor('/thirteen').replace('thirteen', '');
-    expect(baseUrl.split('')[baseUrl.length - 1]).toEqual('/');
-    const ast = parseMapFromSource(`
-      map Test {
-        http GET "/thirteen" {
-          response 200 "application/json" {
-            map result {
-              result = 13
-            }
-          }
-        }
-      }`);
-    const interpreter = new MapInterpreter(
-      {
-        usecase: 'Test',
-        security: [],
-        services: ServiceSelector.withDefaultUrl(baseUrl),
-      },
-      interpreterDependencies
-    );
-    const result = await interpreter.perform(ast);
-
-    expect(result.unwrap()).toEqual({ result: 13 });
-  });
-
-  it('should make response headers accessible', async () => {
-    const url = '/twelve';
-    await mockServer.forGet(url).thenJson(
-      200,
-      {},
-      {
-        'Content-Type': 'application/json; charset=utf-8',
-        'Content-Language': 'en-US, en-CA',
-        Data: '12',
-      }
-    );
-    const interpreter = new MapInterpreter(
-      {
-        usecase: 'Test',
-        security: [],
-        services: mockServicesSelector,
-      },
-      interpreterDependencies
-    );
-    const ast = parseMapFromSource(`
-      map Test {
-        http GET "${url}" {
-          request {
-            headers {
-              "content-type" = "application/json"
-            }
-          }
-
-          response 200 "application/json" "en-US" {
-            map result headers.data
-          }
-        }
-      }`);
-    const result = await interpreter.perform(ast);
-
-    expect(result.isOk() && result.value).toEqual('12');
-  });
-
   it('should use integration parameters in jessie', async () => {
     const ast = parseMapFromSource(`
       map Test {
@@ -1117,60 +617,6 @@ describe('MapInterpreter', () => {
     const result = await interpreter.perform(ast);
 
     expect(result.isOk() && result.value).toEqual('nice!');
-  });
-
-  it('should use integration parameters in URL', async () => {
-    const url = '/twelve';
-    await mockServer.forGet(url).thenJson(200, { data: 12 });
-    const ast = parseMapFromSource(`
-      map Test {
-        http GET "/{parameters.path}" {
-          response 200 "application/json" {
-            map result {
-              result = body.data
-            }
-          }
-        }
-      }`);
-    const interpreter = new MapInterpreter(
-      {
-        usecase: 'Test',
-        parameters: { path: 'twelve' },
-        security: [],
-        services: mockServicesSelector,
-      },
-      interpreterDependencies
-    );
-    const result = await interpreter.perform(ast);
-    expect(result.isOk() && result.value).toEqual({ result: 12 });
-  });
-
-  it('should use integration parameters in baseUrl', async () => {
-    const url = '/twelve/something';
-    await mockServer.forGet(url).thenJson(200, { data: 12 });
-    const ast = parseMapFromSource(`
-      map Test {
-        http GET "/something" {
-          response 200 "application/json" {
-            map result {
-              result = body.data
-            }
-          }
-        }
-      }`);
-    const interpreter = new MapInterpreter(
-      {
-        usecase: 'Test',
-        parameters: { path: 'twelve' },
-        security: [],
-        services: ServiceSelector.withDefaultUrl(
-          `${mockServicesSelector.getUrl()!}/{path}`
-        ),
-      },
-      interpreterDependencies
-    );
-    const result = await interpreter.perform(ast);
-    expect(result.isOk() && result.value).toEqual({ result: 12 });
   });
 
   it('should pass integration parameters to operations', async () => {
@@ -1203,62 +649,6 @@ describe('MapInterpreter', () => {
     const result = await interpreter.perform(ast);
 
     expect(result.isOk() && result.value).toEqual({ x: 13 });
-  });
-
-  it('should correctly select service', async () => {
-    const urlOne = '/one/something';
-    await mockServer.forGet(urlOne).thenJson(200, { data: 1 });
-
-    const urlTwo = '/two/something';
-    await mockServer.forGet(urlTwo).thenJson(200, { data: 2 });
-
-    const urlThree = '/three/something';
-    await mockServer.forGet(urlThree).thenJson(200, { data: 3 });
-
-    const ast = parseMapFromSource(`
-      map Test {
-        value = 0
-
-        http GET default "/something" {
-          response 200 "application/json" {
-            value = value + body.data
-          }
-        }
-
-        http GET "two" "/something" {
-          response 200 "application/json" {
-            value = value + body.data
-          }
-        }
-
-        http GET "three" "/something" {
-          response 200 "application/json" {
-            value = value + body.data
-          }
-        }
-
-        map result {
-          result = value
-        }
-      }`);
-
-    const interpreter = new MapInterpreter(
-      {
-        usecase: 'Test',
-        security: [],
-        services: new ServiceSelector(
-          [
-            { id: 'one', baseUrl: `${mockServicesSelector.getUrl()!}/one` },
-            { id: 'two', baseUrl: `${mockServicesSelector.getUrl()!}/two` },
-            { id: 'three', baseUrl: `${mockServicesSelector.getUrl()!}/three` },
-          ],
-          'one'
-        ),
-      },
-      interpreterDependencies
-    );
-    const result = await interpreter.perform(ast);
-    expect(result.isOk() && result.value).toEqual({ result: 6 });
   });
 
   it('should correctly return error from operation', async () => {
@@ -1675,311 +1065,6 @@ describe('MapInterpreter', () => {
     expect(items).toStrictEqual(expected.toString('binary'));
   });
 
-  it('should send file in its entirety as body', async () => {
-    const filePath = path.resolve(process.cwd(), 'fixtures', 'binary.txt');
-    const file = BinaryData.fromPath(filePath);
-    const expected = await readFile(filePath, 'utf8');
-    await mockServer.forPost('/test').thenCallback(async req => {
-      expect(await req.body.getText()).toStrictEqual(expected);
-
-      return { status: 200, json: { ok: true } };
-    });
-
-    const ast = parseMapFromSource(`
-    map Test {
-      http POST "/test" {
-        request "video/notreallyvideo" {
-          body = input.items
-        }
-
-        response 200 {
-          map result body
-        }
-      }
-    }`);
-
-    const interpreter = new MapInterpreter(
-      {
-        usecase: 'Test',
-        security: [],
-        services: ServiceSelector.withDefaultUrl(mockServer.url),
-        input: {
-          items: file,
-        },
-      },
-      interpreterDependencies
-    );
-
-    const result = await interpreter.perform(ast);
-    if (result.isErr()) {
-      console.error(result.error);
-    }
-    expect(result.isOk()).toBe(true);
-
-    const response = result.unwrap();
-    expect(response).toStrictEqual({ ok: true });
-  });
-
-  it('should send file in its entirety as FormData', async () => {
-    const filePath = path.resolve(process.cwd(), 'fixtures', 'binary.txt');
-    const file = BinaryData.fromPath(filePath);
-    const expected = await readFile(filePath, 'utf8');
-    await mockServer.forPost('/test').thenCallback(async req => {
-      const data = await req.body.getText();
-      expect(data).toMatch(expected);
-
-      return { status: 200, json: { ok: true } };
-    });
-
-    const ast = parseMapFromSource(`
-    map Test {
-      http POST "/test" {
-        request "multipart/form-data" {
-          body = {
-            data: input.items
-          }
-        }
-
-        response 200 {
-          map result body
-        }
-      }
-    }`);
-
-    const interpreter = new MapInterpreter(
-      {
-        usecase: 'Test',
-        security: [],
-        services: ServiceSelector.withDefaultUrl(mockServer.url),
-        input: {
-          items: file,
-        },
-      },
-      interpreterDependencies
-    );
-
-    const result = await interpreter.perform(ast);
-    if (result.isErr()) {
-      console.error(result.error);
-    }
-    expect(result.isOk()).toBe(true);
-
-    const response = result.unwrap();
-    expect(response).toStrictEqual({ ok: true });
-  });
-
-  it('should send file in its entirety as FormData with passed mimetype and filename', async () => {
-    const filePath = path.resolve(process.cwd(), 'fixtures', 'binary.txt');
-    const file = BinaryData.fromPath(filePath, { name: 'test.txt', mimetype: 'text/plain' });
-
-    await mockServer.forPost('/test').thenCallback(async req => {
-      const data = await req.body.getText();
-      expect(data).toContain('Content-Disposition: form-data; name="file"; filename="test.txt"');
-      expect(data).toContain('Content-Type: text/plain');
-
-      return { status: 200, json: { ok: true } };
-    });
-
-    const ast = parseMapFromSource(`
-    map Test {
-      http POST "/test" {
-        request "multipart/form-data" {
-          body = {
-            file: input.file
-          }
-        }
-
-        response 200 {
-          map result body
-        }
-      }
-    }`);
-
-    const interpreter = new MapInterpreter(
-      {
-        usecase: 'Test',
-        security: [],
-        services: ServiceSelector.withDefaultUrl(mockServer.url),
-        input: {
-          file,
-        },
-      },
-      interpreterDependencies
-    );
-
-    const result = await interpreter.perform(ast);
-    if (result.isErr()) {
-      console.error(result.error);
-    }
-    expect(result.isOk()).toBe(true);
-
-    const response = result.unwrap();
-    expect(response).toStrictEqual({ ok: true });
-  });
-
-  it('should send file with set name and mimetype from map', async () => {
-    const filePath = path.resolve(process.cwd(), 'fixtures', 'binary.txt');
-    const file = BinaryData.fromPath(filePath);
-
-    await mockServer.forPost('/test').thenCallback(async req => {
-      const data = await req.body.getText();
-
-      expect(data).toContain('Content-Disposition: form-data; name="file"; filename="mapset.txt"');
-      expect(data).toContain('Content-Type: vnd.test/mapset');
-
-      return { status: 200, json: { ok: true } };
-    });
-
-    const ast = parseMapFromSource(`
-    map Test {
-      // need to do comlink variable assign to be able to use Script expression
-      tmp = (input.file.name = input.filename)
-      tmp = (input.file.mimetype = input.mimetype)
-
-      http POST "/test" {
-        request "multipart/form-data" {
-          body = {
-            file: input.file
-          }
-        }
-
-        response 200 {
-          map result body
-        }
-      }
-    }`);
-
-    const interpreter = new MapInterpreter(
-      {
-        usecase: 'Test',
-        security: [],
-        services: ServiceSelector.withDefaultUrl(mockServer.url),
-        input: {
-          file,
-          filename: 'mapset.txt',
-          mimetype: 'vnd.test/mapset'
-        },
-      },
-      interpreterDependencies
-    );
-
-    const result = await interpreter.perform(ast);
-    if (result.isErr()) {
-      console.error(result.error);
-    }
-    expect(result.isOk()).toBe(true);
-
-    const response = result.unwrap();
-    expect(response).toStrictEqual({ ok: true });
-  });
-
-  it('should correctly send request to / relative url', async () => {
-    const url = '/';
-    await mockServer.forGet(url).thenJson(200, { data: 12 });
-
-    const ast = parseMapFromSource(`
-    map Test {
-      http GET "/" {
-        response 200 {
-          return map result body.data
-        }
-      }
-
-      map error "wrong"
-    }
-    `);
-
-    const interpreter = new MapInterpreter(
-      {
-        usecase: 'Test',
-        security: [],
-        services: ServiceSelector.withDefaultUrl(
-          mockServicesSelector.getUrl()!
-        ),
-        input: {},
-      },
-      interpreterDependencies
-    );
-
-    const result = await interpreter.perform(ast);
-    expect(result.isOk()).toBe(true);
-
-    expect(result.unwrap()).toStrictEqual(12);
-  });
-
-  it('should return ArrayBuffer for binary response', async () => {
-    const url = '/twelve';
-    const filePath = path.resolve(process.cwd(), 'fixtures', 'binary.txt');
-    await mockServer.forGet(url).thenFromFile(200, filePath, { 'content-type': 'application/octet-stream' });
-
-    const interpreter = new MapInterpreter(
-      {
-        usecase: 'Test',
-        security: [],
-        services: mockServicesSelector,
-      },
-      interpreterDependencies
-    );
-    const ast = parseMapFromSource(`
-      map Test {
-        http GET "${url}" {
-          response 200 "application/octet-stream" {
-            map result body
-          }
-        }
-      }`);
-    const result = await interpreter.perform(ast);
-    const expected = (await readFile(filePath)).toString('utf8');
-
-    expect(result.unwrap() instanceof ArrayBuffer).toBe(true);
-    expect(Buffer.from(result.unwrap() as ArrayBuffer).toString('utf8')).toBe(expected);
-  });
-
-  it('should handle null when resolving variables', async () => {
-    const interpreter = new MapInterpreter(
-      {
-        usecase: 'Test',
-        security: [],
-        services: mockServicesSelector,
-        input: {}
-      },
-      interpreterDependencies
-    );
-    const ast = parseMapFromSource(`
-      map Test {
-        map result {
-          field = null
-        }
-      }`);
-    const result = await interpreter.perform(ast);
-
-    expect(result.unwrap()).toEqual({ field: null });
-  });
-
-  it('should handle null in input value', async () => {
-    const interpreter = new MapInterpreter(
-      {
-        usecase: 'Test',
-        security: [],
-        services: mockServicesSelector,
-        input: {
-          field: null
-        } as any
-      },
-      interpreterDependencies
-    );
-    const ast = parseMapFromSource(`
-      map Test {
-        map result {
-          field = input.field
-        }
-      }`);
-    const result = await interpreter.perform(ast);
-
-    expect(result.unwrap()).toEqual({ field: null });
-  });
-
-
   it('should allow success outcome to be undefined', async () => {
     const ast = parseMapFromSource(`
     map Test {
@@ -2054,6 +1139,907 @@ describe('MapInterpreter', () => {
     expect(result.isOk() && result.value).toStrictEqual('1');
   });
 
+  describe('http call', () => {
+    it('should call an API', async () => {
+      const url = '/twelve';
+      await mockServer.forGet(url).thenJson(
+        200,
+        { data: 12 },
+        {
+          'Content-Type': 'application/json; charset=utf-8',
+          'Content-Language': 'en-US, en-CA',
+        }
+      );
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'Test',
+          security: [],
+          services: mockServicesSelector,
+        },
+        interpreterDependencies
+      );
+      const ast = parseMapFromSource(`
+      map Test {
+        http GET "${url}" {
+          request {
+            headers {
+              "content-type" = "application/json"
+            }
+          }
+
+          response 200 "application/json" "en-US" {
+            map result body.data
+          }
+        }
+      }`);
+      const result = await interpreter.perform(ast);
+
+      expect(result.isOk() && result.value).toEqual(12);
+    });
+
+    it('should correctly send request to / relative url', async () => {
+      const url = '/';
+      await mockServer.forGet(url).thenJson(200, { data: 12 });
+
+      const ast = parseMapFromSource(`
+    map Test {
+      http GET "/" {
+        response 200 {
+          return map result body.data
+        }
+      }
+
+      map error "wrong"
+    }
+    `);
+
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'Test',
+          security: [],
+          services: ServiceSelector.withDefaultUrl(
+            mockServicesSelector.getUrl()!
+          ),
+          input: {},
+        },
+        interpreterDependencies
+      );
+
+      const result = await interpreter.perform(ast);
+      expect(result.isOk()).toBe(true);
+
+      expect(result.unwrap()).toStrictEqual(12);
+    });
+
+    it('should call an API with Basic auth', async () => {
+      const url = '/basic';
+      await mockServer
+        .forGet(url)
+        .withHeaders({ Authorization: 'Basic bmFtZTpwYXNzd29yZA==' })
+        .thenJson(200, { data: 12 });
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'testCase',
+          security: [
+            {
+              id: 'my_basic',
+              type: SecurityType.HTTP,
+              scheme: HttpScheme.BASIC,
+              username: 'name',
+              password: 'password',
+            },
+          ],
+          services: mockServicesSelector,
+        },
+        interpreterDependencies
+      );
+      const ast = parseMapFromSource(`
+      map testCase {
+        http GET "${url}" {
+          security "my_basic"
+
+          response 200 {
+            return map result body.data
+          }
+        }
+      }`);
+      const result = await interpreter.perform(ast);
+
+      expect(result.isOk() && result.value).toEqual(12);
+    });
+
+    it('should call an API with Bearer auth', async () => {
+      const url = '/bearer';
+      await mockServer
+        .forGet(url)
+        .withHeaders({ Authorization: 'Bearer SuperSecret' })
+        .thenJson(200, { data: 12 });
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'testCase',
+          security: [
+            {
+              id: 'my_bearer',
+              type: SecurityType.HTTP,
+              scheme: HttpScheme.BEARER,
+              token: 'SuperSecret',
+            },
+          ],
+          services: mockServicesSelector,
+        },
+        interpreterDependencies
+      );
+      const ast = parseMapFromSource(`
+      map testCase {
+        http GET "${url}" {
+          security "my_bearer"
+
+          response 200 {
+            return map result body.data
+          }
+        }
+      }`);
+      const result = await interpreter.perform(ast);
+
+      expect(result.isOk() && result.value).toEqual(12);
+    });
+
+    it('should call an API with Apikey auth in header', async () => {
+      const url = '/apikey';
+      await mockServer
+        .forGet(url)
+        .withHeaders({ Key: 'SuperSecret' })
+        .thenJson(200, { data: 12 });
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'testCase',
+          security: [
+            {
+              id: 'my_apikey',
+              type: SecurityType.APIKEY,
+              in: ApiKeyPlacement.HEADER,
+              name: 'Key',
+              apikey: 'SuperSecret',
+            },
+          ],
+          services: mockServicesSelector,
+        },
+        interpreterDependencies
+      );
+      const ast = parseMapFromSource(`
+      map testCase {
+        http GET "${url}" {
+          security "my_apikey"
+
+          response 200 {
+            return map result body.data
+          }
+        }
+      }`);
+      const result = await interpreter.perform(ast);
+
+      result.unwrap();
+      expect(result.isOk() && result.value).toEqual(12);
+    });
+
+    it('should call an API with Apikey auth in query', async () => {
+      const url = '/apikey';
+      await mockServer
+        .forGet(url)
+        .withQuery({ key: 'SuperSecret' })
+        .thenJson(200, { data: 12 });
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'testCase',
+          security: [
+            {
+              id: 'my_apikey',
+              type: SecurityType.APIKEY,
+              in: ApiKeyPlacement.QUERY,
+              name: 'key',
+              apikey: 'SuperSecret',
+            },
+          ],
+          services: mockServicesSelector,
+        },
+        interpreterDependencies
+      );
+      const ast = parseMapFromSource(`
+      map testCase {
+        http GET "${url}" {
+          security "my_apikey"
+
+          response 200 {
+            return map result body.data
+          }
+        }
+      }`);
+      const result = await interpreter.perform(ast);
+      expect(result.isOk() && result.value).toEqual(12);
+    });
+
+    it('should call an API with multipart/form-data body', async () => {
+      const url = '/formdata';
+      await mockServer.forPost(url).thenCallback(async request => {
+        const text = await request.body.getText();
+        if (
+          text !== undefined &&
+          text.includes('formData') &&
+          text.includes('myFormData') &&
+          text.includes('is') &&
+          text.includes('present')
+        ) {
+          return {
+            json: { data: 12 },
+            status: 201,
+          };
+        }
+
+        return { json: { failed: true }, statusCode: 400 };
+      });
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'testCase',
+          security: [],
+          services: mockServicesSelector,
+        },
+        interpreterDependencies
+      );
+      const ast = parseMapFromSource(`
+      map testCase {
+        http POST "${url}" {
+          request "multipart/form-data" {
+            body {
+              formData = "myFormData"
+              is = "present"
+            }
+          }
+
+          response 201 "application/json" {
+            return map result body.data
+          }
+        }
+      }`);
+      const result = await interpreter.perform(ast);
+
+      expect(result.isOk() && result.value).toEqual(12);
+    });
+
+    it('should call an API with application/x-www-form-urlencoded', async () => {
+      const url = '/urlencoded';
+      await mockServer
+        .forPost(url)
+        .withForm({ form: 'is', o: 'k' })
+        .thenJson(201, { data: 12 });
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'testCase',
+          security: [],
+          services: mockServicesSelector,
+        },
+        interpreterDependencies
+      );
+      const ast = parseMapFromSource(`
+      map testCase {
+        http POST "${url}" {
+          request "application/x-www-form-urlencoded" {
+            body {
+              form = "is"
+              o = "k"
+            }
+          }
+
+          response 201 "application/json" "en-US" {
+            return map result body.data
+          }
+        }
+      }`);
+      const result = await interpreter.perform(ast);
+
+      expect(result.isOk() && result.value).toEqual(12);
+    });
+
+    it.each([
+      ['param', 'param'],
+      [2, '2'],
+      [true, 'true']
+    ])('should call an API with path parameter "%s"', async (value, expected) => {
+      const url = '/twelve';
+      await mockServer.forGet(`${url}/${expected}`).thenJson(200, { data: 144 });
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'Test',
+          input: { page: value },
+          security: [],
+          services: mockServicesSelector,
+        },
+        interpreterDependencies
+      );
+      const ast = parseMapFromSource(`
+      map Test {
+        page = input.page
+        http GET "${url}/{page}" {
+          request {
+            headers {
+              "content-type" = "application/json"
+            }
+          }
+
+          response 200 "application/json" "en-US" {
+            map result body.data
+          }
+        }
+      }`);
+      const result = await interpreter.perform(ast);
+
+      expect(result.unwrap()).toEqual(144);
+    });
+
+    it('should be able to use input in path parameters', async () => {
+      const url = '/twelve';
+      await mockServer.forGet(url).thenJson(200, { data: 12 });
+      const ast = parseMapFromSource(`
+      map Test {
+        http GET "/{input.test}" {
+          response 200 "application/json" {
+            map result {
+              result = body.data
+            }
+          }
+        }
+      }`);
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'Test',
+          input: { test: 'twelve' },
+          security: [],
+          services: mockServicesSelector,
+        },
+        interpreterDependencies
+      );
+      const result = await interpreter.perform(ast);
+
+      expect(result.isOk() && result.value).toEqual({ result: 12 });
+    });
+
+    it('should correctly trim and parse path parameters in http call', async () => {
+      const url = '/thirteen';
+      await mockServer.forGet(url + '/2/get/now').thenJson(200, { data: 169 });
+
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'Test',
+          input: { page: '2', cmd: 'get', when: 'now' },
+          security: [],
+          services: mockServicesSelector,
+        },
+        interpreterDependencies
+      );
+      const ast = parseMapFromSource(`
+      map Test {
+        page = input.page
+        http GET "${url}/{ page     	  }/{input.cmd }/{ input.when}" {
+          request {
+            headers {
+              "content-type" = "application/json"
+            }
+          }
+
+          response 200 "application/json" "en-US" {
+            map result body.data
+          }
+        }
+      }`);
+      const result = await interpreter.perform(ast);
+
+      result.unwrap();
+      expect(result.isOk() && result.value).toEqual(169);
+    });
+
+    it.each([
+      ['"hello"', 'hello'],
+      ['2', '2'],
+      ['false', 'false'],
+      ['[1, true, "hi"]', ['1', 'true', 'hi']]
+    ])('should send a POST request with header "%s" and receive it back', async (value, expected) => {
+      const url = '/checkBody';
+      await mockServer
+        .forPost(url)
+        .withJsonBody({ anArray: [1, 2, 3] })
+        .thenCallback(req => {
+          expect(req.headers['someheader']).toStrictEqual(expected);
+          
+          return {
+            statusCode: 201,
+            headers: {
+              // TODO: an array here gets joined by `, ` instead of sent as multiple header lines
+              // not sure if we can force mockttp to not join it
+              test: req.headers['someheader']
+            },
+            json: { bodyOk: true, headerOk: true },
+          };
+        });
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'Test',
+          security: [],
+          services: mockServicesSelector,
+        },
+        interpreterDependencies
+      );
+      const ast = parseMapFromSource(`
+      map Test {
+        http POST "${url}" {
+          request {
+            headers {
+              someheader = ${value}
+            }
+            body {
+              anArray = [1, 2, 3]
+            }
+          }
+
+          response 201 {
+            map result {
+              bodyOk: body.bodyOk,
+              headerOk: body.headerOk,
+              headerTest: headers["test"]
+            }
+          }
+        }
+      }`);
+      const result = await interpreter.perform(ast);
+
+      expect(result.unwrap()).toEqual({
+        headerOk: true,
+        bodyOk: true,
+        headerTest: expected
+      });
+    });
+
+    it.each([
+      ['2', '2'],
+      [2, '2'],
+      [true, 'true']
+    ])('should call an API with query parameter "%s"', async (value, expected) => {
+      const url = '/twelve';
+      await mockServer
+        .forGet(url)
+        .withQuery({ page: expected })
+        .thenJson(200, { data: 144 });
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'Test',
+          input: { page: value },
+          security: [],
+          services: mockServicesSelector,
+        },
+        interpreterDependencies
+      );
+      const ast = parseMapFromSource(`
+      map Test {
+        http GET "${url}" {
+          request {
+            query {
+              page = input.page.toString()
+            }
+            headers {
+              "content-type" = "application/json"
+            }
+          }
+
+          response 200 "application/json" "en-US" {
+            map result body.data
+          }
+        }
+      }`);
+      const result = await interpreter.perform(ast);
+
+      expect(result.unwrap()).toEqual(144);
+    });
+
+    it('should strip trailing slash from baseUrl', async () => {
+      await mockServer.forGet('/thirteen').thenJson(200, { data: 12 });
+      const baseUrl = mockServer.urlFor('/thirteen').replace('thirteen', '');
+      expect(baseUrl.split('')[baseUrl.length - 1]).toEqual('/');
+      const ast = parseMapFromSource(`
+      map Test {
+        http GET "/thirteen" {
+          response 200 "application/json" {
+            map result {
+              result = 13
+            }
+          }
+        }
+      }`);
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'Test',
+          security: [],
+          services: ServiceSelector.withDefaultUrl(baseUrl),
+        },
+        interpreterDependencies
+      );
+      const result = await interpreter.perform(ast);
+
+      expect(result.unwrap()).toEqual({ result: 13 });
+    });
+
+    it('should make response headers accessible', async () => {
+      const url = '/twelve';
+      await mockServer.forGet(url).thenJson(
+        200,
+        {},
+        {
+          'Content-Type': 'application/json; charset=utf-8',
+          'Content-Language': 'en-US, en-CA',
+          Data: '12',
+        }
+      );
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'Test',
+          security: [],
+          services: mockServicesSelector,
+        },
+        interpreterDependencies
+      );
+      const ast = parseMapFromSource(`
+      map Test {
+        http GET "${url}" {
+          request {
+            headers {
+              "content-type" = "application/json"
+            }
+          }
+
+          response 200 "application/json" "en-US" {
+            map result headers.data
+          }
+        }
+      }`);
+      const result = await interpreter.perform(ast);
+
+      expect(result.isOk() && result.value).toEqual('12');
+    });
+
+    it('should use integration parameters in URL', async () => {
+      const url = '/twelve';
+      await mockServer.forGet(url).thenJson(200, { data: 12 });
+      const ast = parseMapFromSource(`
+      map Test {
+        http GET "/{parameters.path}" {
+          response 200 "application/json" {
+            map result {
+              result = body.data
+            }
+          }
+        }
+      }`);
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'Test',
+          parameters: { path: 'twelve' },
+          security: [],
+          services: mockServicesSelector,
+        },
+        interpreterDependencies
+      );
+      const result = await interpreter.perform(ast);
+      expect(result.isOk() && result.value).toEqual({ result: 12 });
+    });
+
+    it('should use integration parameters in baseUrl', async () => {
+      const url = '/twelve/something';
+      await mockServer.forGet(url).thenJson(200, { data: 12 });
+      const ast = parseMapFromSource(`
+      map Test {
+        http GET "/something" {
+          response 200 "application/json" {
+            map result {
+              result = body.data
+            }
+          }
+        }
+      }`);
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'Test',
+          parameters: { path: 'twelve' },
+          security: [],
+          services: ServiceSelector.withDefaultUrl(
+            `${mockServicesSelector.getUrl()!}/{path}`
+          ),
+        },
+        interpreterDependencies
+      );
+      const result = await interpreter.perform(ast);
+      expect(result.isOk() && result.value).toEqual({ result: 12 });
+    });
+
+    it('should correctly select service', async () => {
+      const urlOne = '/one/something';
+      await mockServer.forGet(urlOne).thenJson(200, { data: 1 });
+
+      const urlTwo = '/two/something';
+      await mockServer.forGet(urlTwo).thenJson(200, { data: 2 });
+
+      const urlThree = '/three/something';
+      await mockServer.forGet(urlThree).thenJson(200, { data: 3 });
+
+      const ast = parseMapFromSource(`
+      map Test {
+        value = 0
+
+        http GET default "/something" {
+          response 200 "application/json" {
+            value = value + body.data
+          }
+        }
+
+        http GET "two" "/something" {
+          response 200 "application/json" {
+            value = value + body.data
+          }
+        }
+
+        http GET "three" "/something" {
+          response 200 "application/json" {
+            value = value + body.data
+          }
+        }
+
+        map result {
+          result = value
+        }
+      }`);
+
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'Test',
+          security: [],
+          services: new ServiceSelector(
+            [
+              { id: 'one', baseUrl: `${mockServicesSelector.getUrl()!}/one` },
+              { id: 'two', baseUrl: `${mockServicesSelector.getUrl()!}/two` },
+              { id: 'three', baseUrl: `${mockServicesSelector.getUrl()!}/three` },
+            ],
+            'one'
+          ),
+        },
+        interpreterDependencies
+      );
+      const result = await interpreter.perform(ast);
+      expect(result.isOk() && result.value).toEqual({ result: 6 });
+    });
+
+    it('should send file in its entirety as body', async () => {
+      const filePath = path.resolve(process.cwd(), 'fixtures', 'binary.txt');
+      const file = BinaryData.fromPath(filePath);
+      const expected = await readFile(filePath, 'utf8');
+      await mockServer.forPost('/test').thenCallback(async req => {
+        expect(await req.body.getText()).toStrictEqual(expected);
+
+        return { status: 200, json: { ok: true } };
+      });
+
+      const ast = parseMapFromSource(`
+    map Test {
+      http POST "/test" {
+        request "video/notreallyvideo" {
+          body = input.items
+        }
+
+        response 200 {
+          map result body
+        }
+      }
+    }`);
+
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'Test',
+          security: [],
+          services: ServiceSelector.withDefaultUrl(mockServer.url),
+          input: {
+            items: file,
+          },
+        },
+        interpreterDependencies
+      );
+
+      const result = await interpreter.perform(ast);
+      if (result.isErr()) {
+        console.error(result.error);
+      }
+      expect(result.isOk()).toBe(true);
+
+      const response = result.unwrap();
+      expect(response).toStrictEqual({ ok: true });
+    });
+
+    it('should send file in its entirety as FormData', async () => {
+      const filePath = path.resolve(process.cwd(), 'fixtures', 'binary.txt');
+      const file = BinaryData.fromPath(filePath);
+      const expected = await readFile(filePath, 'utf8');
+      await mockServer.forPost('/test').thenCallback(async req => {
+        const data = await req.body.getText();
+        expect(data).toMatch(expected);
+
+        return { status: 200, json: { ok: true } };
+      });
+
+      const ast = parseMapFromSource(`
+    map Test {
+      http POST "/test" {
+        request "multipart/form-data" {
+          body = {
+            data: input.items
+          }
+        }
+
+        response 200 {
+          map result body
+        }
+      }
+    }`);
+
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'Test',
+          security: [],
+          services: ServiceSelector.withDefaultUrl(mockServer.url),
+          input: {
+            items: file,
+          },
+        },
+        interpreterDependencies
+      );
+
+      const result = await interpreter.perform(ast);
+      if (result.isErr()) {
+        console.error(result.error);
+      }
+      expect(result.isOk()).toBe(true);
+
+      const response = result.unwrap();
+      expect(response).toStrictEqual({ ok: true });
+    });
+
+    it('should send file in its entirety as FormData with passed mimetype and filename', async () => {
+      const filePath = path.resolve(process.cwd(), 'fixtures', 'binary.txt');
+      const file = BinaryData.fromPath(filePath, { name: 'test.txt', mimetype: 'text/plain' });
+
+      await mockServer.forPost('/test').thenCallback(async req => {
+        const data = await req.body.getText();
+        expect(data).toContain('Content-Disposition: form-data; name="file"; filename="test.txt"');
+        expect(data).toContain('Content-Type: text/plain');
+
+        return { status: 200, json: { ok: true } };
+      });
+
+      const ast = parseMapFromSource(`
+    map Test {
+      http POST "/test" {
+        request "multipart/form-data" {
+          body = {
+            file: input.file
+          }
+        }
+
+        response 200 {
+          map result body
+        }
+      }
+    }`);
+
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'Test',
+          security: [],
+          services: ServiceSelector.withDefaultUrl(mockServer.url),
+          input: {
+            file,
+          },
+        },
+        interpreterDependencies
+      );
+
+      const result = await interpreter.perform(ast);
+      if (result.isErr()) {
+        console.error(result.error);
+      }
+      expect(result.isOk()).toBe(true);
+
+      const response = result.unwrap();
+      expect(response).toStrictEqual({ ok: true });
+    });
+
+    it('should send file with set name and mimetype from map', async () => {
+      const filePath = path.resolve(process.cwd(), 'fixtures', 'binary.txt');
+      const file = BinaryData.fromPath(filePath);
+
+      await mockServer.forPost('/test').thenCallback(async req => {
+        const data = await req.body.getText();
+
+        expect(data).toContain('Content-Disposition: form-data; name="file"; filename="mapset.txt"');
+        expect(data).toContain('Content-Type: vnd.test/mapset');
+
+        return { status: 200, json: { ok: true } };
+      });
+
+      const ast = parseMapFromSource(`
+    map Test {
+      // need to do comlink variable assign to be able to use Script expression
+      tmp = (input.file.name = input.filename)
+      tmp = (input.file.mimetype = input.mimetype)
+
+      http POST "/test" {
+        request "multipart/form-data" {
+          body = {
+            file: input.file
+          }
+        }
+
+        response 200 {
+          map result body
+        }
+      }
+    }`);
+
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'Test',
+          security: [],
+          services: ServiceSelector.withDefaultUrl(mockServer.url),
+          input: {
+            file,
+            filename: 'mapset.txt',
+            mimetype: 'vnd.test/mapset'
+          },
+        },
+        interpreterDependencies
+      );
+
+      const result = await interpreter.perform(ast);
+      if (result.isErr()) {
+        console.error(result.error);
+      }
+      expect(result.isOk()).toBe(true);
+
+      const response = result.unwrap();
+      expect(response).toStrictEqual({ ok: true });
+    });
+
+    it('should return ArrayBuffer for binary response', async () => {
+      const url = '/twelve';
+      const filePath = path.resolve(process.cwd(), 'fixtures', 'binary.txt');
+      await mockServer.forGet(url).thenFromFile(200, filePath, { 'content-type': 'application/octet-stream' });
+
+      const interpreter = new MapInterpreter(
+        {
+          usecase: 'Test',
+          security: [],
+          services: mockServicesSelector,
+        },
+        interpreterDependencies
+      );
+      const ast = parseMapFromSource(`
+      map Test {
+        http GET "${url}" {
+          response 200 "application/octet-stream" {
+            map result body
+          }
+        }
+      }`);
+      const result = await interpreter.perform(ast);
+      const expected = (await readFile(filePath)).toString('utf8');
+
+      expect(result.unwrap() instanceof ArrayBuffer).toBe(true);
+      expect(Buffer.from(result.unwrap() as ArrayBuffer).toString('utf8')).toBe(expected);
+    });
+  });
+
   describe('None type', () => {
     it.each([
       // this is an invalid use of the perform API, so we are just looking for sane behavior - it fails because input is not defined
@@ -2086,7 +2072,7 @@ describe('MapInterpreter', () => {
     it.each([
       // invalid use of API
       [null, err(expect.any(JessieError))],
-      [undefined, err(expect.any(JessieError))], 
+      [undefined, err(expect.any(JessieError))],
       // not touched
       [{ foo: null }, ok({ foo: null })],
       [{ foo: undefined }, ok({ foo: undefined })]

--- a/src/interfaces/errors/map-interpreter.errors.ts
+++ b/src/interfaces/errors/map-interpreter.errors.ts
@@ -1,5 +1,7 @@
 import type { MapASTNode, MapDocumentNode } from '@superfaceai/ast';
 
+import type { HttpMultiMap } from '../../core/interpreter/http';
+
 export interface ErrorMetadata {
   node?: MapASTNode;
   ast?: MapDocumentNode;
@@ -27,12 +29,12 @@ export interface IHTTPError extends Error {
   statusCode?: number;
   request?: {
     body?: unknown;
-    headers?: Record<string, string>;
+    headers?: HttpMultiMap;
     url?: string;
   };
   response?: {
     body?: unknown;
-    headers?: Record<string, string>;
+    headers?: HttpMultiMap;
   };
 }
 

--- a/src/lib/object/object.test.ts
+++ b/src/lib/object/object.test.ts
@@ -8,7 +8,7 @@ describe('recursiveKeyList', () => {
       nope: undefined,
     };
 
-    expect(recursiveKeyList(object).sort()).toMatchObject(['2', 'a']);
+    expect(recursiveKeyList(object).sort()).toMatchObject(['2', 'a', 'nope']);
   });
 
   it('should return all objects keys from a nested object', () => {
@@ -25,7 +25,7 @@ describe('recursiveKeyList', () => {
       },
     };
 
-    expect(recursiveKeyList(object).sort()).toMatchObject([
+    expect(recursiveKeyList(object, v => v !== undefined).sort()).toMatchObject([
       'a',
       'b',
       'b.c',

--- a/src/lib/object/object.ts
+++ b/src/lib/object/object.ts
@@ -1,5 +1,6 @@
 import { UnexpectedError } from '../error';
-import { isClassInstance } from '../variables';
+import type { None } from '../variables';
+import { isClassInstance, isNone } from '../variables';
 
 /**
  * Creates a deep clone of the value.
@@ -50,17 +51,30 @@ export function isRecord(input: unknown): input is Record<string, unknown> {
   return true;
 }
 
+export function fromEntriesOptional<T extends Exclude<unknown, None>>(...entries: [key: string, value: T | None][]): Record<string, T> {
+  const base: Record<string, T> = {};
+
+  for (const [key, value] of entries) {
+    if (!isNone(value)) {
+      base[key] = value;
+    }
+  }
+
+  return base;
+}
+
 /**
  * Recursively descends the record and returns a list of enumerable keys
  */
 export function recursiveKeyList(
   record: Record<string, unknown>,
+  filter?: (value: unknown) => boolean,
   base?: string
 ): string[] {
   const keys: string[] = [];
 
   for (const [key, value] of Object.entries(record)) {
-    if (value === undefined) {
+    if (filter !== undefined && !filter(value)) {
       continue;
     }
 
@@ -72,7 +86,7 @@ export function recursiveKeyList(
 
     if (typeof value === 'object' && value !== null) {
       keys.push(
-        ...recursiveKeyList(value as Record<string, unknown>, basedKey)
+        ...recursiveKeyList(value as Record<string, unknown>, filter, basedKey)
       );
     }
   }

--- a/src/lib/variables/variables.ts
+++ b/src/lib/variables/variables.ts
@@ -133,7 +133,7 @@ export function variableToString(variable: Variables): string {
 }
 
 /**
- * Stringifies a Record of variables. `undefined` values are removed.
+ * Stringifies a Record of variables. `None` values are removed.
  */
 export function variablesToStrings(
   variables: NonPrimitive

--- a/src/node/fetch/fetch.node.ts
+++ b/src/node/fetch/fetch.node.ts
@@ -9,6 +9,7 @@ import type {
   FetchBody,
   FetchError,
   FetchResponse,
+  HttpMultiMap,
   IFetch,
   Interceptable,
   InterceptableMetadata,
@@ -148,7 +149,7 @@ export class NodeFetch implements IFetch, Interceptable, AuthCache {
     return new RequestFetchError('abort');
   }
 
-  private queryParameters(parameters?: Record<string, string | string[]>): string {
+  private queryParameters(parameters?: HttpMultiMap): string {
     if (parameters === undefined || Object.keys(parameters).length === 0) {
       return '';
     }
@@ -217,7 +218,7 @@ export class NodeFetch implements IFetch, Interceptable, AuthCache {
 
   private isBinaryContent(
     responseHeaders: Record<string, string>,
-    requestHeaders?: Record<string, string | string[]>
+    requestHeaders?: HttpMultiMap
   ): boolean {
     if (
       responseHeaders['content-type'] &&

--- a/src/node/fetch/fetch.node.ts
+++ b/src/node/fetch/fetch.node.ts
@@ -148,26 +148,21 @@ export class NodeFetch implements IFetch, Interceptable, AuthCache {
     return new RequestFetchError('abort');
   }
 
-  private queryParameters(parameters?: Record<string, string>): string {
-    if (parameters && Object.keys(parameters).length) {
-      const definedParameters = Object.entries(parameters).reduce(
-        (result, [key, value]) => {
-          if (value === undefined) {
-            return result;
-          }
-
-          return {
-            ...result,
-            [key]: value,
-          };
-        },
-        {}
-      );
-
-      return '?' + new URLSearchParams(definedParameters).toString();
+  private queryParameters(parameters?: Record<string, string | string[]>): string {
+    if (parameters === undefined || Object.keys(parameters).length === 0) {
+      return '';
     }
 
-    return '';
+    const params = new URLSearchParams();
+    for (const [key, param] of Object.entries(parameters)) {
+      if (typeof param === 'string') {
+        params.append(key, param);
+      } else {
+        param.forEach(v => params.append(key, v));
+      }
+    }
+
+    return '?' + params.toString();
   }
 
   private body(


### PR DESCRIPTION
Good news: Tests now compile and all map interpreter tests pass, no less tests pass than in base. Verified by quickly cooking up a differ[0] and checking `jest --json --outputFile tests.json` on the base branch vs. this branch (`python3 differ.py tests1.json tests2.json`).

This contains two BREAKING CHANGEs:
* rejects values passed to headers and query parameters which aren't `string | string[]`, instead telling the user to stringify them themselves before use
  - Relaxed for booleans and numbers, which are stringified by the implementation.
* does not even set `input` nor `parameter` in interpreter if they are passed in as `undefined` or `null` (although with null it is an invalid use of the perform API).
  - This means the map will fail at runtime (jessie error) if you try to access `input` object when there is no input

It also fixes query parameter handling which was apparently broken across 3 places, so now we can pass string arrays to query as well. yay.

<details>
<summary>[0] Differ:</summary>

```python
import json
import sys

with open(sys.argv[1], "r") as file:
	left_json = json.load(file)

with open(sys.argv[2], "r") as file:
	right_json = json.load(file)

left = left_json["testResults"]
right = right_json["testResults"]

def find_suite(results, name):
	for (i, suite) in enumerate(results):
		if suite["name"] == name:
			return i
	
	return None

def find_test(tests, name):
	for (i, tests) in enumerate(tests):
		if tests["fullName"] == name:
			return i
	
	return None

def reverse_side(side):
	return "right" if side == "left" else "left"

def diff_tests(left, right, out, side = "left"):
	left_i = 0
	while True:
		if left_i >= len(left):
			break

		left_test = left[left_i]
		right_i = find_test(right, left_test["fullName"])

		if right_i is None:
			out.append(
				(side, "test", left_test["fullName"], left_test["status"])
			)
			del left[left_i]
			continue
	
		right_test = right[right_i]
		if left_test["status"] != right_test["status"]:
			if left_test["status"] != "passed":
				out.append(
					(side, "test", left_test["fullName"], left_test["status"])
				)
			else:
				out.append(
					(reverse_side(side), "test", right_test["fullName"], right_test["status"])
				)

		del left[left_i]
		del right[right_i]

	if len(right) > 0:
		diff_tests(right, left, out, side = reverse_side(side))

def diff_results(left, right, out, side = "left"):
	left_i = 0
	while True:
		if left_i >= len(left):
			break

		left_suite = left[left_i]
		right_i = find_suite(right, left_suite["name"])
		
		if right_i is None:
			out.append(
				(side, "suite", left_suite["name"], left_suite["status"])
			)
			del left[left_i]
			continue
		
		right_suite = right[right_i]
		if left_suite["status"] != right_suite["status"]:
			left_tests = left_suite["assertionResults"]
			right_tests = right_suite["assertionResults"]
			diff_tests(left_tests, right_tests, out)

		del left[left_i]
		del right[right_i]
	
	if len(right) > 0:
		diff_results(right, left, out, side = reverse_side(side))

out = []
diff_results(left, right, out)
for diff in out:
	print(diff)

```

</details>