### PR TITLE
Normalize superjson preserve ast field

### DIFF
--- a/src/schema-tools/superjson/normalize.test.ts
+++ b/src/schema-tools/superjson/normalize.test.ts
@@ -1,5 +1,6 @@
 import type {
   NormalizedUsecaseDefaults,
+  ProfileEntry,
   ProfileProviderEntry,
 } from '@superfaceai/ast';
 import {
@@ -87,6 +88,48 @@ describe('SuperJson normalization', () => {
         defaults: {},
       });
     });
+
+    it('returns correct object when entry contains ast', async () => {
+      const mockProfileProviderEntry: ProfileProviderEntry = {
+        ast: {
+          kind: 'MapDocument',
+          header: {
+            kind: 'MapHeader',
+            scope: 'scope',
+            name: 'name',
+            version: {
+              major: 1,
+              minor: 0,
+              patch: 0,
+            },
+            provider: 'provider',
+          },
+          definitions: [],
+        },
+      } as unknown as ProfileProviderEntry;
+      const mockDefaults: NormalizedUsecaseDefaults = {};
+
+      expect(
+        normalizeProfileProviderSettings(mockProfileProviderEntry, mockDefaults)
+      ).toEqual({
+        ast: {
+          kind: 'MapDocument',
+          header: {
+            kind: 'MapHeader',
+            scope: 'scope',
+            name: 'name',
+            version: {
+              major: 1,
+              minor: 0,
+              patch: 0,
+            },
+            provider: 'provider',
+          },
+          definitions: [],
+        },
+        defaults: {},
+      });
+    });
   });
 
   describe('when normalizing profile settings', () => {
@@ -126,6 +169,43 @@ describe('SuperJson normalization', () => {
 
       expect(normalizeProfileSettings(mockProfileEntry, [])).toEqual({
         file: 'some/path',
+        priority: [],
+        defaults: {},
+        providers: {},
+      });
+    });
+
+    it('returns correct object when entry contains ast', async () => {
+      const mockProfileEntry: ProfileEntry = {
+        ast: {
+          kind: 'ProfileDocument',
+          header: {
+            kind: 'ProfileHeader',
+            scope: 'scope',
+            name: 'name',
+            version: {
+              major: 1,
+              minor: 0,
+              patch: 0,
+            },
+          },
+        },
+      } as unknown as ProfileEntry;
+
+      expect(normalizeProfileSettings(mockProfileEntry, [])).toEqual({
+        ast: {
+          kind: 'ProfileDocument',
+          header: {
+            kind: 'ProfileHeader',
+            scope: 'scope',
+            name: 'name',
+            version: {
+              major: 1,
+              minor: 0,
+              patch: 0,
+            },
+          },
+        },
         priority: [],
         defaults: {},
         providers: {},
@@ -190,6 +270,41 @@ describe('SuperJson normalization', () => {
       expect(normalizeProviderSettings(mockProviderEntry, environment)).toEqual(
         {
           file: 'some/path',
+          security: [],
+          parameters: {},
+        }
+      );
+    });
+
+    it('returns correct object when entry is a object with ast', async () => {
+      const environment = new MockEnvironment();
+      const mockProviderEntry = {
+        ast: {
+          name: 'swapi',
+          services: [
+            {
+              id: 'default',
+              baseUrl: 'https://swapi.dev/api',
+            },
+          ],
+          defaultService: 'default',
+        },
+        security: [],
+        parameters: {},
+      };
+
+      expect(normalizeProviderSettings(mockProviderEntry, environment)).toEqual(
+        {
+          ast: {
+            name: 'swapi',
+            services: [
+              {
+                id: 'default',
+                baseUrl: 'https://swapi.dev/api',
+              },
+            ],
+            defaultService: 'default',
+          },
           security: [],
           parameters: {},
         }


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->

Follow up to #336 

Normalize function didn't take in account `ast` field and created normalized document without it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md) is correct.
- [ ] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk-js/blob/main/CONTRIBUTING.md) document.
- [ ] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
