### PR TITLE
Ignore body when 204 response status received

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Trailing comments in comlink script expressions broke sandbox evaluation - [#327](https://github.com/superfaceai/one-sdk-js/pull/327)
+- Ignore response body if status 204 received - [#332](https://github.com/superfaceai/one-sdk-js/pull/332)
 
 ## [2.2.0] - 2023-01-02
 ### Added

--- a/src/node/fetch/fetch.node.test.ts
+++ b/src/node/fetch/fetch.node.test.ts
@@ -144,6 +144,31 @@ describe('NodeFetch', () => {
       });
     });
 
+    describe('when status 204 received', () => {
+      let responseJsonMock: jest.Mock;
+      let result: any;
+
+      beforeEach(async () => {
+        responseJsonMock = jest.fn().mockResolvedValue(undefined);
+
+        jest.mocked(fetch).mockResolvedValue({
+          status: 204,
+          headers: new Headers([['content-type', 'application/json']]),
+          json: responseJsonMock,
+        } as any);
+
+        const fetchInstance = new NodeFetch(timers);
+
+        result = await fetchInstance.fetch(`${mockServer.url}/test`, {
+          method: 'GET',
+        });
+      });
+
+      it('should ignore content-type in header and return undefined in result body', async () => {
+        expect(result.body).toBeUndefined();
+      });
+    });
+
     describe('when application/json content type received', () => {
       let responseJsonMock: jest.Mock;
       let result: any;

--- a/src/node/fetch/fetch.node.ts
+++ b/src/node/fetch/fetch.node.ts
@@ -139,7 +139,10 @@ export class NodeFetch implements IFetch, Interceptable, AuthCache {
 
     const contentType = getHeaderMulti(headers, 'content-type');
     const accept = getHeaderMulti(requestHeaders.raw(), 'accept');
-    if (NodeFetch.isJsonContentType(contentType, accept)) {
+
+    if (response.status === 204) {
+      body = undefined;
+    } else if (NodeFetch.isJsonContentType(contentType, accept)) {
       body = await response.json();
     } else if (NodeFetch.isBinaryContentType(contentType, accept)) {
       body = await response.arrayBuffer(); // TODO: BinaryData.fromStream(response.body)


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->

Skip body handling for 204 responses

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Some server may return `Content-Type: application/json` header, but don't send any body.
This leads to failed JSON.parse.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [x] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
