### PR TITLE
Add ast property to superjson to load profile ast, map ast and provider.json 

### DIFF
--- a/src/core/profile-provider/resolve-map-ast.ts
+++ b/src/core/profile-provider/resolve-map-ast.ts
@@ -52,6 +52,18 @@ export async function resolveMapAst({
 
   const log = logger?.log(DEBUG_NAMESPACE);
   if ('file' in profileProviderSettings) {
+    let json: unknown = null;
+
+    try {
+      json = JSON.parse(profileProviderSettings.file);
+    } catch (e) {
+      // nothing
+    }
+
+    if (json !== null) {
+      return assertMapDocumentNode(json);
+    }
+
     let path: string;
     if (profileProviderSettings.file.endsWith(EXTENSIONS.map.source)) {
       path = fileSystem.path.resolve(

--- a/src/core/profile/resolve-profile-ast.ts
+++ b/src/core/profile/resolve-profile-ast.ts
@@ -87,10 +87,23 @@ export async function resolveProfileAst({
   // TODO: do we want to check `file` if we have version from getProfile?
   if (superJson !== undefined && profileSettings !== undefined) {
     if ('file' in profileSettings) {
+      let json: unknown = null;
+
+      try {
+        json = JSON.parse(profileSettings.file);
+      } catch (e) {
+        // nothing
+      }
+
+      if (json !== null) {
+        return assertProfileDocumentNode(json);
+      }
+
       filepath = fileSystem.path.resolve(
         fileSystem.path.dirname(config.superfacePath),
         profileSettings.file
       );
+
       // if we find source file we assume compiled file next to it
       if (filepath.endsWith(EXTENSIONS.profile.source)) {
         astPath = filepath.replace(

--- a/src/core/provider/resolve-provider-json.test.ts
+++ b/src/core/provider/resolve-provider-json.test.ts
@@ -1,3 +1,5 @@
+import type { NormalizedSuperJsonDocument } from '@superfaceai/ast';
+
 import type { IFileSystemError } from '../../interfaces';
 import type { Result } from '../../lib';
 import { err, ok } from '../../lib';
@@ -147,5 +149,71 @@ describe('resolve-provider-json', () => {
         config,
       })
     ).resolves.toEqual(providerJson);
+  });
+
+  describe('when using ast property', () => {
+    it('prefers content in ast property over file property', async () => {
+      await expect(
+        resolveProviderJson({
+          providerName,
+          fileSystem: mockFileSystem(
+            'path.json',
+            ok(JSON.stringify(mockProviderJson({ name: 'file_provider' })))
+          ),
+          superJson: {
+            profiles: {},
+            providers: {
+              [providerName]: {
+                file: 'path.json',
+                ast: providerJson,
+              },
+            },
+          } as unknown as NormalizedSuperJsonDocument,
+          config,
+        })
+      ).resolves.toEqual(providerJson);
+    });
+
+    it('returns provider json when passed as string', async () => {
+      await expect(
+        resolveProviderJson({
+          providerName,
+          fileSystem: mockFileSystem(
+            'path.json',
+            err(new NotFoundError('test'))
+          ),
+          superJson: {
+            profiles: {},
+            providers: {
+              [providerName]: {
+                ast: JSON.stringify(providerJson),
+              },
+            },
+          } as unknown as NormalizedSuperJsonDocument,
+          config,
+        })
+      ).resolves.toEqual(providerJson);
+    });
+
+    it('returns provider json when passed as object', async () => {
+      await expect(
+        resolveProviderJson({
+          providerName,
+          fileSystem: mockFileSystem(
+            'path.json',
+            err(new NotFoundError('test'))
+          ),
+          superJson: {
+            profiles: {},
+            providers: {
+              [providerName]: {
+                ast: providerJson,
+              },
+            },
+          } as unknown as NormalizedSuperJsonDocument,
+          config,
+        })
+      ).resolves.toEqual(providerJson);
+    });
   });
 });

--- a/src/core/provider/resolve-provider-json.ts
+++ b/src/core/provider/resolve-provider-json.ts
@@ -40,19 +40,33 @@ export async function resolveProviderJson({
   }
 
   const log = logger?.log(DEBUG_NAMESPACE);
-  const path = fileSystem.path.resolve(
-    fileSystem.path.dirname(config.superfacePath),
-    providerSettings.file
-  );
+  let providerJson: ProviderJson;
+  let json: unknown = null;
 
-  log?.(`Reading provider json from path: "${path}"`);
-  const contents = await fileSystem.readFile(path);
-
-  if (contents.isErr()) {
-    throw referencedFileNotFoundError(path, []);
+  try {
+    json = JSON.parse(providerSettings.file);
+  } catch (e) {
+    // nothing
   }
 
-  const providerJson = assertProviderJson(JSON.parse(contents.value));
+  if (json !== null) {
+    providerJson = assertProviderJson(json);
+  } else {
+    const path = fileSystem.path.resolve(
+      fileSystem.path.dirname(config.superfacePath),
+      providerSettings.file
+    );
+
+    log?.(`Reading provider json from path: "${path}"`);
+    const contents = await fileSystem.readFile(path);
+
+    if (contents.isErr()) {
+      throw referencedFileNotFoundError(path, []);
+    }
+
+    providerJson = assertProviderJson(JSON.parse(contents.value));
+  }
+
   // check if provider name match
   if (providerName !== providerJson.name) {
     throw providersDoNotMatchError(

--- a/src/lib/utils/utils.ts
+++ b/src/lib/utils/utils.ts
@@ -22,3 +22,7 @@ export function versionToString(version: {
 }
 
 export function forceCast<T>(_: unknown): asserts _ is T {}
+
+export function isSettingsWithAst<T>(input: T): input is T & { ast: unknown } {
+  return typeof input === 'object' && input !== null && 'ast' in input;
+}


### PR DESCRIPTION
Goal is to be able to pass ASTs directly in super.json. See example bellow.

Eventually I will add `ast` to [SuperJson](https://github.com/superfaceai/ast-js/tree/main/src/interfaces/superjson), but for internal use this should be sufficient. 

```ts
import type { SuperJsonDocument } from '@superfaceai/ast';
import { readFile } from 'fs/promises';
import { resolve } from 'path';

import { SuperfaceClient } from '../node';

async function readAst(file: string): Promise<string> {
  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
  return await readFile(resolve(__dirname, file), { encoding: 'utf8' });
}

async function main() {
  const superJson: SuperJsonDocument = {
    profiles: {
      profile: {
        ast: await readAst('./profile.supr.ast.json'),
        providers: {
          provider: {
            ast: await readAst('./map.suma.ast.json'),
          },
        },
      },
    },
    providers: {
      provider: {
        ast: await readAst('./provider.json'), // I know it is not ast, but consistency with profile and map(profile provider)
      },
    },
  } as unknown as SuperJsonDocument; // this is needed for TS to compile

  const client = new SuperfaceClient({ superJson, superfacePath: __dirname });
  const profile = await client.getProfile('profile');
  const result = await profile.getUseCase('UseCase').perform({ foo: 'foo' });

  console.log(result);
}

void main();
```