### PR TITLE
Multi-valued response headers as multimap

### DIFF
--- a/src/core/interpreter/http/interfaces.ts
+++ b/src/core/interpreter/http/interfaces.ts
@@ -55,7 +55,7 @@ export type FetchParameters = {
 export type FetchResponse = {
   status: number;
   statusText: string;
-  headers: Record<string, string>;
+  headers: HttpMultiMap;
   body?: unknown;
 };
 

--- a/src/core/interpreter/http/security/digest/digest.ts
+++ b/src/core/interpreter/http/security/digest/digest.ts
@@ -18,6 +18,7 @@ import {
 } from '../../filters';
 import type { HttpMultiMap, IFetch } from '../../interfaces';
 import type { HttpResponse } from '../../types';
+import { getHeaderMulti } from '../../utils';
 import type {
   AuthCache,
   AuthenticateRequestAsync,
@@ -116,10 +117,8 @@ export class DigestHandler implements ISecurityHandler {
           throw new Error('Response is undefined');
         }
 
-        if (
-          response.statusCode !== this.statusCode ||
-          !response.headers[this.challengeHeader]
-        ) {
+        const challengeHeader = getHeaderMulti(response.headers, this.challengeHeader);
+        if (response.statusCode !== this.statusCode || challengeHeader === undefined) {
           throw digestHeaderNotFound(
             this.challengeHeader,
             Object.keys(response.headers)
@@ -131,7 +130,7 @@ export class DigestHandler implements ISecurityHandler {
           // We need actual resolved url
           response.debug.request.url,
           parameters.method,
-          this.extractDigestValues(response.headers[this.challengeHeader])
+          this.extractDigestValues(challengeHeader)
         );
 
         return credentials;
@@ -153,7 +152,9 @@ export class DigestHandler implements ISecurityHandler {
     resourceRequestParameters: RequestParameters
   ) => {
     if (response.statusCode === this.statusCode) {
-      if (!response.headers[this.challengeHeader]) {
+      const challengeHeader = getHeaderMulti(response.headers, this.challengeHeader);
+
+      if (challengeHeader === undefined) {
         throw digestHeaderNotFound(
           this.challengeHeader,
           Object.keys(response.headers)
@@ -173,7 +174,7 @@ export class DigestHandler implements ISecurityHandler {
             // We need actual resolved url
             response.debug.request.url,
             resourceRequestParameters.method,
-            this.extractDigestValues(response.headers[this.challengeHeader])
+            this.extractDigestValues(challengeHeader)
           );
         }
       );
@@ -273,10 +274,17 @@ export class DigestHandler implements ISecurityHandler {
       .join(',');
   }
 
-  private extractDigestValues(header: string): DigestAuthValues {
+  private extractDigestValues(headerValues: string[]): DigestAuthValues {
     this.logSensitive?.(
-      `Extracting digest authentication values from: ${header}`
+      `Extracting digest authentication values from: ${headerValues.join(', ')}`
     );
+
+    if (headerValues.length != 1) {
+      // TODO: the RFC does seem to allow multiple challenges:
+      // https://www.rfc-editor.org/rfc/rfc2617#section-1.2
+      // here we just pick the first one
+    }
+    const header = headerValues[0];
 
     const scheme = header.split(/\s/)[0];
     if (!scheme) {

--- a/src/core/interpreter/http/types.ts
+++ b/src/core/interpreter/http/types.ts
@@ -1,10 +1,12 @@
+import type { HttpMultiMap } from './interfaces';
+
 export interface HttpResponse {
   statusCode: number;
   body: unknown;
-  headers: Record<string, string>;
+  headers: HttpMultiMap;
   debug: {
     request: {
-      headers: Record<string, string>;
+      headers: HttpMultiMap;
       url: string;
       body: unknown;
     };

--- a/src/core/interpreter/map-interpreter.errors.ts
+++ b/src/core/interpreter/map-interpreter.errors.ts
@@ -105,7 +105,7 @@ export class HTTPError extends MapInterpreterErrorBase implements IHTTPError {
     },
     public response?: {
       body?: unknown;
-      headers?: Record<string, string>;
+      headers?: HttpMultiMap;
     }
   ) {
     super('HTTPError', message, metadata);

--- a/src/core/interpreter/map-interpreter.test.ts
+++ b/src/core/interpreter/map-interpreter.test.ts
@@ -1552,8 +1552,6 @@ describe('MapInterpreter', () => {
           return {
             statusCode: 201,
             headers: {
-              // TODO: an array here gets joined by `, ` instead of sent as multiple header lines
-              // not sure if we can force mockttp to not join it
               test: req.headers['someheader']
             },
             json: { bodyOk: true, headerOk: true },
@@ -1593,7 +1591,7 @@ describe('MapInterpreter', () => {
       expect(result.unwrap()).toEqual({
         headerOk: true,
         bodyOk: true,
-        headerTest: expected
+        headerTest: expected,
       });
     });
 

--- a/src/node/fetch/fetch.node.test.ts
+++ b/src/node/fetch/fetch.node.test.ts
@@ -8,19 +8,15 @@ import { MockTimers } from '../../mock';
 import { NodeTimers } from '../timers';
 import { NodeFetch } from './fetch.node';
 
-// Maybe this can be done better?
-// The issue here is that we need to mock the default export (fetch) while
-// preserving everything as as actual implementation.
 jest.mock('node-fetch', () => {
-  const actual = jest.requireActual('node-fetch');
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const actual = jest.requireActual<typeof import('node-fetch')>('node-fetch');
 
-  const base: any = jest.fn();
-  for (const [key, value] of Object.entries(actual)) {
-    base[key] = value;
-  }
-  base['default'] = base;
-
-  return base as unknown;
+  return {
+    __esModule: true,
+    ...actual,
+    default: jest.fn(),
+  };
 });
 
 const mockServer = getLocal();

--- a/src/node/fetch/fetch.node.test.ts
+++ b/src/node/fetch/fetch.node.test.ts
@@ -11,9 +11,9 @@ import { NodeFetch } from './fetch.node';
 // Maybe this can be done better?
 // The issue here is that we need to mock the default export (fetch) while
 // preserving everything as as actual implementation.
-jest.mock('node-fetch', ()  => {
+jest.mock('node-fetch', () => {
   const actual = jest.requireActual('node-fetch');
-  
+
   const base: any = jest.fn();
   for (const [key, value] of Object.entries(actual)) {
     base[key] = value;
@@ -45,9 +45,9 @@ describe('NodeFetch', () => {
           .mocked(fetch)
           .mockImplementation(jest.requireActual('node-fetch').default);
 
-          await mockServer.forGet('/test').thenTimeout();
-          const realTimers = new NodeTimers();
-          const nodeFetch = new NodeFetch(realTimers);
+        await mockServer.forGet('/test').thenTimeout();
+        const realTimers = new NodeTimers();
+        const nodeFetch = new NodeFetch(realTimers);
 
         await expect(
           nodeFetch.fetch(`${mockServer.url}/test`, {
@@ -63,8 +63,8 @@ describe('NodeFetch', () => {
           .mocked(fetch)
           .mockImplementation(jest.requireActual('node-fetch').default);
 
-          await mockServer.forGet('/test').thenCloseConnection();
-          const nodeFetch = new NodeFetch(timers);
+        await mockServer.forGet('/test').thenCloseConnection();
+        const nodeFetch = new NodeFetch(timers);
 
         await expect(
           nodeFetch.fetch(`${mockServer.url}/test`, {
@@ -189,12 +189,12 @@ describe('NodeFetch', () => {
       beforeEach(async () => {
         responseTextMock = jest.fn().mockResolvedValue('foobar');
 
-      jest.mocked(fetch).mockResolvedValue({
-        headers: new Headers([['content-type', 'text/plain']]),
-        text: responseTextMock,
-      } as any);
+        jest.mocked(fetch).mockResolvedValue({
+          headers: new Headers([['content-type', 'text/plain']]),
+          text: responseTextMock,
+        } as any);
 
-      const fetchInstance = new NodeFetch(timers);
+        const fetchInstance = new NodeFetch(timers);
 
         result = await fetchInstance.fetch(`${mockServer.url}/test`, {
           method: 'GET',
@@ -230,10 +230,10 @@ describe('NodeFetch', () => {
               .fn()
               .mockResolvedValue(Buffer.from('foobar'));
 
-          jest.mocked(fetch).mockResolvedValue({
-            headers: new Headers([['content-type', contentType]]),
-            arrayBuffer: responseArrayBufferMock,
-          } as any);
+            jest.mocked(fetch).mockResolvedValue({
+              headers: new Headers([['content-type', contentType]]),
+              arrayBuffer: responseArrayBufferMock,
+            } as any);
 
             const fetchInstance = new NodeFetch(timers);
 
@@ -242,9 +242,9 @@ describe('NodeFetch', () => {
             });
           });
 
-        it('should call arrayBuffer', async () => {
-          expect(responseArrayBufferMock).toHaveBeenCalled();
-        });
+          it('should call arrayBuffer', async () => {
+            expect(responseArrayBufferMock).toHaveBeenCalled();
+          });
 
           it('should return instance of Buffer in body', async () => {
             expect(result.body).toBeInstanceOf(Buffer);
@@ -261,11 +261,11 @@ describe('NodeFetch', () => {
           .fn()
           .mockResolvedValue(Buffer.from('foobar'));
 
-      jest.mocked(fetch).mockResolvedValue({
-        headers: new Headers(),
-        arrayBuffer: responseArrayBufferMock,
-      } as any);
-    });
+        jest.mocked(fetch).mockResolvedValue({
+          headers: new Headers(),
+          arrayBuffer: responseArrayBufferMock,
+        } as any);
+      });
 
       describe('when accept header contains string value', () => {
         let result: any;
@@ -281,9 +281,9 @@ describe('NodeFetch', () => {
           });
         });
 
-      it('should call arrayBuffer', async () => {
-        expect(responseArrayBufferMock).toHaveBeenCalled();
-      });
+        it('should call arrayBuffer', async () => {
+          expect(responseArrayBufferMock).toHaveBeenCalled();
+        });
 
         it('should return instance of Buffer in body', async () => {
           expect(result.body).toBeInstanceOf(Buffer);
@@ -304,9 +304,9 @@ describe('NodeFetch', () => {
           });
         });
 
-      it('should call arrayBuffer', async () => {
-        expect(responseArrayBufferMock).toHaveBeenCalled();
-      });
+        it('should call arrayBuffer', async () => {
+          expect(responseArrayBufferMock).toHaveBeenCalled();
+        });
 
         it('should return instance of Buffer in body', async () => {
           expect(result.body).toBeInstanceOf(Buffer);
@@ -381,11 +381,12 @@ describe('NodeFetch', () => {
 
     // this test works under the assumption that node-fetch returns multi-valued headers as arrays
     // this is not true for node-fetch 2.x
-    it('should correctly send and receive multi-valued headers', async () => {
+    // eslint-disable-next-line jest/no-disabled-tests
+    it.skip('should correctly send and receive multi-valued headers', async () => {
       jest.mocked(fetch).mockImplementation(
         async (url, options) => {
           expect(url).toStrictEqual('http://test.local');
-          
+
           const requestHeaders = options?.headers as Headers;
           expect(requestHeaders.raw()).toMatchObject({ first: ['abc'], second: ['ab', 'bc'] });
 

--- a/src/node/fetch/fetch.node.test.ts
+++ b/src/node/fetch/fetch.node.test.ts
@@ -1,18 +1,30 @@
 import FormData from 'form-data';
 import { getLocal } from 'mockttp';
-import fetch from 'node-fetch';
+import type { Response } from 'node-fetch';
+import fetch, { Headers } from 'node-fetch';
 
 import { NetworkFetchError, RequestFetchError } from '../../core';
 import { MockTimers } from '../../mock';
 import { NodeTimers } from '../timers';
 import { NodeFetch } from './fetch.node';
 
-jest.mock('node-fetch');
+// Maybe this can be done better?
+// The issue here is that we need to mock the default export (fetch) while
+// preserving everything as as actual implementation.
+jest.mock('node-fetch', ()  => {
+  const actual = jest.requireActual('node-fetch');
+  
+  const base: any = jest.fn();
+  for (const [key, value] of Object.entries(actual)) {
+    base[key] = value;
+  }
+  base['default'] = base;
+
+  return base as unknown;
+});
 
 const mockServer = getLocal();
 const timers = new MockTimers();
-
-type ForEachCallbackFunction = (value?: string, type?: string) => void;
 
 describe('NodeFetch', () => {
   describe('fetch', () => {
@@ -147,11 +159,7 @@ describe('NodeFetch', () => {
         });
 
         jest.mocked(fetch).mockResolvedValue({
-          headers: {
-            forEach: jest.fn((callbackfn: ForEachCallbackFunction) => {
-              callbackfn('application/json', 'content-type');
-            }),
-          },
+          headers: new Headers([['content-type', 'application/json']]),
           json: responseJsonMock,
         } as any);
 
@@ -182,11 +190,7 @@ describe('NodeFetch', () => {
         responseTextMock = jest.fn().mockResolvedValue('foobar');
 
       jest.mocked(fetch).mockResolvedValue({
-        headers: {
-          forEach: jest.fn((callbackfn: ForEachCallbackFunction) => {
-            callbackfn('text/plain', 'content-type');
-          }),
-        },
+        headers: new Headers([['content-type', 'text/plain']]),
         text: responseTextMock,
       } as any);
 
@@ -227,11 +231,7 @@ describe('NodeFetch', () => {
               .mockResolvedValue(Buffer.from('foobar'));
 
           jest.mocked(fetch).mockResolvedValue({
-            headers: {
-              forEach: jest.fn((callbackfn: ForEachCallbackFunction) => {
-                callbackfn(contentType, 'content-type');
-              }),
-            },
+            headers: new Headers([['content-type', contentType]]),
             arrayBuffer: responseArrayBufferMock,
           } as any);
 
@@ -262,11 +262,7 @@ describe('NodeFetch', () => {
           .mockResolvedValue(Buffer.from('foobar'));
 
       jest.mocked(fetch).mockResolvedValue({
-        headers: {
-          forEach: jest.fn((callbackfn: ForEachCallbackFunction) => {
-            callbackfn(undefined, undefined);
-          }),
-        },
+        headers: new Headers(),
         arrayBuffer: responseArrayBufferMock,
       } as any);
     });
@@ -321,11 +317,7 @@ describe('NodeFetch', () => {
     describe('when request body contains binary data', () => {
       it('should call fetch with Buffer in body', async () => {
         jest.mocked(fetch).mockResolvedValue({
-          headers: {
-            forEach: jest.fn((callbackfn: ForEachCallbackFunction) => {
-              callbackfn(undefined, undefined);
-            }),
-          },
+          headers: new Headers(),
           text: jest.fn(),
         } as any);
 
@@ -347,11 +339,7 @@ describe('NodeFetch', () => {
         fetchInstance = new NodeFetch(timers);
 
         jest.mocked(fetch).mockResolvedValue({
-          headers: {
-            forEach: jest.fn((callbackfn: ForEachCallbackFunction) => {
-              callbackfn(undefined, undefined);
-            }),
-          },
+          headers: new Headers(),
           text: jest.fn(),
         } as any);
       });
@@ -390,34 +378,43 @@ describe('NodeFetch', () => {
         });
       });
     });
-  });
 
-  describe('prepareHeadersInit', () => {
-    let nodeFetch: NodeFetch;
+    // this test works under the assumption that node-fetch returns multi-valued headers as arrays
+    // this is not true for node-fetch 2.x
+    it('should correctly send and receive multi-valued headers', async () => {
+      jest.mocked(fetch).mockImplementation(
+        async (url, options) => {
+          expect(url).toStrictEqual('http://test.local');
+          
+          const requestHeaders = options?.headers as Headers;
+          expect(requestHeaders.raw()).toMatchObject({ first: ['abc'], second: ['ab', 'bc'] });
 
-    type OverrideNodeFetch = {
-      prepareHeadersInit: (data: any) => any | undefined;
-    };
+          const headers = new Headers();
+          headers.append('foo', 'string');
+          headers.append('bar', 'a');
+          headers.append('bar', 'b');
+          headers.append('bar', 'c');
 
-    beforeEach(() => {
-      nodeFetch = new NodeFetch(timers);
-    });
+          return {
+            headers: headers,
+            text: jest.fn()
+          } as unknown as Response;
+        }
+      );
 
-    it('returns empty array if data are undefined', () => {
-      expect(
-        (nodeFetch as any as OverrideNodeFetch).prepareHeadersInit(undefined)
-      ).toEqual([]);
-    });
+      const fetchInstance = new NodeFetch(timers);
+      const result = await fetchInstance.fetch('http://test.local', {
+        method: 'GET',
+        headers: {
+          first: 'abc',
+          second: ['ab', 'bc']
+        }
+      });
 
-    it('returns array of tuples if header value is array', () => {
-      expect(
-        (nodeFetch as any as OverrideNodeFetch).prepareHeadersInit({
-          header: ['val1', 'val2'],
-        })
-      ).toEqual([
-        ['header', 'val1'],
-        ['header', 'val2'],
-      ]);
+      expect(result.headers).toStrictEqual({
+        foo: 'string',
+        bar: ['a', 'b', 'c']
+      });
     });
   });
 });

--- a/src/node/fetch/fetch.node.test.ts
+++ b/src/node/fetch/fetch.node.test.ts
@@ -1,6 +1,5 @@
 import FormData from 'form-data';
 import { getLocal } from 'mockttp';
-import type { Response } from 'node-fetch';
 import fetch, { Headers } from 'node-fetch';
 
 import { NetworkFetchError, RequestFetchError } from '../../core';
@@ -379,38 +378,43 @@ describe('NodeFetch', () => {
     // this is not true for node-fetch 2.x
     // eslint-disable-next-line jest/no-disabled-tests
     it.skip('should correctly send and receive multi-valued headers', async () => {
-      jest.mocked(fetch).mockImplementation(
-        async (url, options) => {
-          expect(url).toStrictEqual('http://test.local');
+      // we want to use actual fetch implementation
+      jest
+        .mocked(fetch)
+        .mockImplementation(jest.requireActual('node-fetch').default);
 
-          const requestHeaders = options?.headers as Headers;
-          expect(requestHeaders.raw()).toMatchObject({ first: ['abc'], second: ['ab', 'bc'] });
+      await mockServer.forGet('/test').thenCallback((req) => {
+        expect(req.rawHeaders).toEqual(
+          expect.arrayContaining([['first', 'abc'], ['second', 'ab'], ['second', 'bc']])
+        );
 
-          const headers = new Headers();
-          headers.append('foo', 'string');
-          headers.append('bar', 'a');
-          headers.append('bar', 'b');
-          headers.append('bar', 'c');
-
-          return {
-            headers: headers,
-            text: jest.fn()
-          } as unknown as Response;
-        }
-      );
+        return {
+          statusCode: 200,
+          headers: {
+            foo: 'string',
+            bar: ['a', 'b', 'c']
+          },
+          body: 'Ok',
+        };
+      });
 
       const fetchInstance = new NodeFetch(timers);
-      const result = await fetchInstance.fetch('http://test.local', {
+      const result = await fetchInstance.fetch(mockServer.urlFor('/test'), {
         method: 'GET',
         headers: {
           first: 'abc',
-          second: ['ab', 'bc']
+          second: ['ab', 'bc'],
+          connection: 'close'
         }
       });
 
-      expect(result.headers).toStrictEqual({
+      if (result.status !== 200) {
+        console.error(result.body);
+      }
+
+      expect(result.headers).toEqual({
         foo: 'string',
-        bar: ['a', 'b', 'c']
+        bar: ['a', 'b', 'c'],
       });
     });
   });

--- a/src/node/fetch/fetch.node.ts
+++ b/src/node/fetch/fetch.node.ts
@@ -41,6 +41,9 @@ export class NodeFetch implements IFetch, Interceptable, AuthCache {
       return headers;
     }
 
+    // Header values are folded as fetch uses message.headers
+    //   https://github.com/node-fetch/node-fetch/blob/2.x/src/index.js#L163
+    //   https://nodejs.org/dist/latest-v19.x/docs/api/http.html#messageheaders
     for (const [key, value] of Object.entries(map)) {
       let valueArray = value;
       if (!Array.isArray(value)) {
@@ -89,12 +92,12 @@ export class NodeFetch implements IFetch, Interceptable, AuthCache {
 
     return false;
   }
-  
+
   public metadata: InterceptableMetadata | undefined;
   public events: Events | undefined;
   public digest: SuperCache<string> = new SuperCache();
 
-  constructor(private readonly timers: ITimers) {}
+  constructor(private readonly timers: ITimers) { }
 
   @eventInterceptor({
     eventName: 'fetch',

--- a/src/node/fetch/fetch.node.ts
+++ b/src/node/fetch/fetch.node.ts
@@ -1,6 +1,6 @@
 import { AbortController } from 'abort-controller';
 import FormData from 'form-data';
-import type { HeadersInit, RequestInit, Response } from 'node-fetch';
+import type { RequestInit, Response } from 'node-fetch';
 import fetch, { Headers } from 'node-fetch';
 
 import type {
@@ -13,10 +13,12 @@ import type {
   IFetch,
   Interceptable,
   InterceptableMetadata,
-  ITimers} from '../../core';
+  ITimers
+} from '../../core';
 import {
   BINARY_CONTENT_REGEXP,
   FetchParameters,
+  getHeaderMulti,
   isBinaryBody,
   isBinaryData,
   isBinaryDataMeta,
@@ -32,6 +34,62 @@ import { eventInterceptor } from '../../core/events/events';
 import { SuperCache } from '../../lib';
 
 export class NodeFetch implements IFetch, Interceptable, AuthCache {
+  private static multimapToHeaders(map: HttpMultiMap | undefined): Headers {
+    const headers = new Headers();
+
+    if (map === undefined) {
+      return headers;
+    }
+
+    for (const [key, value] of Object.entries(map)) {
+      let valueArray = value;
+      if (!Array.isArray(value)) {
+        valueArray = [value];
+      }
+
+      for (const element of valueArray) {
+        headers.append(key, element);
+      }
+    }
+
+    return headers;
+  }
+
+  private static isJsonContentType(
+    contentType: string[] | undefined,
+    _accept: string[] | undefined
+  ): boolean {
+    if (
+      contentType !== undefined
+      && contentType.some(v => v.includes(JSON_CONTENT) || v.includes(JSON_PROBLEM_CONTENT))
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+
+  private static isBinaryContentType(
+    contentType: string[] | undefined,
+    accept: string[] | undefined
+  ): boolean {
+    if (
+      contentType !== undefined
+      && contentType.some(v => BINARY_CONTENT_REGEXP.test(v))
+    ) {
+      return true;
+    }
+
+    if (
+      accept !== undefined
+      && accept.some(v => BINARY_CONTENT_REGEXP.test(v))
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+  
   public metadata: InterceptableMetadata | undefined;
   public events: Events | undefined;
   public digest: SuperCache<string> = new SuperCache();
@@ -46,10 +104,9 @@ export class NodeFetch implements IFetch, Interceptable, AuthCache {
     url: string,
     parameters: FetchParameters
   ): Promise<FetchResponse> {
-    const headersInit = this.prepareHeadersInit(parameters.headers);
-
+    const requestHeaders = NodeFetch.multimapToHeaders(parameters.headers);
     const request: RequestInit = {
-      headers: new Headers(headersInit),
+      headers: requestHeaders,
       method: parameters.method,
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore https://github.com/form-data/form-data/issues/513
@@ -62,22 +119,23 @@ export class NodeFetch implements IFetch, Interceptable, AuthCache {
       parameters.timeout
     );
 
-    const headers: Record<string, string> = {};
-    response.headers.forEach((value, key) => {
-      headers[key] = value;
-    });
+    const headers: HttpMultiMap = {};
+    // headers.raw() returns an object with prototype set to null for some reason, so we need to rewrap the values
+    for (const [key, value] of Object.entries(response.headers.raw())) {
+      if (value.length > 1) {
+        headers[key] = value;
+      } else if (value.length === 1) {
+        headers[key] = value[0];
+      }
+    }
 
     let body: unknown;
 
-    if (
-      headers['content-type'] &&
-      (headers['content-type'].includes(JSON_CONTENT) ||
-        headers['content-type'].includes(JSON_PROBLEM_CONTENT)) // ||
-      // TODO: update this when we have security handlers preparing whole requests
-      // parameters.headers?.['accept']?.includes(JSON_CONTENT)
-    ) {
+    const contentType = getHeaderMulti(headers, 'content-type');
+    const accept = getHeaderMulti(requestHeaders.raw(), 'accept');
+    if (NodeFetch.isJsonContentType(contentType, accept)) {
       body = await response.json();
-    } else if (this.isBinaryContent(headers, parameters.headers)) {
+    } else if (NodeFetch.isBinaryContentType(contentType, accept)) {
       body = await response.arrayBuffer(); // TODO: BinaryData.fromStream(response.body)
     } else {
       body = await response.text();
@@ -214,54 +272,5 @@ export class NodeFetch implements IFetch, Interceptable, AuthCache {
 
   private urlSearchParams(data?: Record<string, string>): URLSearchParams {
     return new URLSearchParams(data);
-  }
-
-  private isBinaryContent(
-    responseHeaders: Record<string, string>,
-    requestHeaders?: HttpMultiMap
-  ): boolean {
-    if (
-      responseHeaders['content-type'] &&
-      BINARY_CONTENT_REGEXP.test(responseHeaders['content-type'])
-    ) {
-      return true;
-    }
-
-    if (
-      requestHeaders !== undefined &&
-      requestHeaders['accept'] !== undefined
-    ) {
-      if (typeof requestHeaders['accept'] === 'string') {
-        return BINARY_CONTENT_REGEXP.test(requestHeaders['accept']);
-      } else {
-        for (const value of requestHeaders['accept']) {
-          if (BINARY_CONTENT_REGEXP.test(value)) {
-            return true;
-          }
-        }
-      }
-    }
-
-    return false;
-  }
-
-  private prepareHeadersInit(
-    data: FetchParameters['headers'] | undefined
-  ): HeadersInit {
-    if (data === undefined) {
-      return [];
-    }
-
-    const headers: [string, string][] = [];
-
-    Object.entries(data).forEach(([key, value]) => {
-      if (Array.isArray(value)) {
-        value.forEach(val => headers.push([key, val]));
-      } else {
-        headers.push([key, value]);
-      }
-    });
-
-    return headers;
   }
 }


### PR DESCRIPTION
This applies on top of #323. It was supposed to fix multi-valued response headers, but it seems we are blocked by node-fetch and upgrading it to 3.x version isn't trivial, so for now only these changes.

I'm setting the base to #323 for the diff to be meaningful, but it should be changed to `dev` later, I suppose.