### PR TITLE
Trailing comment in sandbox expression shouldn't breake it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Trailing comments in comlink script expressions broke sandbox evaluation
 
 ## [2.2.0] - 2023-01-02
 ### Added

--- a/src/core/interpreter/sandbox/sandbox.test.ts
+++ b/src/core/interpreter/sandbox/sandbox.test.ts
@@ -139,6 +139,20 @@ describe('sandbox', () => {
     expect(Array.isArray((v as { b: unknown }).b)).toBe(true);
   });
 
+  it('correctly works with line comment', () => {
+    expect(evalScript(config, '34; // this is number 34')).toStrictEqual(34);
+  });
+
+  it('errors with unclosed block comment', () => {
+    expect(() => evalScript(config, '34; /* this is number 34')).toThrow(
+      'Invalid or unexpected token'
+    );
+  });
+
+  it('correctly works without semicolon', () => {
+    expect(evalScript(config, '34')).toStrictEqual(34);
+  });
+
   describe('stdlib', () => {
     it('provides unstable stdlib', () => {
       expect(

--- a/src/core/interpreter/sandbox/sandbox.ts
+++ b/src/core/interpreter/sandbox/sandbox.ts
@@ -104,7 +104,10 @@ export function evalScript(
 
   log?.('Evaluating:', js);
   const result = vm.run(
-    `'use strict';const vmResult = ${js};vmResult`
+    `
+      'use strict';
+      const vmResult = ${js}
+      ;vmResult`
   ) as unknown;
   const resultVm2Fixed = vm2ExtraArrayKeysFixup(result);
 


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->

Safer sandbox, but better eval expression.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Potentially this could break Comlink Script expression's evaluation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [x] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
