### PR TITLE
Hotfix: trailing comment in vm expression shouldn't break it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Trailing comments in comlink script expressions broke sandbox evaluation
 
 ## [2.2.0] - 2023-01-02
 ### Added

--- a/src/core/interpreter/sandbox/sandbox.test.ts
+++ b/src/core/interpreter/sandbox/sandbox.test.ts
@@ -139,6 +139,20 @@ describe('sandbox', () => {
     expect(Array.isArray((v as { b: unknown }).b)).toBe(true);
   });
 
+  it('correctly works with line comment', () => {
+    expect(evalScript(config, '34; // this is number 34')).toStrictEqual(34);
+  });
+
+  it('errors with unclosed block comment', () => {
+    expect(() => evalScript(config, '34; /* this is number 34')).toThrow(
+      'Invalid or unexpected token'
+    );
+  });
+
+  it('correctly works without semicolon', () => {
+    expect(evalScript(config, '34')).toStrictEqual(34);
+  });
+
   describe('stdlib', () => {
     it('provides unstable stdlib', () => {
       expect(

--- a/src/core/interpreter/sandbox/sandbox.ts
+++ b/src/core/interpreter/sandbox/sandbox.ts
@@ -104,7 +104,10 @@ export function evalScript(
 
   log?.('Evaluating:', js);
   const result = vm.run(
-    `'use strict';const vmResult = ${js};vmResult`
+    `
+      'use strict';
+      const vmResult = ${js}
+      ;vmResult`
   ) as unknown;
   const resultVm2Fixed = vm2ExtraArrayKeysFixup(result);
 


### PR DESCRIPTION
Cherry-picked hotfix (#327) to release without other changes in `dev` branch.