### PR TITLE
Input validation to work with None values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Correctly handle objects with `null` prototype in `isClassInstance` - [#333](https://github.com/superfaceai/one-sdk-js/pull/333)
+- Treat not defined input in profile as nullable data structure - [#334](https://github.com/superfaceai/one-sdk-js/pull/334)
 
 ## [2.3.0] - 2023-02-07
 ### Changed

--- a/src/core/events/reporter/reporter.test.ts
+++ b/src/core/events/reporter/reporter.test.ts
@@ -335,7 +335,7 @@ describe('MetricReporter', () => {
 
     const profile = await client.getProfile('test-profile');
 
-    await profile.getUseCase('Test').perform({});
+    await profile.getUseCase('Test').perform(undefined);
     client.timers.tick(2000);
     while (await eventEndpoint.isPending()) {
       await new Promise(setImmediate);
@@ -382,7 +382,9 @@ describe('MetricReporter', () => {
 
     const profile = await client.getProfile('test-profile');
 
-    await expect(profile.getUseCase('Test').perform({})).rejects.toThrow();
+    await expect(
+      profile.getUseCase('Test').perform(undefined)
+    ).rejects.toThrow();
     client.timers.tick(2000);
     let requests = await eventEndpoint.getSeenRequests();
     while (requests.length < 2) {
@@ -460,7 +462,7 @@ describe('MetricReporter', () => {
 
     const profile = await client.getProfile('test-profile');
 
-    await profile.getUseCase('Test').perform({});
+    await profile.getUseCase('Test').perform(undefined);
     client.timers.tick(800);
     while (await eventEndpoint.isPending()) {
       await new Promise(setImmediate);
@@ -496,8 +498,8 @@ describe('MetricReporter', () => {
     );
     const profile = await client.getProfile('test-profile');
 
-    await profile.getUseCase('Test').perform({});
-    await profile.getUseCase('Test').perform({});
+    await profile.getUseCase('Test').perform(undefined);
+    await profile.getUseCase('Test').perform(undefined);
     client.timers.tick(2000);
     let requests = await eventEndpoint.getSeenRequests();
 
@@ -544,14 +546,14 @@ describe('MetricReporter', () => {
     );
     const profile = await client.getProfile('test-profile');
 
-    await profile.getUseCase('Test').perform({});
+    await profile.getUseCase('Test').perform(undefined);
     client.timers.tick(2000);
     let requests = await eventEndpoint.getSeenRequests();
     while (requests.length < 1) {
       await new Promise(setImmediate);
       requests = await eventEndpoint.getSeenRequests();
     }
-    await profile.getUseCase('Test').perform({});
+    await profile.getUseCase('Test').perform(undefined);
     client.timers.tick(1000);
     while (requests.length < 2) {
       await new Promise(setImmediate);
@@ -618,7 +620,7 @@ describe('MetricReporter', () => {
     const profile = await client.getProfile('test-profile');
 
     for (let i = 0; i < 100; i++) {
-      await profile.getUseCase('Test').perform({});
+      await profile.getUseCase('Test').perform(undefined);
       client.timers.tick(900);
       currentTime = currentTime.valueOf() + 900;
     }
@@ -696,7 +698,7 @@ describe('MetricReporter', () => {
     );
     const profile = await client.getProfile('test-profile');
 
-    void profile.getUseCase('Test').perform({});
+    void profile.getUseCase('Test').perform(undefined);
     let requests = await eventEndpoint.getSeenRequests();
     while (requests.length < 2) {
       currentTime += 0.1;

--- a/src/core/interpreter/profile-parameter-validator.test.ts
+++ b/src/core/interpreter/profile-parameter-validator.test.ts
@@ -857,6 +857,7 @@ describe('ProfileParameterValidator', () => {
       });
 
       it('returns ok for valid input data', () => {
+        parameterValidator = new ProfileParameterValidator(ast);
         expect(
           parameterValidator
             .validate(
@@ -873,6 +874,55 @@ describe('ProfileParameterValidator', () => {
             )
             .isOk()
         ).toBeTruthy();
+      });
+
+      it("returns error if input isn't passed", () => {
+        expect(
+          parameterValidator.validate(null, 'input', 'Test').isErr()
+        ).toBeTruthy();
+      });
+
+      describe('profile without input defined', () => {
+        const astNoInput = parseProfileFromSource(`
+          usecase Test {
+          }
+        `);
+
+        beforeEach(() => {
+          parameterValidator = new ProfileParameterValidator(astNoInput);
+        });
+
+        it('returns ok if null passed', () => {
+          expect(
+            parameterValidator.validate(null, 'input', 'Test').isOk()
+          ).toBeTruthy();
+        });
+
+        it('returns ok if non primitive value without additional fields is passed', () => {
+          expect(
+            parameterValidator.validate({}, 'input', 'Test').isOk()
+          ).toBeTruthy();
+        });
+
+        it('returns error if non primitive value with additional fields is passed', () => {
+          expect(
+            parameterValidator
+              .validate(
+                {
+                  additionalField: 'value',
+                },
+                'input',
+                'Test'
+              )
+              .isErr()
+          ).toBeTruthy();
+        });
+
+        it('returns error if primitive value is passed', () => {
+          expect(
+            parameterValidator.validate('string', 'input', 'Test').isErr()
+          ).toBeTruthy();
+        });
       });
     });
 


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->

This adds proper validation of input and it emulates  inputs based on presence in profile.

This is temporary fix as the best is to wrap input structure to NoneNull already in parser. Which I will do in next iteration.

Also I needed to change passed values in one test which did pass object even though nothing should be passed. Exactly we are doing this change. To make clearer what is validated.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [x] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
